### PR TITLE
PF-28 Another MyGet build fix

### DIFF
--- a/MyGet.cmd
+++ b/MyGet.cmd
@@ -8,29 +8,34 @@ if "%config%" == "" (
 set version=
 if not "%PackageVersion%" == "" (
    set version=-Version %PackageVersion%
+   echo Applying version number %PackageVersion% ...
    powershell -Command "foreach ($path in dir -Filter AssemblyInfo.cs -Recurse | %%{$_.FullName}){ (gc $path) -replace '0.0.0.0', '%PackageVersion%' | Out-File -Encoding utf8 $path }"
 )
 
 rem Package restore
+echo Restoring packages ...
 call "%NuGet%" restore src
 if not "%errorlevel%"=="0" goto failure
 
 rem Build
+echo Building project ...
 call "%MsBuildExe%" build.proj /p:Configuration="%config%" /m /v:M /fl /flp:LogFile=msbuild.log;Verbosity=Normal /nr:false
 if not "%errorlevel%"=="0" goto failure
 
 rem Tests
 set NUnitRunner=src\packages\NUnit.Runners.2.6.3\tools\nunit-console.exe
+echo Running tests ...
 call "%NUnitRunner%" /config:%config% /framework:net-4.5 src\Aquarius.Client.UnitTests\bin\%config%\Aquarius.Client.UnitTests.dll
 if not "%errorlevel%"=="0" goto failure
 
 rem Package create
 mkdir Build
-rem call "%NuGet%" pack "src\Aquarius.Client\Aquarius.Client.csproj" -symbols -o Build -p Configuration=%config% %version%
+echo Creating packages ...
+call "%NuGet%" pack "src\Aquarius.Client\Aquarius.Client.csproj" -symbols -o Build -p Configuration=%config% %version%
 if not "%errorlevel%"=="0" goto failure
 
 :success
-exit 0
+exit /b 0
 
 :failure
-exit -1
+exit /b -1


### PR DESCRIPTION
@timothychu-AI Fourth time is a charm? The MyGet build services have not been kind to me today.

MyGet stopped auto-detecting and creating the NuGet package once the explicit version-modification step was added.
So add the manual package creation step back in the MyGet.cmd script.

Also add some "echo" statements for easier log step tracing.