### PR TITLE
PF-28 Set the user agent string for all requests originating from the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The **AQUARIUS SDK for .NET** enables .NET developers to easily work with the [A
 * [AQUARIUS Samples](http://aquaticinformatics.com/products/aquarius-samples/) (coming soon!)
 * [AQUARIUS WebPortal](http://aquaticinformatics.com/products/aquarius-webportal/) (coming soon!)
 
+View the [Release Notes](ReleaseNotes.md) here.
+
 ## Downloading
 
 [![Download on NuGet](images/installfromnuget.png)](https://www.nuget.org/packages/Aquarius.SDK/)
@@ -23,3 +25,4 @@ See the [Wiki](https://github.com/AquaticInformatics/aquarius-sdk-net/wiki) for 
 Contributions are always welcome, no matter how large or small. Before contributing, please read the [code of conduct](CODE_OF_CONDUCT.md).
 
 See [Contributing](CONTRIBUTING.md).
+

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,0 +1,14 @@
+## AQUARIUS.SDK Release Notes
+
+This page highlights some changes in the SDK.
+
+Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
+
+### 17.2.26
+
+- Fixed the file version of the SDK assembly
+- Includes the SDK version and application version in the user agent string for all requests originating from the SDK
+
+### 17.2.17
+
+- Initial public release of the SDK

--- a/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
+++ b/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
@@ -74,7 +74,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helpers\SdkServiceClientTests.cs" />
     <Compile Include="Helpers\UriHelperTests.cs" />
+    <Compile Include="Helpers\UserAgentBuilderTests.cs" />
     <Compile Include="TimeSeries\Client\AquariusServerVersionTests.cs" />
     <Compile Include="TimeSeries\Client\AquariusSystemDetectorTests.cs" />
     <Compile Include="TimeSeries\Client\CredentialsParserTests.cs" />

--- a/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
+++ b/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
@@ -74,6 +74,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helpers\UriHelperTests.cs" />
     <Compile Include="TimeSeries\Client\AquariusServerVersionTests.cs" />
     <Compile Include="TimeSeries\Client\AquariusSystemDetectorTests.cs" />
     <Compile Include="TimeSeries\Client\CredentialsParserTests.cs" />

--- a/src/Aquarius.Client.UnitTests/Helpers/SdkServiceClientTests.cs
+++ b/src/Aquarius.Client.UnitTests/Helpers/SdkServiceClientTests.cs
@@ -1,0 +1,32 @@
+﻿using Aquarius.Helpers;
+using FluentAssertions;
+using NUnit.Framework;
+using ServiceStack;
+
+namespace Aquarius.UnitTests.Helpers
+{
+    [TestFixture]
+    public class SdkServiceClientTests
+    {
+        [Test]
+        public void DefaulyCtor_IncludesExpectedUserAgent()
+        {
+            AssertJsonServiceClientHasExpectedUserAgent(new SdkServiceClient());
+        }
+
+        private void AssertJsonServiceClientHasExpectedUserAgent(JsonServiceClient client)
+        {
+            var userAgent = client.UserAgent;
+
+            userAgent.Should().StartWith("ServiceStack");
+            userAgent.Should().Contain("/" + UserAgentBuilder.GetSdkComponent());
+            userAgent.Should().Contain("/" + UserAgentBuilder.GetApplicationComponent());
+        }
+
+        [Test]
+        public void CtorWithUri_IncludesExpectedUserAgent()
+        {
+            AssertJsonServiceClientHasExpectedUserAgent(new SdkServiceClient("/api"));
+        }
+    }
+}

--- a/src/Aquarius.Client.UnitTests/Helpers/UriHelperTests.cs
+++ b/src/Aquarius.Client.UnitTests/Helpers/UriHelperTests.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using Aquarius.Helpers;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Aquarius.UnitTests.Helpers
+{
+    [TestFixture]
+    public class UriHelperTests
+    {
+        private static readonly IEnumerable<TestCaseData> ResolveTests = new[]
+        {
+            new TestCaseData("localhost", "/api", null, "http://localhost/api", "Plain host with null default scheme defaults to HTTP"),
+            new TestCaseData("localhost", "/api", Uri.UriSchemeFtp, "ftp://localhost/api", "Plain host with a default scheme defaults to the given scheme"),
+            new TestCaseData("https://localhost", "/api", Uri.UriSchemeFtp, "https://localhost/api", "Host with a scheme does not receive the default scheme"),
+            new TestCaseData("123.123.123.123", "/api", null, "http://123.123.123.123/api", "IPv4 host with null default scheme defaults to HTTP"),
+            new TestCaseData("http://123.123.123.123:55", "/api", null, "http://123.123.123.123:55/api", "IPv4 host with non-standard port and null default scheme defaults to HTTP"),
+            new TestCaseData("https://localhost/somepath", "/api", null, "https://localhost/api", "Host with a path replaces path with the endpoint"),
+        };
+
+        [TestCaseSource(nameof(ResolveTests))]
+        public void ResolveUri_ResolvestoExpectedUrl(string host, string endpoint, string defaultScheme, string expectedUrl, string reason)
+        {
+            var actual = UriHelper.ResolveUri(host, endpoint, defaultScheme).ToString();
+
+            actual.ShouldBeEquivalentTo(expectedUrl, reason);
+        }
+
+        [TestCaseSource(nameof(ResolveTests))]
+        public void ResolveEndpoint_ResolvestoExpectedUrl(string host, string endpoint, string defaultScheme, string expectedUrl, string reason)
+        {
+            var actual = UriHelper.ResolveEndpoint(host, endpoint, defaultScheme);
+
+            actual.ShouldBeEquivalentTo(expectedUrl, reason);
+        }
+
+        private static readonly IEnumerable<TestCaseData> InvalidArgumentTests = new[]
+        {
+            new TestCaseData(null, "/api", "Null host should throw"),
+            new TestCaseData(string.Empty, "/api", "Empty host should throw"),
+            new TestCaseData("somehost", null, "Null endpoint should throw"),
+            new TestCaseData("somehost", string.Empty, "Empty endpoint should throw"),
+            new TestCaseData("123.123.123.123:55", "/api", "IPv4 with port but no scheme should throw"), 
+        };
+
+        [TestCaseSource(nameof(InvalidArgumentTests))]
+        public void ResolveUri_WithInvalidArguments_Throws(string host, string endpoint, string reason)
+        {
+            Action action = () => UriHelper.ResolveUri(null, "/api");
+
+            action.ShouldThrow<UriFormatException>();
+        }
+
+        [TestCaseSource(nameof(InvalidArgumentTests))]
+        public void ResolveEndpoint_WithInvalidArguments_Throws(string host, string endpoint, string reason)
+        {
+            Action action = () => UriHelper.ResolveEndpoint(null, "/api");
+
+            action.ShouldThrow<UriFormatException>();
+        }
+    }
+}

--- a/src/Aquarius.Client.UnitTests/Helpers/UserAgentBuilderTests.cs
+++ b/src/Aquarius.Client.UnitTests/Helpers/UserAgentBuilderTests.cs
@@ -1,0 +1,28 @@
+﻿using System.IO;
+using Aquarius.Helpers;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Aquarius.UnitTests.Helpers
+{
+    [TestFixture]
+    public class UserAgentBuilderTests
+    {
+        [Test]
+        public void GetSdkComponent_ShouldContainSdkAssemblyName()
+        {
+            var expected = Path.GetFileNameWithoutExtension(typeof(SdkServiceClient).Assembly.Location);
+            var actual = UserAgentBuilder.GetSdkComponent();
+
+            actual.Should().StartWith(expected);
+        }
+
+        [Test]
+        public void GetApplicationComponent_ShouldNotBeEmpty()
+        {
+            var actual = UserAgentBuilder.GetApplicationComponent();
+
+            actual.Should().NotBeEmpty();
+        }
+    }
+}

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/Helpers/ClientHelperTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/Helpers/ClientHelperTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Aquarius.Helpers;
 using Aquarius.TimeSeries.Client.Helpers;
 using FluentAssertions;
 using NUnit.Framework;
@@ -16,7 +17,7 @@ namespace Aquarius.UnitTests.TimeSeries.Client.Helpers
         [SetUp]
         public void ForEachTest()
         {
-            _rawClient = new JsonServiceClient();
+            _rawClient = new SdkServiceClient();
             _fixture = new Fixture();
         }
 

--- a/src/Aquarius.Client/Aquarius.Client.csproj
+++ b/src/Aquarius.Client/Aquarius.Client.csproj
@@ -65,7 +65,7 @@
     <Compile Include="TimeSeries\Client\EndPoints\Provisioning.cs" />
     <Compile Include="TimeSeries\Client\EndPoints\PublishV2.cs" />
     <Compile Include="TimeSeries\Client\EndPoints\Root.cs" />
-    <Compile Include="TimeSeries\Client\EndPoints\UriHelper.cs" />
+    <Compile Include="Helpers\UriHelper.cs" />
     <Compile Include="TimeSeries\Client\Helpers\AuthenticationHeaders.cs" />
     <Compile Include="TimeSeries\Client\Helpers\ClientHelper.cs" />
     <Compile Include="TimeSeries\Client\Helpers\DurationExtensions.cs" />

--- a/src/Aquarius.Client/Aquarius.Client.csproj
+++ b/src/Aquarius.Client/Aquarius.Client.csproj
@@ -51,9 +51,12 @@
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Helpers\SdkServiceClient.cs" />
+    <Compile Include="Helpers\UserAgentBuilder.cs" />
     <Compile Include="TimeSeries\Client\AdaptivePollingTimer.cs" />
     <Compile Include="TimeSeries\Client\AquariusClient.cs" />
     <Compile Include="TimeSeries\Client\AquariusServerType.cs" />

--- a/src/Aquarius.Client/Helpers/SdkServiceClient.cs
+++ b/src/Aquarius.Client/Helpers/SdkServiceClient.cs
@@ -1,0 +1,30 @@
+﻿using ServiceStack;
+
+namespace Aquarius.Helpers
+{
+    public class SdkServiceClient : JsonServiceClient
+    {
+        public SdkServiceClient(string baseUri)
+            :base(baseUri)
+        {
+            SetUserAgent();
+        }
+
+        public SdkServiceClient()
+        {
+            SetUserAgent();
+        }
+
+        private void SetUserAgent()
+        {
+            var components = new[]
+            {
+                UserAgent,
+                UserAgentBuilder.GetSdkComponent(),
+                UserAgentBuilder.GetApplicationComponent()
+            };
+
+            UserAgent = string.Join("/", components);
+        }
+    }
+}

--- a/src/Aquarius.Client/Helpers/UriHelper.cs
+++ b/src/Aquarius.Client/Helpers/UriHelper.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Aquarius.TimeSeries.Client.EndPoints
+namespace Aquarius.Helpers
 {
     public class UriHelper
     {

--- a/src/Aquarius.Client/Helpers/UriHelper.cs
+++ b/src/Aquarius.Client/Helpers/UriHelper.cs
@@ -4,7 +4,7 @@ namespace Aquarius.Helpers
 {
     public class UriHelper
     {
-        public static Uri ResolveUri(string host, string endpoint)
+        public static Uri ResolveUri(string host, string endpoint, string defaultScheme = null)
         {
             var uriBuilder = new UriBuilder();
             Uri uri;
@@ -22,16 +22,16 @@ namespace Aquarius.Helpers
                 }
             }
 
-            uriBuilder.Scheme = Uri.UriSchemeHttp;
+            uriBuilder.Scheme = defaultScheme ?? Uri.UriSchemeHttp;
             uriBuilder.Host = host;
             uriBuilder.Path = endpoint;
 
             return uriBuilder.Uri;
         }
 
-        public static string ResolveEndpoint(string host, string endpoint)
+        public static string ResolveEndpoint(string host, string endpoint, string defaultScheme = null)
         {
-            return ResolveUri(host, endpoint).ToString();
+            return ResolveUri(host, endpoint, defaultScheme).ToString();
         }
     }
 }

--- a/src/Aquarius.Client/Helpers/UserAgentBuilder.cs
+++ b/src/Aquarius.Client/Helpers/UserAgentBuilder.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Web.Compilation;
+
+namespace Aquarius.Helpers
+{
+    public class UserAgentBuilder
+    {
+        public static string GetSdkComponent()
+        {
+            return GetAgentComponent(GetSdkAssemblyPath());
+        }
+
+        public static string GetApplicationComponent()
+        {
+            var path = GetExecutingAssemblyPath();
+
+            if (string.IsNullOrEmpty(path))
+            {
+                // When all else fails, just use the process info to identify the application
+                path = Process.GetCurrentProcess().MainModule.FileName;
+            }
+
+            return GetAgentComponent(path);
+        }
+
+        private static string GetAgentComponent(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return string.Empty;
+
+            return $"{Path.GetFileNameWithoutExtension(path)} {FileVersionInfo.GetVersionInfo(path).FileVersion}";
+        }
+
+        private static string GetSdkAssemblyPath()
+        {
+            return GetTrueAssemblyPath(typeof(SdkServiceClient).Assembly);
+        }
+
+        private static string GetExecutingAssemblyPath()
+        {
+            return GetTrueAssemblyPath(GetEntryAssembly());
+        }
+
+        private static Assembly GetEntryAssembly()
+        {
+            var assembly = Assembly.GetEntryAssembly();
+
+            if (assembly != null)
+                return assembly;
+
+            // We will get here if the host process is not a .NET assembly, but some unmanaged code (like an IIS app pool)
+
+            try
+            {
+                // This will identify an ASP.NET entry point
+                assembly = BuildManager.GetGlobalAsaxType().BaseType?.Assembly;
+            }
+            catch (InvalidOperationException)
+            {
+                // The expected exception when the process is not an ASP.NET application
+            }
+
+            return assembly;
+        }
+
+        private static string GetTrueAssemblyPath(Assembly assembly)
+        {
+            if (assembly == null)
+                return string.Empty;
+
+            return new Uri(assembly.CodeBase).AbsolutePath;
+        }
+    }
+}

--- a/src/Aquarius.Client/TimeSeries/Client/AquariusClient.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/AquariusClient.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
+using Aquarius.Helpers;
 using Aquarius.TimeSeries.Client.EndPoints;
 using Aquarius.TimeSeries.Client.Helpers;
 using ServiceStack;
@@ -162,9 +163,9 @@ namespace Aquarius.TimeSeries.Client
 
         private void Connect(string hostname, string username, string password)
         {
-            _serviceClients.Add(ClientType.PublishJson, new JsonServiceClient(PublishV2.ResolveEndpoint(hostname)));
-            _serviceClients.Add(ClientType.AcquisitionJson, new JsonServiceClient(AcquisitionV2.ResolveEndpoint(hostname)));
-            _serviceClients.Add(ClientType.ProvisioningJson, new JsonServiceClient(Provisioning.ResolveEndpoint(hostname)));
+            _serviceClients.Add(ClientType.PublishJson, new SdkServiceClient(PublishV2.ResolveEndpoint(hostname)));
+            _serviceClients.Add(ClientType.AcquisitionJson, new SdkServiceClient(AcquisitionV2.ResolveEndpoint(hostname)));
+            _serviceClients.Add(ClientType.ProvisioningJson, new SdkServiceClient(Provisioning.ResolveEndpoint(hostname)));
 
             Username = username;
             Password = password;

--- a/src/Aquarius.Client/TimeSeries/Client/AquariusSystemDetector.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/AquariusSystemDetector.cs
@@ -4,6 +4,7 @@ using System.Configuration;
 using System.Diagnostics;
 using System.Net;
 using System.Reflection;
+using Aquarius.Helpers;
 using Aquarius.TimeSeries.Client.EndPoints;
 using ServiceStack;
 using ServiceStack.Logging;

--- a/src/Aquarius.Client/TimeSeries/Client/AquariusSystemDetector.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/AquariusSystemDetector.cs
@@ -45,7 +45,7 @@ namespace Aquarius.TimeSeries.Client
 
         private static IServiceClient CreateJsonServiceClientWithQuickTimeouts(string baseUri)
         {
-            return new JsonServiceClient(baseUri)
+            return new SdkServiceClient(baseUri)
             {
                 Timeout = FirstByteReceivedTimeout,
                 ReadWriteTimeout = ReadEntireResponseTimeout

--- a/src/Aquarius.Client/TimeSeries/Client/EndPoints/AcquisitionV2.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/EndPoints/AcquisitionV2.cs
@@ -1,4 +1,6 @@
-﻿namespace Aquarius.TimeSeries.Client.EndPoints
+﻿using Aquarius.Helpers;
+
+namespace Aquarius.TimeSeries.Client.EndPoints
 {
     public class AcquisitionV2
     {

--- a/src/Aquarius.Client/TimeSeries/Client/EndPoints/LegacyDataService.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/EndPoints/LegacyDataService.cs
@@ -1,4 +1,6 @@
-﻿namespace Aquarius.TimeSeries.Client.EndPoints
+﻿using Aquarius.Helpers;
+
+namespace Aquarius.TimeSeries.Client.EndPoints
 {
     public class LegacyDataService
     {

--- a/src/Aquarius.Client/TimeSeries/Client/EndPoints/Provisioning.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/EndPoints/Provisioning.cs
@@ -1,4 +1,6 @@
-﻿namespace Aquarius.TimeSeries.Client.EndPoints
+﻿using Aquarius.Helpers;
+
+namespace Aquarius.TimeSeries.Client.EndPoints
 {
     public class Provisioning
     {

--- a/src/Aquarius.Client/TimeSeries/Client/EndPoints/PublishV2.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/EndPoints/PublishV2.cs
@@ -1,4 +1,6 @@
-﻿namespace Aquarius.TimeSeries.Client.EndPoints
+﻿using Aquarius.Helpers;
+
+namespace Aquarius.TimeSeries.Client.EndPoints
 {
     public class PublishV2
     {

--- a/src/Aquarius.Client/TimeSeries/Client/Helpers/ClientHelper.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/Helpers/ClientHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Security.Cryptography;
 using System.Text;
+using Aquarius.Helpers;
 using Aquarius.TimeSeries.Client.ServiceModels.Publish;
 using ServiceStack;
 using GetPublicKey = Aquarius.TimeSeries.Client.ServiceModels.Publish.GetPublicKey;
@@ -49,7 +50,7 @@ namespace Aquarius.TimeSeries.Client.Helpers
             var builder = new UriBuilder(client.BaseUri);
             builder.Path = baseUri;
 
-            var clone = new JsonServiceClient(builder.ToString());
+            var clone = new SdkServiceClient(builder.ToString());
 
             foreach (var headerKey in client.Headers.AllKeys)
             {

--- a/src/Aquarius.SDK.sln
+++ b/src/Aquarius.SDK.sln
@@ -15,6 +15,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RepoRoot", "RepoRoot", "{6B
 		..\LICENSE.txt = ..\LICENSE.txt
 		..\MyGet.cmd = ..\MyGet.cmd
 		..\README.md = ..\README.md
+		..\ReleaseNotes.md = ..\ReleaseNotes.md
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
@erinlim-ai Do you have time to do a review?
@timothychu-AI Feel-free to comment as well.

This change will ensure that any request originating from the SDK can be easily identified in the webserver request logs.

By default, every ServiceStack.Client request has a user agent string of `"ServiceStack .NET Client x.y"`. That isn't enough information to distinguish between requests from our SDK and requests from another app that also uses the ServiceStack framework.

This change will compose a user agent string of `"ServiceStack .NET Client x.y/Aquarius.Client x.y.z/<ApplicationName> <ApplicationVersion>"` to be sent with all requests.

Retrieving the correct application name and version is a little tricky (the `UserAgentBuilder` class handles this).
- When the app is a standard .NET executable (like a console app or Windows service), just use the main assembly name.
- When the app is an IIS app pool (which happens when WebPortal makes API requests to AQTS), we need to find the root ASP.NET assembly (the one with Global.asax).
- Otherwise, we fall back to use the process name and version (which works in various unit-test runners)

I couldn't easily unit-test the ASP.NET application detection logic, but I have bench tested it to confirm correct operation.
