### PR TITLE
PF-28 Use the correct environment variable for version-stamping

### DIFF
--- a/MyGet.cmd
+++ b/MyGet.cmd
@@ -8,7 +8,7 @@ if "%config%" == "" (
 set version=
 if not "%PackageVersion%" == "" (
    set version=-Version %PackageVersion%
-   powershell -Command "foreach ($path in dir -Filter AssemblyInfo.cs -Recurse | %{$_.FullName}){ (gc $path) -replace '0.0.0.0', '%version%' | Out-File -Encoding utf8 $path }"
+   powershell -Command "foreach ($path in dir -Filter AssemblyInfo.cs -Recurse | %{$_.FullName}){ (gc $path) -replace '0.0.0.0', '%PackageVersion%' | Out-File -Encoding utf8 $path }"
 )
 
 rem Package restore


### PR DESCRIPTION
@timothychu-AI The wrong environment variable was being used for the substitution.

It was yielding `[AssemblyFileVersion("-Version 17.2.21.0")]` instead of `[AssemblyFileVersion("17.2.21.0")]`