### PR TITLE
Feature/pf 28 fix assembly versioning

### DIFF
--- a/MyGet.cmd
+++ b/MyGet.cmd
@@ -8,6 +8,7 @@ if "%config%" == "" (
 set version=
 if not "%PackageVersion%" == "" (
    set version=-Version %PackageVersion%
+   powershell -Command "foreach ($path in dir -Filter AssemblyInfo.cs -Recurse | %{$_.FullName}){ (gc $path) -replace '0.0.0.0', '%version%' | Out-File -Encoding utf8 $path }"
 )
 
 rem Package restore

--- a/src/Aquarius.Client/Properties/AssemblyInfo.cs
+++ b/src/Aquarius.Client/Properties/AssemblyInfo.cs
@@ -15,3 +15,4 @@ using System.Runtime.InteropServices;
 // Developer builds should remain at version 0.0.0.0 so that unofficial binaries will be obvious.
 [assembly: AssemblyVersion("0.0.0.0")]
 [assembly: AssemblyFileVersion("0.0.0.0")]
+[assembly: AssemblyInformationalVersion("0.0.0.0")]

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2017-05-01 10:56:22
+Date: 2017-05-10 11:48:36
 Version: 4.56
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: http://autoserver1/AQUARIUS/Acquisition/v2
@@ -267,6 +267,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("17.2.60.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("17.2.69.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2017-05-01 10:56:21
+Date: 2017-05-10 11:48:35
 Version: 4.56
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: http://autoserver1/AQUARIUS/Provisioning/v1
@@ -123,6 +123,17 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
     public class GetInterpolationTypes
         : IReturn<InterpolationTypesResponse>
     {
+    }
+
+    [Route("/fielddataplugins/{UniqueId}", "DELETE")]
+    public class DeleteFieldDataPlugin
+        : IReturnVoid
+    {
+        ///<summary>
+        ///Unique ID of the field data plugin
+        ///</summary>
+        [ApiMember(IsRequired=true, Description="Unique ID of the field data plugin", ParameterType="path", DataType="string")]
+        public Guid UniqueId { get; set; }
     }
 
     [Route("/fielddataplugins", "GET")]
@@ -2420,6 +2431,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("17.2.60.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("17.2.69.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2017-05-01 10:56:20
+Date: 2017-05-10 11:48:34
 Version: 4.56
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: http://autoserver1/AQUARIUS/Publish/v2
@@ -6148,6 +6148,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("17.2.60.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("17.2.69.0");
     }
 }

--- a/src/Aquarius.SDK.sln
+++ b/src/Aquarius.SDK.sln
@@ -7,6 +7,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aquarius.Client", "Aquarius
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aquarius.Client.UnitTests", "Aquarius.Client.UnitTests\Aquarius.Client.UnitTests.csproj", "{51EEDD80-3F9F-42A4-A9B8-37B46D323C57}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RepoRoot", "RepoRoot", "{6B91AAEF-9A80-4489-97F2-6610711A29FD}"
+	ProjectSection(SolutionItems) = preProject
+		..\build.proj = ..\build.proj
+		..\CODE_OF_CONDUCT.md = ..\CODE_OF_CONDUCT.md
+		..\CONTRIBUTING.md = ..\CONTRIBUTING.md
+		..\LICENSE.txt = ..\LICENSE.txt
+		..\MyGet.cmd = ..\MyGet.cmd
+		..\README.md = ..\README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
@timothychu-AI Can you have a look?

The most important change is the 2nd commit, which should yield an assembly with both a correct `[AssemblyVersion]` attribute (MyGet builds were doing this automatically) and a correct `[AssemblyFileVersion]` attribute (which MyGet builds do not update, grrr!)

MyGet was generating assemblies with an unmodified file version of 0.0.0.0, and this was throwing off some WiX installer file-tracking for Hobart products (and possibly for the SamplesConnector installer).