### PR TITLE
PF-28 Fix the powershell script

### DIFF
--- a/MyGet.cmd
+++ b/MyGet.cmd
@@ -8,7 +8,7 @@ if "%config%" == "" (
 set version=
 if not "%PackageVersion%" == "" (
    set version=-Version %PackageVersion%
-   powershell -Command "foreach ($path in dir -Filter AssemblyInfo.cs -Recurse | %{$_.FullName}){ (gc $path) -replace '0.0.0.0', '%PackageVersion%' | Out-File -Encoding utf8 $path }"
+   powershell -Command "foreach ($path in dir -Filter AssemblyInfo.cs -Recurse | %%{$_.FullName}){ (gc $path) -replace '0.0.0.0', '%PackageVersion%' | Out-File -Encoding utf8 $path }"
 )
 
 rem Package restore


### PR DESCRIPTION
@timothychu-AI Third time's a charm?

Needed to escape the `%` in `%{$_.FullName}` to avoid premature CMD.EXE environment variable expansion.

I've now been able to bench test the MyGet build process locally, and it seems to be doing the right thing now.