### PR TITLE
PF-27 Add .NET client for Samples

### DIFF
--- a/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
+++ b/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
@@ -70,6 +70,7 @@
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -77,6 +78,7 @@
     <Compile Include="Helpers\SdkServiceClientTests.cs" />
     <Compile Include="Helpers\UriHelperTests.cs" />
     <Compile Include="Helpers\UserAgentBuilderTests.cs" />
+    <Compile Include="Samples\Client\FileUploaderTests.cs" />
     <Compile Include="TimeSeries\Client\AquariusServerVersionTests.cs" />
     <Compile Include="TimeSeries\Client\AquariusSystemDetectorTests.cs" />
     <Compile Include="TimeSeries\Client\CredentialsParserTests.cs" />

--- a/src/Aquarius.Client.UnitTests/Samples/Client/FileUploaderTests.cs
+++ b/src/Aquarius.Client.UnitTests/Samples/Client/FileUploaderTests.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using Aquarius.Samples.Client;
+using Aquarius.Samples.Client.ServiceModel;
+using Aquarius.TimeSeries.Client;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+using ServiceStack;
+
+namespace Aquarius.UnitTests.Samples.Client
+{
+    [TestFixture]
+    public class FileUploaderTests
+    {
+        [TestFixtureSetUp]
+        public void BeforeAnyTests()
+        {
+            ServiceStackConfig.ConfigureServiceStack();
+        }
+
+        private IFixture _fixture;
+
+        private string _mockAuthorizationHeaderValue;
+        private string _mockUserAgent;
+        private string _mockFilename;
+        private int _mockFileSize;
+        private IRestClient _mockRestClient;
+
+        private FileUploader _uploader;
+
+        [SetUp]
+        public void BeforeEachTest()
+        {
+            _fixture = new Fixture();
+            _mockAuthorizationHeaderValue = _fixture.Create<string>();
+            _mockUserAgent = _fixture.Create<string>();
+            _mockFilename = _fixture.Create<string>()+".csv";
+            _mockFileSize = _fixture.Create<int>();
+            _mockRestClient = Substitute.For<IRestClient>();
+
+            _uploader = new FileUploader(_mockRestClient, _mockAuthorizationHeaderValue, _mockUserAgent);
+        }
+
+        private static readonly IEnumerable<TestCaseData> ImportServiceRouteTests = new[]
+        {
+            new TestCaseData(new PostUploadAttachment().ToPostUrl(), false),
+            new TestCaseData(new PostImportAnalysisMethods().ToPostUrl(), true),
+        };
+
+        [TestCaseSource(nameof(ImportServiceRouteTests))]
+        public void IsImportServiceRoute_DetectsImportServiceRoutesCorrectly(string relativeOrAbsoluteUri, bool expected)
+        {
+            var actual = FileUploader.IsImportServiceUpload(relativeOrAbsoluteUri);
+            actual.ShouldBeEquivalentTo(expected);
+
+            if (actual)
+            {
+                FileUploader.IsImportServiceUpload(relativeOrAbsoluteUri.ToLowerInvariant()).ShouldBeEquivalentTo(true, "Lowercase of URL should also be true");
+                FileUploader.IsImportServiceUpload(relativeOrAbsoluteUri.ToUpperInvariant()).ShouldBeEquivalentTo(true, "Uppercase of URL should also be true");
+            }
+        }
+
+        [Test]
+        public void ctor_ConfiguresRequestHeadersCorrectly()
+        {
+            _mockRestClient
+                .Received(1)
+                .AddHeader(Arg.Is(SamplesClient.AuthorizationHeaderKey), Arg.Is(_mockAuthorizationHeaderValue));
+
+            _mockRestClient
+                .Received(1)
+                .AddHeader(Arg.Is("User-Agent"), Arg.Is(_mockUserAgent));
+        }
+
+        [Test]
+        public void PostFileWithRequest_WithAttachmentRequest_PostsFineUploaderContent()
+        {
+            AssertPostFileComposesMultiPartRequest(new PostUploadAttachment());
+        }
+
+        [Test]
+        public void PostFileWithRequest_WithImportServiceRequest_PostsImportServiceContent()
+        {
+            AssertPostFileComposesMultiPartRequest(new PostImportAnalysisMethods());
+        }
+
+        private void AssertPostFileComposesMultiPartRequest<TResponse>(IReturn<TResponse> requestDto)
+        {
+            var postUrl = $"http://somehost{requestDto.ToPostUrl()}";
+            var queryString = QueryStringSerializer.SerializeToString(requestDto);
+            var isImport = FileUploader.IsImportServiceUpload(postUrl);
+            var streamToUpload = CreateMemoryStream(_mockFileSize);
+
+            _uploader.PostFileWithRequest(postUrl, streamToUpload, _mockFilename, requestDto);
+
+            var expectedUri = new UriBuilder(postUrl) {Query = queryString}.ToString();
+
+            if (isImport)
+            {
+                _mockRestClient
+                    .Received(1)
+                    .Post<TResponse>(Arg.Is(expectedUri), Arg.Is<object>(content => IsImportServiceContent(content)));
+            }
+            else
+            {
+                _mockRestClient
+                    .Received(1)
+                    .Post<TResponse>(Arg.Is(expectedUri), Arg.Is<object>(content => IsFineUploaderContent(content)));
+            }
+        }
+
+        private static Stream CreateMemoryStream(int byteCount)
+        {
+            return new MemoryStream(new byte[byteCount]);
+        }
+
+        private bool IsFineUploaderContent(object content)
+        {
+            var parts = AssertMultipartFormContent(content, "qqfile");
+
+            if (parts == null)
+                return false;
+
+            var uuidContent = parts.Single(p => p is StringContent && p.Headers.ContentDisposition.Name == "qquuid");
+            var uuidText = uuidContent.ReadAsStringAsync().Result;
+            Guid dummy;
+            Guid.TryParseExact(uuidText, "D", out dummy).ShouldBeEquivalentTo(true, $"Can't parse {uuidText} as a GUID");
+
+            var filenameContent = parts.Single(p => p is StringContent && p.Headers.ContentDisposition.Name == "qqfilename");
+            filenameContent.ReadAsStringAsync().Result.ShouldBeEquivalentTo(_mockFilename, "Filenames should match");
+
+            var totalSizeContent = parts.Single(p => p is StringContent && p.Headers.ContentDisposition.Name == "qqtotalfilesize");
+            var totalSize = int.Parse(totalSizeContent.ReadAsStringAsync().Result);
+            totalSize.ShouldBeEquivalentTo(_mockFileSize, "Total file sizes should match");
+
+            return true;
+        }
+
+        private bool IsImportServiceContent(object content)
+        {
+            var parts = AssertMultipartFormContent(content, "file");
+
+            return parts != null;
+        }
+
+        private List<HttpContent> AssertMultipartFormContent(object content, string expectedName)
+        {
+            var multipartFormDataContent = content as MultipartFormDataContent;
+
+            if (multipartFormDataContent == null)
+                return null;
+
+            var parts = multipartFormDataContent.ToList();
+
+            if (!parts.Any())
+                return null;
+
+            if (parts.Any(p => p.Headers.ContentDisposition.DispositionType != "form-data"))
+                return null;
+
+            var fileContent = parts.Last() as ByteArrayContent;
+
+            if (fileContent == null)
+                return null;
+
+            var bytes = fileContent.ReadAsByteArrayAsync().Result;
+            bytes.Length.ShouldBeEquivalentTo(_mockFileSize, "Content size should match");
+
+            fileContent.Headers.ContentDisposition.FileName.ShouldBeEquivalentTo(_mockFilename, "Uploaded filename should match");
+            fileContent.Headers.ContentDisposition.Name.ShouldBeEquivalentTo(expectedName, "Name field should match");
+
+            return parts;
+        }
+    }
+}

--- a/src/Aquarius.Client/Aquarius.Client.csproj
+++ b/src/Aquarius.Client/Aquarius.Client.csproj
@@ -39,6 +39,10 @@
       <HintPath>..\packages\ServiceStack.Client.4.5.6\lib\net45\ServiceStack.Client.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="ServiceStack.HttpClient, Version=4.5.6.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ServiceStack.HttpClient.4.5.6\lib\net45\ServiceStack.HttpClient.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="ServiceStack.Interfaces, Version=4.0.0.0, Culture=neutral, PublicKeyToken=e06fbc6124f57c43, processorArchitecture=MSIL">
       <HintPath>..\packages\ServiceStack.Interfaces.4.5.6\lib\portable-wp80+sl5+net45+win8+wpa81+monotouch+monoandroid+xamarin.ios10\ServiceStack.Interfaces.dll</HintPath>
       <Private>True</Private>
@@ -50,6 +54,16 @@
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Net.Http.Extensions, Version=2.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives, Version=4.2.29.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
@@ -60,9 +74,15 @@
     <Compile Include="Samples\Client\IPaginatedRequest.cs" />
     <Compile Include="Samples\Client\IPaginatedResponse.cs" />
     <Compile Include="Samples\Client\LazyResult.cs" />
+    <Compile Include="Samples\Client\SamplesApiException.cs" />
+    <Compile Include="Samples\Client\SamplesAuthenticationException.cs" />
     <Compile Include="Samples\Client\SamplesClient.cs" />
+    <Compile Include="Samples\Client\SamplesErrorResponse.cs" />
+    <Compile Include="Samples\Client\FileUploader.cs" />
+    <Compile Include="Samples\Client\SamplesMaintenanceModeException.cs" />
     <Compile Include="Samples\Client\ServiceModel.cs" />
     <Compile Include="Samples\Client\ISamplesClient.cs" />
+    <Compile Include="Samples\Client\WebServiceExceptionHandler.cs" />
     <Compile Include="TimeSeries\Client\AdaptivePollingTimer.cs" />
     <Compile Include="TimeSeries\Client\AquariusClient.cs" />
     <Compile Include="TimeSeries\Client\AquariusServerType.cs" />
@@ -103,6 +123,11 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureBclBuildImported" BeforeTargets="BeforeBuild" Condition="'$(BclBuildImported)' == ''">
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=317567." HelpKeyword="BCLBUILD2001" />
+    <Error Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" Text="The build restored NuGet packages. Build the project again to include these packages in the build. For more information, see http://go.microsoft.com/fwlink/?LinkID=317568." HelpKeyword="BCLBUILD2002" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/Aquarius.Client/Aquarius.Client.csproj
+++ b/src/Aquarius.Client/Aquarius.Client.csproj
@@ -57,6 +57,12 @@
   <ItemGroup>
     <Compile Include="Helpers\SdkServiceClient.cs" />
     <Compile Include="Helpers\UserAgentBuilder.cs" />
+    <Compile Include="Samples\Client\IPaginatedRequest.cs" />
+    <Compile Include="Samples\Client\IPaginatedResponse.cs" />
+    <Compile Include="Samples\Client\LazyResult.cs" />
+    <Compile Include="Samples\Client\SamplesClient.cs" />
+    <Compile Include="Samples\Client\ServiceModel.cs" />
+    <Compile Include="Samples\Client\ISamplesClient.cs" />
     <Compile Include="TimeSeries\Client\AdaptivePollingTimer.cs" />
     <Compile Include="TimeSeries\Client\AquariusClient.cs" />
     <Compile Include="TimeSeries\Client\AquariusServerType.cs" />

--- a/src/Aquarius.Client/Properties/AssemblyInfo.cs
+++ b/src/Aquarius.Client/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Aquarius.Client")]
@@ -10,6 +11,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCulture("")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyConfiguration("")]
+
+[assembly: InternalsVisibleTo("Aquarius.Client.UnitTests")]
 
 // This code will be updated by the build system.
 // Developer builds should remain at version 0.0.0.0 so that unofficial binaries will be obvious.

--- a/src/Aquarius.Client/Samples/Client/FileUploader.cs
+++ b/src/Aquarius.Client/Samples/Client/FileUploader.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Globalization;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using ServiceStack;
+
+namespace Aquarius.Samples.Client
+{
+    public class FileUploader
+    {
+        private readonly JsonServiceClient _client;
+
+        public FileUploader(JsonServiceClient client)
+        {
+            _client = client;
+        }
+
+        public TResponse PostFileWithRequest<TResponse>(Stream contentToUpload, string uploadedFileName, IReturn<TResponse> requestDto)
+        {
+            using (var httpClient = new JsonHttpClient(_client.BaseUri))
+            {
+                httpClient.Headers.Add(SamplesClient.AuthorizationHeader, _client.Headers[SamplesClient.AuthorizationHeader]);
+                httpClient.Headers.Add("User-Agent", _client.UserAgent);
+
+                return httpClient.Post<TResponse>(
+                    ComposePostUrlWithQueryParams(requestDto),
+                    CreateMultipartContent(contentToUpload, uploadedFileName, requestDto));
+            }
+        }
+
+        private string ComposePostUrlWithQueryParams<TResponse>(IReturn<TResponse> requestDto)
+        {
+            var queryString = QueryStringSerializer.SerializeToString(requestDto);
+
+            var uriBuilder = new UriBuilder(GetPostUrl(requestDto)) {Query = queryString};
+
+            return uriBuilder.ToString();
+        }
+
+        private string GetPostUrl<TResponse>(IReturn<TResponse> requestDto)
+        {
+            return _client.ResolveTypedUrl(HttpMethods.Post, requestDto);
+        }
+
+        private MultipartContent CreateMultipartContent<TResponse>(Stream contentToUpload,
+            string uploadedFilename, IReturn<TResponse> requestDto)
+        {
+            // TODO: We need a better way to distinguish between file upload request types
+            const string importServiceRoute = "/services/import/";
+
+            var url = GetPostUrl(requestDto).ToLowerInvariant();
+
+            return url.Contains(importServiceRoute)
+                ? CreateImportServiceUploadContent(contentToUpload, uploadedFilename)
+                : CreateFineUploaderContent(contentToUpload, uploadedFilename);
+        }
+
+        private static MultipartFormDataContent CreateImportServiceUploadContent(Stream contentToUpload, string uploadedFilename)
+        {
+            return CreateMultipartContent(contentToUpload, uploadedFilename, "file");
+        }
+
+        private static MultipartFormDataContent CreateFineUploaderContent(Stream contentToUpload, string uploadedFilename)
+        {
+            return CreateMultipartContent(contentToUpload, uploadedFilename, "qqfile", (content, contentBytes) =>
+            {
+                AddFormDataContent(content, new StringContent(uploadedFilename), "qqfilename");
+                AddFormDataContent(content, new StringContent(Guid.NewGuid().ToString("D")), "qquuid");
+                AddFormDataContent(content, new StringContent(contentBytes.Length.ToString(CultureInfo.InvariantCulture)), "qqtotalfilesize");
+            });
+        }
+
+        private static MultipartFormDataContent CreateMultipartContent(
+            Stream contentToUpload,
+            string uploadedFilename,
+            string contentFieldName,
+            Action<MultipartFormDataContent, byte[]> contentSizeAction = null)
+        {
+            var content = new MultipartFormDataContent();
+
+            var fileBytes = contentToUpload.ReadFully();
+
+            contentSizeAction?.Invoke(content, fileBytes);
+
+            var fileContent = new ByteArrayContent(fileBytes, 0, fileBytes.Length);
+
+            AddFormDataContent(content, fileContent, contentFieldName);
+
+            fileContent.Headers.ContentDisposition.FileName = uploadedFilename;
+            fileContent.Headers.ContentType = MediaTypeHeaderValue.Parse(MimeTypes.GetMimeType(uploadedFilename));
+
+            return content;
+        }
+
+        private static void AddFormDataContent(MultipartContent content, HttpContent partContent, string partName)
+        {
+            partContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
+                { Name = partName };
+            content.Add(partContent);
+        }
+    }
+}

--- a/src/Aquarius.Client/Samples/Client/IPaginatedRequest.cs
+++ b/src/Aquarius.Client/Samples/Client/IPaginatedRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace Aquarius.Samples.Client
+{
+    public interface IPaginatedRequest
+    {
+        string Cursor { get; set; }
+    }
+}

--- a/src/Aquarius.Client/Samples/Client/IPaginatedResponse.cs
+++ b/src/Aquarius.Client/Samples/Client/IPaginatedResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+
+namespace Aquarius.Samples.Client
+{
+    public interface IPaginatedResponse<TDomainObject>
+    {
+        int TotalCount { get; set; }
+        string Cursor { get; set; }
+        List<TDomainObject> DomainObjects { get; set; }
+    }
+}

--- a/src/Aquarius.Client/Samples/Client/ISamplesClient.cs
+++ b/src/Aquarius.Client/Samples/Client/ISamplesClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using Aquarius.TimeSeries.Client;
 using ServiceStack;
 using ServiceStack.Text;
@@ -23,6 +24,9 @@ namespace Aquarius.Samples.Client
 
         TResponse SparsePut<TResponse>(IReturn<TResponse> requestDto);
         void SparsePut(IReturnVoid requestDto);
+
+        TResponse PostFileWithRequest<TResponse>(string path, IReturn<TResponse> requestDto);
+        TResponse PostFileWithRequest<TResponse>(Stream contentToUpload, string uploadedFileName, IReturn<TResponse> requestDto);
 
         LazyResult<TDomainObject> LazyGet<TDomainObject, TRequest, TResponse>(TRequest requestDto)
             where TRequest : IPaginatedRequest, IReturn<TResponse>

--- a/src/Aquarius.Client/Samples/Client/ISamplesClient.cs
+++ b/src/Aquarius.Client/Samples/Client/ISamplesClient.cs
@@ -11,8 +11,6 @@ namespace Aquarius.Samples.Client
         IServiceClient Client { get; }
         AquariusServerVersion ServerVersion { get; }
 
-        JsConfigScope WithScope();
-
         TResponse Get<TResponse>(IReturn<TResponse> requestDto);
         void Get(IReturnVoid requestDto);
         TResponse Post<TResponse>(IReturn<TResponse> requestDto);
@@ -31,5 +29,10 @@ namespace Aquarius.Samples.Client
         LazyResult<TDomainObject> LazyGet<TDomainObject, TRequest, TResponse>(TRequest requestDto)
             where TRequest : IPaginatedRequest, IReturn<TResponse>
             where TResponse : IPaginatedResponse<TDomainObject>;
+
+        JsConfigScope WithScope();
+
+        void InvokeWebServiceMethod(Action webServiceMethod, Func<JsConfigScope> scopeMethod = null);
+        TResponse InvokeWebServiceMethod<TResponse>(Func<TResponse> webServiceMethod, Func<JsConfigScope> scopeMethod = null);
     }
 }

--- a/src/Aquarius.Client/Samples/Client/ISamplesClient.cs
+++ b/src/Aquarius.Client/Samples/Client/ISamplesClient.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using Aquarius.TimeSeries.Client;
+using ServiceStack;
+using ServiceStack.Text;
+
+namespace Aquarius.Samples.Client
+{
+    public interface ISamplesClient : IDisposable
+    {
+        IServiceClient Client { get; }
+        AquariusServerVersion ServerVersion { get; }
+
+        JsConfigScope WithScope();
+
+        TResponse Get<TResponse>(IReturn<TResponse> requestDto);
+        void Get(IReturnVoid requestDto);
+        TResponse Post<TResponse>(IReturn<TResponse> requestDto);
+        void Post(IReturnVoid requestDto);
+        TResponse Put<TResponse>(IReturn<TResponse> requestDto);
+        void Put(IReturnVoid requestDto);
+        TResponse Delete<TResponse>(IReturn<TResponse> requestDto);
+        void Delete(IReturnVoid requestDto);
+
+        TResponse SparsePut<TResponse>(IReturn<TResponse> requestDto);
+        void SparsePut(IReturnVoid requestDto);
+
+        LazyResult<TDomainObject> LazyGet<TDomainObject, TRequest, TResponse>(TRequest requestDto)
+            where TRequest : IPaginatedRequest, IReturn<TResponse>
+            where TResponse : IPaginatedResponse<TDomainObject>;
+    }
+}

--- a/src/Aquarius.Client/Samples/Client/LazyResult.cs
+++ b/src/Aquarius.Client/Samples/Client/LazyResult.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace Aquarius.Samples.Client
+{
+    public class LazyResult<TDomainObject>
+    {
+        public int TotalCount { get; set; }
+        public IEnumerable<TDomainObject> DomainObjects { get; set; }
+    }
+}

--- a/src/Aquarius.Client/Samples/Client/SamplesApiException.cs
+++ b/src/Aquarius.Client/Samples/Client/SamplesApiException.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using ServiceStack;
+
+namespace Aquarius.Samples.Client
+{
+    public class SamplesApiException : Exception, IHasStatusCode
+    {
+        public SamplesApiException(string message) : base(message)
+        {
+        }
+
+        public SamplesApiException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+
+        public SamplesApiException(string message, WebServiceException originalException)
+            : base(message, originalException)
+        {
+            StatusCode = originalException.StatusCode;
+        }
+
+        public SamplesApiException(string message, WebServiceException originalException, SamplesErrorResponse errorResponse)
+            : base(message, originalException)
+        {
+            StatusCode = originalException.StatusCode;
+            SamplesError = errorResponse;
+        }
+
+        public int StatusCode { get; set; }
+        public SamplesErrorResponse SamplesError { get; set; }
+    }
+}

--- a/src/Aquarius.Client/Samples/Client/SamplesAuthenticationException.cs
+++ b/src/Aquarius.Client/Samples/Client/SamplesAuthenticationException.cs
@@ -1,0 +1,21 @@
+﻿using ServiceStack;
+
+namespace Aquarius.Samples.Client
+{
+    public class SamplesAuthenticationException : SamplesApiException
+    {
+        public SamplesAuthenticationException(string message) : base(message)
+        {
+        }
+
+        public SamplesAuthenticationException(string message, WebServiceException originalException)
+            : base(message, originalException)
+        {
+        }
+
+        public SamplesAuthenticationException(string message, WebServiceException originalException, SamplesErrorResponse errorResponse)
+            : base(message, originalException, errorResponse)
+        {
+        }
+    }
+}

--- a/src/Aquarius.Client/Samples/Client/SamplesClient.cs
+++ b/src/Aquarius.Client/Samples/Client/SamplesClient.cs
@@ -183,6 +183,9 @@ namespace Aquarius.Samples.Client
 
             for (var count = 0; count < totalCount;)
             {
+                if (responseDto.DomainObjects == null)
+                    break;
+
                 foreach (var domainObject in responseDto.DomainObjects)
                 {
                     yield return domainObject;
@@ -190,7 +193,7 @@ namespace Aquarius.Samples.Client
 
                 count += responseDto.DomainObjects.Count;
 
-                if (count >= totalCount || !responseDto.DomainObjects.Any())
+                if (count >= totalCount || count >= responseDto.TotalCount || !responseDto.DomainObjects.Any() || string.IsNullOrEmpty(responseDto.Cursor))
                     break;
 
                 requestDto.Cursor = responseDto.Cursor;

--- a/src/Aquarius.Client/Samples/Client/SamplesClient.cs
+++ b/src/Aquarius.Client/Samples/Client/SamplesClient.cs
@@ -1,0 +1,214 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using Aquarius.Helpers;
+using Aquarius.TimeSeries.Client;
+using ServiceStack;
+using ServiceStack.Logging;
+using ServiceStack.Text;
+
+namespace Aquarius.Samples.Client
+{
+    public class SamplesClient : ISamplesClient
+    {
+        private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        public static ISamplesClient CreateConnectedClient(string baseUrl, string apiToken)
+        {
+            return new SamplesClient(baseUrl, apiToken);
+        }
+
+        public AquariusServerVersion ServerVersion { get; }
+
+        private JsonServiceClient _client;
+
+        private SamplesClient(string baseUrl, string apiToken)
+        {
+            _client = new SdkServiceClient(UriHelper.ResolveEndpoint(baseUrl, "/api", Uri.UriSchemeHttps));
+            _client.Headers.Add("Authorization", $"token {apiToken}");
+
+            ServerVersion = GetServerVersion();
+        }
+
+        public IServiceClient Client => _client;
+
+        public void Dispose()
+        {
+            _client?.Dispose();
+            _client = null;
+        }
+
+        public JsConfigScope WithScope()
+        {
+            return WithCommonScope();
+        }
+
+        private static JsConfigScope WithCommonScope()
+        {
+            return WithScope(includeNullValues: false);
+        }
+
+        private static JsConfigScope WithSparsePutScope()
+        {
+            return WithScope(includeNullValues: true);
+        }
+
+        private static JsConfigScope WithScope(bool includeNullValues)
+        {
+            var scope = JsConfig.With(includeNullValues:includeNullValues, emitCamelCaseNames: true);
+            return scope;
+        }
+
+        private AquariusServerVersion GetServerVersion()
+        {
+            var response = Get(new GetStatus());
+
+            return AquariusServerVersion.Create(response.ReleaseName);
+        }
+
+        // TODO: This needs to be added to exposed Swagger methods
+        [Route("/v1/status", HttpMethods.Get)]
+        private class GetStatus : IReturn<StatusResponse>
+        {
+            
+        }
+
+        private class StatusResponse
+        {
+            public string ReleaseName { get; set; }
+        }
+
+        public TResponse Get<TResponse>(IReturn<TResponse> requestDto)
+        {
+            return InvokeWebServiceMethod(() => _client.Get(requestDto));
+        }
+
+        public void Get(IReturnVoid requestDto)
+        {
+            InvokeWebServiceMethod(() => _client.Get(requestDto));
+        }
+
+        public TResponse Post<TResponse>(IReturn<TResponse> requestDto)
+        {
+            return InvokeWebServiceMethod(() => _client.Post(requestDto));
+        }
+
+        public void Post(IReturnVoid requestDto)
+        {
+            InvokeWebServiceMethod(() => _client.Post(requestDto));
+        }
+
+        public TResponse Put<TResponse>(IReturn<TResponse> requestDto)
+        {
+            return InvokeWebServiceMethod(() => _client.Put(requestDto));
+        }
+
+        public void Put(IReturnVoid requestDto)
+        {
+            InvokeWebServiceMethod(() => _client.Put(requestDto));
+        }
+
+        public TResponse Delete<TResponse>(IReturn<TResponse> requestDto)
+        {
+            return InvokeWebServiceMethod(() => _client.Delete(requestDto));
+        }
+
+        public void Delete(IReturnVoid requestDto)
+        {
+            InvokeWebServiceMethod(() => _client.Delete(requestDto));
+        }
+
+        public TResponse SparsePut<TResponse>(IReturn<TResponse> requestDto)
+        {
+            return InvokeWebServiceMethod(() => _client.Put(requestDto), WithSparsePutScope);
+        }
+
+        public void SparsePut(IReturnVoid requestDto)
+        {
+            InvokeWebServiceMethod(() => _client.Put(requestDto), WithSparsePutScope);
+        }
+
+
+        public LazyResult<TDomainObject> LazyGet<TDomainObject, TRequest, TResponse>(TRequest requestDto)
+            where TRequest : IPaginatedRequest, IReturn<TResponse>
+            where TResponse : IPaginatedResponse<TDomainObject>
+        {
+            var responseDto = Get(requestDto);
+
+            return new LazyResult<TDomainObject>
+            {
+                TotalCount = responseDto.TotalCount,
+                DomainObjects = GetPaginatedResults<TDomainObject, TRequest, TResponse>(requestDto, responseDto)
+            };
+        }
+
+        private IEnumerable<TDomainObject> GetPaginatedResults<TDomainObject, TRequest, TResponse>(TRequest requestDto, TResponse responseDto)
+            where TRequest : IPaginatedRequest, IReturn<TResponse>
+            where TResponse : IPaginatedResponse<TDomainObject>
+        {
+            var totalCount = responseDto.TotalCount;
+
+            for (var count = 0; count < totalCount;)
+            {
+                foreach (var domainObject in responseDto.DomainObjects)
+                {
+                    yield return domainObject;
+                }
+
+                count += responseDto.DomainObjects.Count;
+
+                if (count >= totalCount || !responseDto.DomainObjects.Any())
+                    break;
+
+                requestDto.Cursor = responseDto.Cursor;
+
+                responseDto = Get(requestDto);
+            }
+        }
+
+        private static TResponse InvokeWebServiceMethod<TResponse>(Func<TResponse> webServiceMethod, Func<JsConfigScope> scopeMethod = null)
+        {
+            try
+            {
+                using (scopeMethod == null ? WithCommonScope() : scopeMethod.Invoke())
+                {
+                    return webServiceMethod.Invoke();
+                }
+            }
+            catch (WebServiceException exception)
+            {
+                Log.Error(exception);
+                throw;
+            }
+            catch (WebException exception)
+            {
+                Log.Error(exception);
+                throw;
+            }
+        }
+
+
+        private static void InvokeWebServiceMethod(Action webServiceMethod, Func<JsConfigScope> scopeMethod = null)
+        {
+            try
+            {
+                using (scopeMethod == null ? WithCommonScope() : scopeMethod.Invoke())
+                {
+                    webServiceMethod.Invoke();
+                }
+            }
+            catch (WebServiceException exception)
+            {
+                Log.Error(exception);
+                throw;
+            }
+            catch (WebException exception)
+            {
+                Log.Error(exception);
+                throw;
+            }
+        }
+    }
+}

--- a/src/Aquarius.Client/Samples/Client/SamplesClient.cs
+++ b/src/Aquarius.Client/Samples/Client/SamplesClient.cs
@@ -105,6 +105,11 @@ namespace Aquarius.Samples.Client
             InvokeWebServiceMethod(() => _client.Post(requestDto));
         }
 
+        public TResponse Post<TResponse>(string relativeOrAbsoluteUri, object request)
+        {
+            return InvokeWebServiceMethod(() => _client.Post<TResponse>(relativeOrAbsoluteUri, request));
+        }
+
         public TResponse Put<TResponse>(IReturn<TResponse> requestDto)
         {
             return InvokeWebServiceMethod(() => _client.Put(requestDto));
@@ -194,7 +199,7 @@ namespace Aquarius.Samples.Client
             }
         }
 
-        private static void InvokeWebServiceMethod(Action webServiceMethod, Func<JsConfigScope> scopeMethod = null)
+        public void InvokeWebServiceMethod(Action webServiceMethod, Func<JsConfigScope> scopeMethod = null)
         {
             const int dummyValueToIgnore = 0;
 
@@ -206,7 +211,7 @@ namespace Aquarius.Samples.Client
             }, scopeMethod);
         }
 
-        private static TResponse InvokeWebServiceMethod<TResponse>(Func<TResponse> webServiceMethod, Func<JsConfigScope> scopeMethod = null)
+        public TResponse InvokeWebServiceMethod<TResponse>(Func<TResponse> webServiceMethod, Func<JsConfigScope> scopeMethod = null)
         {
             try
             {

--- a/src/Aquarius.Client/Samples/Client/SamplesClient.cs
+++ b/src/Aquarius.Client/Samples/Client/SamplesClient.cs
@@ -14,7 +14,7 @@ namespace Aquarius.Samples.Client
 {
     public class SamplesClient : ISamplesClient
     {
-        public const string AuthorizationHeader = HttpHeaders.Authorization;
+        public const string AuthorizationHeaderKey = HttpHeaders.Authorization;
 
         private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
 
@@ -30,7 +30,7 @@ namespace Aquarius.Samples.Client
         private SamplesClient(string baseUrl, string apiToken)
         {
             _client = new SdkServiceClient(UriHelper.ResolveEndpoint(baseUrl, "/api", Uri.UriSchemeHttps));
-            _client.Headers.Add(AuthorizationHeader, $"token {apiToken}");
+            _client.Headers.Add(AuthorizationHeaderKey, $"token {apiToken}");
 
             ServerVersion = GetServerVersion();
 
@@ -149,7 +149,12 @@ namespace Aquarius.Samples.Client
         {
             var fileUploader = new FileUploader(_client);
 
-            return InvokeWebServiceMethod(() => fileUploader.PostFileWithRequest(contentToUpload, uploadedFileName, requestDto));
+            return InvokeWebServiceMethod(() => fileUploader.PostFileWithRequest(GetPostUrl(requestDto), contentToUpload, uploadedFileName, requestDto));
+        }
+
+        private string GetPostUrl<TResponse>(IReturn<TResponse> requestDto)
+        {
+            return _client.ResolveTypedUrl(HttpMethods.Post, requestDto);
         }
 
         public LazyResult<TDomainObject> LazyGet<TDomainObject, TRequest, TResponse>(TRequest requestDto)

--- a/src/Aquarius.Client/Samples/Client/SamplesErrorResponse.cs
+++ b/src/Aquarius.Client/Samples/Client/SamplesErrorResponse.cs
@@ -1,0 +1,27 @@
+﻿using ServiceStack;
+
+namespace Aquarius.Samples.Client
+{
+    public class SamplesErrorResponse
+    {
+        public ResponseStatus ResponseStatus { get; } = new ResponseStatus();
+
+        public string Message
+        {
+            get { return ResponseStatus.Message; }
+            set { ResponseStatus.Message = value; }
+        }
+
+        public string ErrorCode
+        {
+            get { return ResponseStatus.ErrorCode; }
+            set { ResponseStatus.ErrorCode = value; }
+        }
+
+        public string StackTrace
+        {
+            get { return ResponseStatus.StackTrace; }
+            set { ResponseStatus.StackTrace = value; }
+        }
+    }
+}

--- a/src/Aquarius.Client/Samples/Client/SamplesMaintenanceModeException.cs
+++ b/src/Aquarius.Client/Samples/Client/SamplesMaintenanceModeException.cs
@@ -1,0 +1,16 @@
+﻿using ServiceStack;
+
+namespace Aquarius.Samples.Client
+{
+    public class SamplesMaintenanceModeException : SamplesApiException
+    {
+        public SamplesMaintenanceModeException(string message) : base(message)
+        {
+        }
+
+        public SamplesMaintenanceModeException(string message, WebServiceException originalException)
+            : base(message, originalException)
+        {
+        }
+    }
+}

--- a/src/Aquarius.Client/Samples/Client/ServiceModel.cs
+++ b/src/Aquarius.Client/Samples/Client/ServiceModel.cs
@@ -1,0 +1,3134 @@
+// Date: 2017-05-15T16:05:10.6309739-07:00
+// Base URL: https://demo.aqsamples.com/api/swagger.json
+// Source: AQUARIUS Samples API (2017.6.2047)
+
+using System.Collections.Generic;
+using ServiceStack;
+using NodaTime;
+using Aquarius.TimeSeries.Client;
+// ReSharper disable InconsistentNaming
+
+// ReSharper disable once CheckNamespace
+namespace Aquarius.Samples.Client.ServiceModel
+{
+    public static class Current
+    {
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("2017.6.2047");
+    }
+
+    [Route("/v1/accessgroups", "GET")]
+    public class GetAccessGroups : IReturn<SearchResultAccessGroup>
+    {
+        
+    }
+
+    [Route("/v1/accessgroups", "POST")]
+    public class PostAccessGroup : IReturn<AccessGroup>
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public bool? CanEditAllData { get; set; }
+        public List<SamplingLocationGroupSimple> SamplingLocationGroups { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/accessgroups/{id}", "GET")]
+    public class GetAccessGroup : IReturn<AccessGroup>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/accessgroups/{id}", "PUT")]
+    public class PutSparseAccessGroup : IReturn<AccessGroup>
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public bool? CanEditAllData { get; set; }
+        public List<SamplingLocationGroupSimple> SamplingLocationGroups { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/accessgroups/{id}", "DELETE")]
+    public class DeleteAccessGroupById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/activities", "GET")]
+    public class GetActivities : IReturn<SearchResultActivitySimple>
+    {
+        public List<string> CollectionMethodIds { get; set; }
+        public string CustomId { get; set; }
+        public string FieldVisitId { get; set; }
+        public List<string> SamplingLocationIds { get; set; }
+        public ActivityType? Type { get; set; }
+    }
+
+    [Route("/v1/activities", "POST")]
+    public class PostActivity : IReturn<Activity>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public ActivityType? Type { get; set; }
+        public string ReplicateSourceActivityId { get; set; }
+        public Instant? StartTime { get; set; }
+        public Instant? EndTime { get; set; }
+        public string Comment { get; set; }
+        public string LoggerFileName { get; set; }
+        public Device Device { get; set; }
+        public CollectionMethod CollectionMethod { get; set; }
+        public MediumType? Medium { get; set; }
+        public ActivityTemplateMinimal ActivityTemplate { get; set; }
+        public Quantity Depth { get; set; }
+        public SamplingLocation SamplingLocation { get; set; }
+        public FieldVisit FieldVisit { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/activities/{id}", "GET")]
+    public class GetActivity : IReturn<ActivityRepresentation>
+    {
+        public string Id { get; set; }
+        public bool? Detail { get; set; }
+    }
+
+    [Route("/v1/activities/{id}", "PUT")]
+    public class PutSparseActivity : IReturn<Activity>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public ActivityType? Type { get; set; }
+        public string ReplicateSourceActivityId { get; set; }
+        public Instant? StartTime { get; set; }
+        public Instant? EndTime { get; set; }
+        public string Comment { get; set; }
+        public string LoggerFileName { get; set; }
+        public Device Device { get; set; }
+        public CollectionMethod CollectionMethod { get; set; }
+        public MediumType? Medium { get; set; }
+        public ActivityTemplateMinimal ActivityTemplate { get; set; }
+        public Quantity Depth { get; set; }
+        public SamplingLocation SamplingLocation { get; set; }
+        public FieldVisit FieldVisit { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/activities/{id}", "DELETE")]
+    public class DeleteActivityById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/activities/{id}/replicate", "POST")]
+    public class PostReplicateActivity : IReturn<Activity>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/activitytemplates", "GET")]
+    public class GetActivityTemplates : IReturn<SearchResultActivityTemplate>
+    {
+        public ActivityType? Type { get; set; }
+    }
+
+    [Route("/v1/activitytemplates", "POST")]
+    public class PostActivityTemplate : IReturn<ActivityTemplate>
+    {
+        public string Id { get; set; }
+        public List<SpecimenTemplate> SpecimenTemplates { get; set; }
+        public string CustomId { get; set; }
+        public ActivityType? Type { get; set; }
+        public string Comment { get; set; }
+        public MediumType? Medium { get; set; }
+        public Quantity Depth { get; set; }
+        public CollectionMethod CollectionMethod { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/activitytemplates/{id}", "GET")]
+    public class GetActivityTemplate : IReturn<ActivityTemplate>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/activitytemplates/{id}", "PUT")]
+    public class PutSparseActivityTemplate : IReturn<ActivityTemplate>
+    {
+        public string Id { get; set; }
+        public List<SpecimenTemplate> SpecimenTemplates { get; set; }
+        public string CustomId { get; set; }
+        public ActivityType? Type { get; set; }
+        public string Comment { get; set; }
+        public MediumType? Medium { get; set; }
+        public Quantity Depth { get; set; }
+        public CollectionMethod CollectionMethod { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/activitytemplates/{id}", "DELETE")]
+    public class DeleteActivityTemplateById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/analyticalgroups", "GET")]
+    public class GetAnalyticalGroups : IReturn<SearchResultAnalyticalGroup>
+    {
+        public List<string> ObservedPropertyIds { get; set; }
+    }
+
+    [Route("/v1/analyticalgroups", "POST")]
+    public class PostAnalyticalGroup : IReturn<AnalyticalGroup>
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public AnalyticalGroupType? Type { get; set; }
+        public int? NumberOfObservedPropertiesInGroupItems { get; set; }
+        public int? NumberOfAnalysisMethodsInGroupItems { get; set; }
+        public List<AnalyticalGroupItem> AnalyticalGroupItems { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/analyticalgroups/{id}", "GET")]
+    public class GetAnalyticalGroup : IReturn<AnalyticalGroup>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/analyticalgroups/{id}", "PUT")]
+    public class PutSparseAnalyticalGroup : IReturn<AnalyticalGroup>
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public AnalyticalGroupType? Type { get; set; }
+        public int? NumberOfObservedPropertiesInGroupItems { get; set; }
+        public int? NumberOfAnalysisMethodsInGroupItems { get; set; }
+        public List<AnalyticalGroupItem> AnalyticalGroupItems { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/analyticalgroups/{id}", "DELETE")]
+    public class DeleteAnalyticalGroupById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/attachments/upload", "POST")]
+    public class PostUploadAttachment : IReturn<AttachmentRepresentation>
+    {
+        
+    }
+
+    [Route("/v1/attachments/{id}", "GET")]
+    public class GetAttachment : IReturn<Attachment>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/attachments/{id}", "PUT")]
+    public class PutAttachment : IReturn<Attachment>
+    {
+        public string Id { get; set; }
+        public string FileName { get; set; }
+        public string ContentType { get; set; }
+        public string Comment { get; set; }
+        public long? FileSize { get; set; }
+        public Instant? DateTaken { get; set; }
+        public string Latitude { get; set; }
+        public string Longitude { get; set; }
+        public string Resolution { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/attachments/{id}", "DELETE")]
+    public class DeleteAttachment : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/attachments/{id}/contents", "GET")]
+    public class GetAttachmentContent : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/collectionmethods", "GET")]
+    public class GetCollectionMethods : IReturn<SearchResultCollectionMethod>
+    {
+        
+    }
+
+    [Route("/v1/collectionmethods", "POST")]
+    public class PostCollectionMethod : IReturn<CollectionMethod>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string IdentifierOrganization { get; set; }
+        public string Name { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/collectionmethods/{id}", "GET")]
+    public class GetCollectionMethod : IReturn<CollectionMethod>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/collectionmethods/{id}", "PUT")]
+    public class PutSparseCollectionMethod : IReturn<CollectionMethod>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string IdentifierOrganization { get; set; }
+        public string Name { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/collectionmethods/{id}", "DELETE")]
+    public class DeleteCollectionMethodById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/fieldtrips", "GET")]
+    public class GetFieldTrips : IReturn<SearchResultFieldTrip>
+    {
+        public int? Limit { get; set; }
+        public List<string> Search { get; set; }
+    }
+
+    [Route("/v1/fieldtrips", "POST")]
+    public class PostFieldTrip : IReturn<FieldTrip>
+    {
+        public List<FieldVisit> FieldVisits { get; set; }
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public Instant? StartTime { get; set; }
+        public Instant? EndTime { get; set; }
+        public string Participants { get; set; }
+        public string Notes { get; set; }
+        public List<DomainObjectAttachment> Attachments { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/fieldtrips/{id}", "GET")]
+    public class GetFieldTrip : IReturn<FieldTrip>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/fieldtrips/{id}", "PUT")]
+    public class PutSparseFieldTrip : IReturn<FieldTrip>
+    {
+        public string Id { get; set; }
+        public List<FieldVisit> FieldVisits { get; set; }
+        public string CustomId { get; set; }
+        public Instant? StartTime { get; set; }
+        public Instant? EndTime { get; set; }
+        public string Participants { get; set; }
+        public string Notes { get; set; }
+        public List<DomainObjectAttachment> Attachments { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/fieldtrips/{id}", "DELETE")]
+    public class DeleteFieldTripById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/fieldvisits", "GET")]
+    public class GetFieldVisits : IReturn<SearchResultFieldVisitSimple>
+    {
+        public string CustomId { get; set; }
+        public List<string> PlanningStatuses { get; set; }
+        public List<string> SamplingLocationIds { get; set; }
+    }
+
+    [Route("/v1/fieldvisits", "POST")]
+    public class PostFieldVisit : IReturn<FieldVisit>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public Instant? StartTime { get; set; }
+        public Instant? EndTime { get; set; }
+        public string Participants { get; set; }
+        public string Notes { get; set; }
+        public string FieldTripId { get; set; }
+        public PlanningStatusType? PlanningStatus { get; set; }
+        public SamplingLocation SamplingLocation { get; set; }
+        public List<PlannedFieldResult> PlannedFieldResults { get; set; }
+        public List<ActivityTemplate> ActivityTemplates { get; set; }
+        public List<DomainObjectAttachment> Attachments { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/fieldvisits/{id}", "GET")]
+    public class GetFieldVisit : IReturn<FieldVisit>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/fieldvisits/{id}", "PUT")]
+    public class PutSparseFieldVisit : IReturn<FieldVisit>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public Instant? StartTime { get; set; }
+        public Instant? EndTime { get; set; }
+        public string Participants { get; set; }
+        public string Notes { get; set; }
+        public string FieldTripId { get; set; }
+        public PlanningStatusType? PlanningStatus { get; set; }
+        public SamplingLocation SamplingLocation { get; set; }
+        public List<PlannedFieldResult> PlannedFieldResults { get; set; }
+        public List<ActivityTemplate> ActivityTemplates { get; set; }
+        public List<DomainObjectAttachment> Attachments { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/fieldvisits/{id}", "DELETE")]
+    public class DeleteFieldVisitById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/fieldvisits/{id}/activitywithtemplate", "POST")]
+    public class PostAddActivityWithTemplate : IReturn<Activity>
+    {
+        public string Id { get; set; }
+        public List<SpecimenTemplate> SpecimenTemplates { get; set; }
+        public string CustomId { get; set; }
+        public ActivityType? Type { get; set; }
+        public string Comment { get; set; }
+        public MediumType? Medium { get; set; }
+        public Quantity Depth { get; set; }
+        public CollectionMethod CollectionMethod { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/fieldvisits/{id}/attachments", "GET")]
+    public class GetFieldVisitAttachments : IReturn<SearchResultAttachment>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/fieldvisits/{id}/statistics", "GET")]
+    public class GetFieldVisitStatistics : IReturn<FieldVisitStatistics>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/labanalysismethods", "GET")]
+    public class GetLabAnalysisMethods : IReturn<SearchResultLabAnalysisMethod>
+    {
+        public string Context { get; set; }
+        public List<string> ObservedPropertyIds { get; set; }
+    }
+
+    [Route("/v1/labanalysismethods", "POST")]
+    public class PostLabAnalysisMethod : IReturn<LabAnalysisMethod>
+    {
+        public List<ObservedProperty> ObservedProperties { get; set; }
+        public string Id { get; set; }
+        public string MethodId { get; set; }
+        public string Name { get; set; }
+        public string Context { get; set; }
+        public string Description { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/labanalysismethods/{id}", "GET")]
+    public class GetLabAnalysisMethod : IReturn<LabAnalysisMethod>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/labanalysismethods/{id}", "PUT")]
+    public class PutSparseLabAnalysisMethod : IReturn<LabAnalysisMethod>
+    {
+        public string Id { get; set; }
+        public List<ObservedProperty> ObservedProperties { get; set; }
+        public string MethodId { get; set; }
+        public string Name { get; set; }
+        public string Context { get; set; }
+        public string Description { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/labanalysismethods/{id}", "DELETE")]
+    public class DeleteLabAnalysisMethodById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/laboratories", "GET")]
+    public class GetLaboratories : IReturn<SearchResultLaboratory>
+    {
+        
+    }
+
+    [Route("/v1/laboratories", "POST")]
+    public class PostLaboratory : IReturn<Laboratory>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Address { get; set; }
+        public string PointOfContact { get; set; }
+        public string EmailAddress { get; set; }
+        public string PhoneNumber { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/laboratories/{id}", "GET")]
+    public class GetLaboratory : IReturn<Laboratory>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/laboratories/{id}", "PUT")]
+    public class PutSparseLaboratory : IReturn<Laboratory>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Address { get; set; }
+        public string PointOfContact { get; set; }
+        public string EmailAddress { get; set; }
+        public string PhoneNumber { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/laboratories/{id}", "DELETE")]
+    public class DeleteLaboratoryById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/labreports", "GET")]
+    public class GetLabReports : IReturn<SearchResultLabReport>
+    {
+        public string CustomId { get; set; }
+        public List<string> LaboratoryIds { get; set; }
+        public int? Limit { get; set; }
+        public List<string> Search { get; set; }
+    }
+
+    [Route("/v1/labreports", "POST")]
+    public class PostLabReport : IReturn<LabReport>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public Instant? DateReceived { get; set; }
+        public string CaseNarrative { get; set; }
+        public string QcSummary { get; set; }
+        public Laboratory Laboratory { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/labreports/{id}", "GET")]
+    public class GetLabReport : IReturn<LabReport>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/labreports/{id}", "PUT")]
+    public class PutSparseLabReport : IReturn<LabReport>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public Instant? DateReceived { get; set; }
+        public string CaseNarrative { get; set; }
+        public string QcSummary { get; set; }
+        public Laboratory Laboratory { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/labreports/{id}", "DELETE")]
+    public class DeleteLabReportById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/observations", "GET")]
+    public class GetObservations : IReturn<SearchResultObservation>, IPaginatedRequest
+    {
+        public string ActivityCustomId { get; set; }
+        public string ActivityId { get; set; }
+        public List<string> AnalyticalGroupIds { get; set; }
+        public List<string> CollectionMethodIds { get; set; }
+        public string Cursor { get; set; }
+        public string CustomId { get; set; }
+        public List<string> DataClassifications { get; set; }
+        public string DepthUnitCustomId { get; set; }
+        public string DepthUnitId { get; set; }
+        public double? DepthValue { get; set; }
+        public DetectionConditionType? DetectionCondition { get; set; }
+        public Instant? EndObservedTime { get; set; }
+        public Instant? EndResultTime { get; set; }
+        public string FieldVisitId { get; set; }
+        public string ImportHistoryEventId { get; set; }
+        public List<string> LabAnalysisMethodIds { get; set; }
+        public List<string> LabReportIds { get; set; }
+        public List<string> LaboratoryIds { get; set; }
+        public int? Limit { get; set; }
+        public List<string> Media { get; set; }
+        public List<string> ObservedPropertyIds { get; set; }
+        public string ProjectId { get; set; }
+        public List<string> QualityControlTypes { get; set; }
+        public List<string> ResultGrades { get; set; }
+        public List<string> ResultStatuses { get; set; }
+        public SampleFractionType? SampleFraction { get; set; }
+        public List<string> SamplingLocationIds { get; set; }
+        public List<string> Search { get; set; }
+        public string Sort { get; set; }
+        public string SpecimenName { get; set; }
+        public Instant? StartObservedTime { get; set; }
+        public Instant? StartResultTime { get; set; }
+        public List<string> TaxonIds { get; set; }
+    }
+
+    [Route("/v1/observations", "POST")]
+    public class PostObservation : IReturn<Observation>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public Activity Activity { get; set; }
+        public CollectionMethod CollectionMethod { get; set; }
+        public ObservedProperty ObservedProperty { get; set; }
+        public Specimen Specimen { get; set; }
+        public SamplingLocation SamplingLocation { get; set; }
+        public NumericResult NumericResult { get; set; }
+        public CategoricalResult CategoricalResult { get; set; }
+        public TaxonomicResult TaxonomicResult { get; set; }
+        public QualityControlType? QualityControlType { get; set; }
+        public DataClassificationType? DataClassification { get; set; }
+        public MediumType? Medium { get; set; }
+        public string MediumSubdivision { get; set; }
+        public Instant? ObservedTime { get; set; }
+        public Instant? ResultTime { get; set; }
+        public Quantity Depth { get; set; }
+        public LabInstruction LabInstruction { get; set; }
+        public LabResultDetails LabResultDetails { get; set; }
+        public string Comment { get; set; }
+        public FieldVisit FieldVisit { get; set; }
+        public Device Device { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public List<RuleValidationDetails> ValidationWarnings { get; set; }
+        public ResultGradeType? ResultGrade { get; set; }
+        public ResultStatusType? ResultStatus { get; set; }
+        public PlannedFieldResult PlannedFieldResult { get; set; }
+        public Taxon RelatedTaxon { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/observations", "DELETE")]
+    public class DeleteObservations : IReturnVoid
+    {
+        public string ActivityCustomId { get; set; }
+        public string ActivityId { get; set; }
+        public List<string> AnalyticalGroupIds { get; set; }
+        public List<string> CollectionMethodIds { get; set; }
+        public string Cursor { get; set; }
+        public string CustomId { get; set; }
+        public List<string> DataClassifications { get; set; }
+        public string DepthUnitCustomId { get; set; }
+        public string DepthUnitId { get; set; }
+        public double? DepthValue { get; set; }
+        public DetectionConditionType? DetectionCondition { get; set; }
+        public Instant? EndObservedTime { get; set; }
+        public Instant? EndResultTime { get; set; }
+        public string FieldVisitId { get; set; }
+        public string ImportHistoryEventId { get; set; }
+        public List<string> LabAnalysisMethodIds { get; set; }
+        public List<string> LabReportIds { get; set; }
+        public List<string> LaboratoryIds { get; set; }
+        public int? Limit { get; set; }
+        public List<string> Media { get; set; }
+        public List<string> ObservedPropertyIds { get; set; }
+        public string ProjectId { get; set; }
+        public List<string> QualityControlTypes { get; set; }
+        public List<string> ResultGrades { get; set; }
+        public List<string> ResultStatuses { get; set; }
+        public SampleFractionType? SampleFraction { get; set; }
+        public List<string> SamplingLocationIds { get; set; }
+        public List<string> Search { get; set; }
+        public string Sort { get; set; }
+        public string SpecimenName { get; set; }
+        public Instant? StartObservedTime { get; set; }
+        public Instant? StartResultTime { get; set; }
+        public List<string> TaxonIds { get; set; }
+    }
+
+    [Route("/v1/observations/charts", "GET")]
+    public class GetChartData : IReturn<MultiChartData>
+    {
+        public string ActivityCustomId { get; set; }
+        public string ActivityId { get; set; }
+        public List<string> AnalyticalGroupIds { get; set; }
+        public List<string> CollectionMethodIds { get; set; }
+        public string Cursor { get; set; }
+        public string CustomId { get; set; }
+        public List<string> DataClassifications { get; set; }
+        public string DepthUnitCustomId { get; set; }
+        public string DepthUnitId { get; set; }
+        public double? DepthValue { get; set; }
+        public DetectionConditionType? DetectionCondition { get; set; }
+        public Instant? EndObservedTime { get; set; }
+        public Instant? EndResultTime { get; set; }
+        public string FieldVisitId { get; set; }
+        public string ImportHistoryEventId { get; set; }
+        public List<string> LabAnalysisMethodIds { get; set; }
+        public List<string> LabReportIds { get; set; }
+        public List<string> LaboratoryIds { get; set; }
+        public int? Limit { get; set; }
+        public List<string> Media { get; set; }
+        public List<string> ObservedPropertyIds { get; set; }
+        public string ProjectId { get; set; }
+        public List<string> QualityControlTypes { get; set; }
+        public List<string> ResultGrades { get; set; }
+        public List<string> ResultStatuses { get; set; }
+        public SampleFractionType? SampleFraction { get; set; }
+        public List<string> SamplingLocationIds { get; set; }
+        public List<string> Search { get; set; }
+        public string Sort { get; set; }
+        public string SpecimenName { get; set; }
+        public Instant? StartObservedTime { get; set; }
+        public Instant? StartResultTime { get; set; }
+        public List<string> TaxonIds { get; set; }
+    }
+
+    [Route("/v1/observations/geographic", "GET")]
+    public class GetGroupedObservations : IReturn<SearchResultLocationObservationsGroup>, IPaginatedRequest
+    {
+        public string ActivityCustomId { get; set; }
+        public string ActivityId { get; set; }
+        public List<string> AnalyticalGroupIds { get; set; }
+        public List<string> CollectionMethodIds { get; set; }
+        public string Cursor { get; set; }
+        public string CustomId { get; set; }
+        public List<string> DataClassifications { get; set; }
+        public string DepthUnitCustomId { get; set; }
+        public string DepthUnitId { get; set; }
+        public double? DepthValue { get; set; }
+        public DetectionConditionType? DetectionCondition { get; set; }
+        public Instant? EndObservedTime { get; set; }
+        public Instant? EndResultTime { get; set; }
+        public string FieldVisitId { get; set; }
+        public string ImportHistoryEventId { get; set; }
+        public List<string> LabAnalysisMethodIds { get; set; }
+        public List<string> LabReportIds { get; set; }
+        public List<string> LaboratoryIds { get; set; }
+        public int? Limit { get; set; }
+        public List<string> Media { get; set; }
+        public List<string> ObservedPropertyIds { get; set; }
+        public string ProjectId { get; set; }
+        public List<string> QualityControlTypes { get; set; }
+        public List<string> ResultGrades { get; set; }
+        public List<string> ResultStatuses { get; set; }
+        public SampleFractionType? SampleFraction { get; set; }
+        public List<string> SamplingLocationIds { get; set; }
+        public List<string> Search { get; set; }
+        public string Sort { get; set; }
+        public string SpecimenName { get; set; }
+        public Instant? StartObservedTime { get; set; }
+        public Instant? StartResultTime { get; set; }
+        public List<string> TaxonIds { get; set; }
+    }
+
+    [Route("/v1/observations/{id}", "GET")]
+    public class GetObservation : IReturn<Observation>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/observations/{id}", "PUT")]
+    public class PutSparseObservation : IReturn<Observation>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public Activity Activity { get; set; }
+        public CollectionMethod CollectionMethod { get; set; }
+        public ObservedProperty ObservedProperty { get; set; }
+        public Specimen Specimen { get; set; }
+        public SamplingLocation SamplingLocation { get; set; }
+        public NumericResult NumericResult { get; set; }
+        public CategoricalResult CategoricalResult { get; set; }
+        public TaxonomicResult TaxonomicResult { get; set; }
+        public QualityControlType? QualityControlType { get; set; }
+        public DataClassificationType? DataClassification { get; set; }
+        public MediumType? Medium { get; set; }
+        public string MediumSubdivision { get; set; }
+        public Instant? ObservedTime { get; set; }
+        public Instant? ResultTime { get; set; }
+        public Quantity Depth { get; set; }
+        public LabInstruction LabInstruction { get; set; }
+        public LabResultDetails LabResultDetails { get; set; }
+        public string Comment { get; set; }
+        public FieldVisit FieldVisit { get; set; }
+        public Device Device { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public List<RuleValidationDetails> ValidationWarnings { get; set; }
+        public ResultGradeType? ResultGrade { get; set; }
+        public ResultStatusType? ResultStatus { get; set; }
+        public PlannedFieldResult PlannedFieldResult { get; set; }
+        public Taxon RelatedTaxon { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/observations/{id}", "DELETE")]
+    public class DeleteObservationById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/observedproperties", "GET")]
+    public class GetObservedProperties : IReturn<SearchResultObservedProperty>
+    {
+        public List<string> AnalysisTypes { get; set; }
+        public string CustomId { get; set; }
+        public int? Limit { get; set; }
+        public List<string> ResultTypes { get; set; }
+        public List<string> Search { get; set; }
+    }
+
+    [Route("/v1/observedproperties", "POST")]
+    public class PostObservedProperty : IReturn<ObservedProperty>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public ResultType? ResultType { get; set; }
+        public AnalysisType? AnalysisType { get; set; }
+        public UnitGroup UnitGroup { get; set; }
+        public Unit DefaultUnit { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public string CasNumber { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/observedproperties/{id}", "GET")]
+    public class GetObservedProperty : IReturn<ObservedProperty>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/observedproperties/{id}", "PUT")]
+    public class PutSparseObservedProperty : IReturn<ObservedProperty>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public ResultType? ResultType { get; set; }
+        public AnalysisType? AnalysisType { get; set; }
+        public UnitGroup UnitGroup { get; set; }
+        public Unit DefaultUnit { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public string CasNumber { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/observedproperties/{id}", "DELETE")]
+    public class DeleteObservedPropertyById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/projects", "GET")]
+    public class GetProjects : IReturn<SearchResultProject>
+    {
+        
+    }
+
+    [Route("/v1/projects", "POST")]
+    public class PostProject : IReturn<Project>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public ProjectType? Type { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string ScopeStatement { get; set; }
+        public bool? Approved { get; set; }
+        public string ApprovalAgency { get; set; }
+        public Instant? StartTime { get; set; }
+        public Instant? EndTime { get; set; }
+        public Filter Filter { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/projects/{id}", "GET")]
+    public class GetProject : IReturn<Project>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/projects/{id}", "PUT")]
+    public class PutSparseProject : IReturn<Project>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public ProjectType? Type { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string ScopeStatement { get; set; }
+        public bool? Approved { get; set; }
+        public string ApprovalAgency { get; set; }
+        public Instant? StartTime { get; set; }
+        public Instant? EndTime { get; set; }
+        public Filter Filter { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/projects/{id}", "DELETE")]
+    public class DeleteProjectById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/samplinglocationgroups", "GET")]
+    public class GetSamplingLocationGroups : IReturn<SearchResultSamplingLocationGroup>
+    {
+        
+    }
+
+    [Route("/v1/samplinglocationgroups", "POST")]
+    public class PostSamplingLocationGroup : IReturn<SamplingLocationGroup>
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/samplinglocationgroups/{id}", "GET")]
+    public class GetSamplingLocationGroup : IReturn<SamplingLocationGroup>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/samplinglocationgroups/{id}", "PUT")]
+    public class PutSparseSamplingLocationGroup : IReturn<SamplingLocationGroup>
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/samplinglocationgroups/{id}", "DELETE")]
+    public class DeleteSamplingLocationGroupById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/samplinglocations", "GET")]
+    public class GetSamplingLocations : IReturn<SearchResultSamplingLocation>, IPaginatedRequest
+    {
+        public string Cursor { get; set; }
+        public string CustomId { get; set; }
+        public int? Limit { get; set; }
+        public List<string> Search { get; set; }
+        public string Sort { get; set; }
+    }
+
+    [Route("/v1/samplinglocations", "POST")]
+    public class PostSamplingLocation : IReturn<SamplingLocation>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public SamplingLocationType? Type { get; set; }
+        public string Latitude { get; set; }
+        public string Longitude { get; set; }
+        public string HorizontalDatum { get; set; }
+        public string VerticalDatum { get; set; }
+        public string HorizontalCollectionMethod { get; set; }
+        public string VerticalCollectionMethod { get; set; }
+        public string Description { get; set; }
+        public Address Address { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public List<StandardSimple> Standards { get; set; }
+        public List<DomainObjectAttachment> Attachments { get; set; }
+        public List<SamplingLocationGroupSimple> SamplingLocationGroups { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/samplinglocations/{id}", "GET")]
+    public class GetSamplingLocation : IReturn<SamplingLocation>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/samplinglocations/{id}", "PUT")]
+    public class PutSparseSamplingLocation : IReturn<SamplingLocation>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public SamplingLocationType? Type { get; set; }
+        public string Latitude { get; set; }
+        public string Longitude { get; set; }
+        public string HorizontalDatum { get; set; }
+        public string VerticalDatum { get; set; }
+        public string HorizontalCollectionMethod { get; set; }
+        public string VerticalCollectionMethod { get; set; }
+        public string Description { get; set; }
+        public Address Address { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public List<StandardSimple> Standards { get; set; }
+        public List<DomainObjectAttachment> Attachments { get; set; }
+        public List<SamplingLocationGroupSimple> SamplingLocationGroups { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/samplinglocations/{id}", "DELETE")]
+    public class DeleteSamplingLocationById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/samplinglocations/{id}/attachments", "GET")]
+    public class GetSamplingLocationAttachments : IReturn<SearchResultAttachment>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/samplinglocations/{id}/canedit", "GET")]
+    public class GetCanUserEditSamplingLocationData : IReturn<bool>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/samplinglocations/{id}/summary", "GET")]
+    public class GetSummary : IReturn<SamplingLocationSummary>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/services/export/fieldsheets/{fieldVisitId}", "GET")]
+    public class GetExportFieldSheet : IReturnVoid
+    {
+        public string FieldVisitId { get; set; }
+    }
+
+    [Route("/v1/services/export/observations", "GET")]
+    public class GetExportObservations : IReturnVoid
+    {
+        public FormatType? Format { get; set; }
+        public string ActivityCustomId { get; set; }
+        public string ActivityId { get; set; }
+        public List<string> AnalyticalGroupIds { get; set; }
+        public List<string> CollectionMethodIds { get; set; }
+        public string Cursor { get; set; }
+        public string CustomId { get; set; }
+        public List<string> DataClassifications { get; set; }
+        public string DepthUnitCustomId { get; set; }
+        public string DepthUnitId { get; set; }
+        public double? DepthValue { get; set; }
+        public DetectionConditionType? DetectionCondition { get; set; }
+        public Instant? EndObservedTime { get; set; }
+        public Instant? EndResultTime { get; set; }
+        public string FieldVisitId { get; set; }
+        public string ImportHistoryEventId { get; set; }
+        public List<string> LabAnalysisMethodIds { get; set; }
+        public List<string> LabReportIds { get; set; }
+        public List<string> LaboratoryIds { get; set; }
+        public int? Limit { get; set; }
+        public List<string> Media { get; set; }
+        public List<string> ObservedPropertyIds { get; set; }
+        public string ProjectId { get; set; }
+        public List<string> QualityControlTypes { get; set; }
+        public List<string> ResultGrades { get; set; }
+        public List<string> ResultStatuses { get; set; }
+        public SampleFractionType? SampleFraction { get; set; }
+        public List<string> SamplingLocationIds { get; set; }
+        public List<string> Search { get; set; }
+        public string Sort { get; set; }
+        public string SpecimenName { get; set; }
+        public Instant? StartObservedTime { get; set; }
+        public Instant? StartResultTime { get; set; }
+        public List<string> TaxonIds { get; set; }
+    }
+
+    [Route("/v1/services/export/specimens", "GET")]
+    public class GetExportSpecimens : IReturnVoid
+    {
+        public string ActivityId { get; set; }
+        public List<string> ActivityTypes { get; set; }
+        public Instant? After { get; set; }
+        public List<string> AnalyticalGroupIds { get; set; }
+        public Instant? Before { get; set; }
+        public string Cursor { get; set; }
+        public List<string> LaboratoryIds { get; set; }
+        public int? Limit { get; set; }
+        public List<string> SamplingLocationIds { get; set; }
+        public List<string> Search { get; set; }
+        public string Sort { get; set; }
+        public List<string> SpecimenStatuses { get; set; }
+    }
+
+    [Route("/v1/services/import/fieldsheets", "POST")]
+    public class PostImportFieldSheet : IReturn<FieldSheetImportSummary>
+    {
+        public string TimeZoneOffset { get; set; }
+    }
+
+    [Route("/v1/services/import/fieldsheets/dryrun", "POST")]
+    public class PostImportFieldSheetDryRun : IReturn<FieldSheetImportSummary>
+    {
+        public string TimeZoneOffset { get; set; }
+    }
+
+    [Route("/v1/services/import/labanalysismethods", "POST")]
+    public class PostImportAnalysisMethods : IReturn<LabAnalysisMethodImportSummary>
+    {
+        
+    }
+
+    [Route("/v1/services/import/labanalysismethods/dryrun", "POST")]
+    public class PostImportAnalysisMethodsDryrun : IReturn<LabAnalysisMethodImportSummary>
+    {
+        
+    }
+
+    [Route("/v1/services/import/labreportdata", "POST")]
+    public class PostImportLabReportData : IReturn<ObservationImportSummary>
+    {
+        public string FileType { get; set; }
+        public string TimeZoneOffset { get; set; }
+        public bool? CreateMissingObjects { get; set; }
+        public bool? UpdateExistingResults { get; set; }
+    }
+
+    [Route("/v1/services/import/labreportdata/dryrun", "POST")]
+    public class PostImportLabReportDataDryRun : IReturn<ObservationImportSummary>
+    {
+        public string FileType { get; set; }
+        public string TimeZoneOffset { get; set; }
+        public bool? CreateMissingObjects { get; set; }
+        public bool? UpdateExistingResults { get; set; }
+    }
+
+    [Route("/v1/services/import/observations", "POST")]
+    public class PostImportObservations : IReturn<ObservationImportSummary>
+    {
+        public string FileType { get; set; }
+        public string TimeZoneOffset { get; set; }
+        public bool? LinkFieldVisitsForNewObservations { get; set; }
+    }
+
+    [Route("/v1/services/import/observations/dryrun", "POST")]
+    public class PostImportObservationsDryrun : IReturn<ObservationImportSummary>
+    {
+        public string FileType { get; set; }
+        public string TimeZoneOffset { get; set; }
+        public bool? LinkFieldVisitsForNewObservations { get; set; }
+    }
+
+    [Route("/v1/services/import/observedproperties", "POST")]
+    public class PostImportObservedProperties : IReturn<ObservedPropertyImportSummary>
+    {
+        
+    }
+
+    [Route("/v1/services/import/observedproperties/dryrun", "POST")]
+    public class PostImportObservedPropertiesDryrun : IReturn<ObservedPropertyImportSummary>
+    {
+        
+    }
+
+    [Route("/v1/services/import/samplinglocations", "POST")]
+    public class PostImportSamplingLocations : IReturn<SamplingLocationImportSummary>
+    {
+        public string FileType { get; set; }
+    }
+
+    [Route("/v1/services/import/samplinglocations/dryrun", "POST")]
+    public class PostImportSamplingLocationsDryrun : IReturn<SamplingLocationImportSummary>
+    {
+        public string FileType { get; set; }
+    }
+
+    [Route("/v1/services/import/taxons", "POST")]
+    public class PostImportTaxons : IReturn<TaxonImportSummary>
+    {
+        
+    }
+
+    [Route("/v1/services/import/taxons/dryrun", "POST")]
+    public class PostImportTaxonsDryRun : IReturn<TaxonImportSummary>
+    {
+        
+    }
+
+    [Route("/v1/services/import/verticalprofiledata", "POST")]
+    public class PostImportVerticalProfileData : IReturnVoid
+    {
+        public string ActivityId { get; set; }
+        public string SamplingLocationIds { get; set; }
+    }
+
+    [Route("/v1/shippingcontainers", "GET")]
+    public class GetShippingContainers : IReturn<SearchResultShippingContainer>
+    {
+        public int? Limit { get; set; }
+        public List<string> Search { get; set; }
+    }
+
+    [Route("/v1/shippingcontainers", "POST")]
+    public class PostShippingContainer : IReturn<ShippingContainer>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string TrackingId { get; set; }
+        public string Comment { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/shippingcontainers/{id}", "GET")]
+    public class GetShippingContainer : IReturn<ShippingContainer>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/shippingcontainers/{id}", "PUT")]
+    public class PutSparseShippingContainer : IReturn<ShippingContainer>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string TrackingId { get; set; }
+        public string Comment { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/shippingcontainers/{id}", "DELETE")]
+    public class DeleteShippingContainerById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/specimens", "GET")]
+    public class GetSpecimens : IReturn<SearchResultSpecimenView>, IPaginatedRequest
+    {
+        public string ActivityId { get; set; }
+        public List<string> ActivityTypes { get; set; }
+        public Instant? After { get; set; }
+        public List<string> AnalyticalGroupIds { get; set; }
+        public Instant? Before { get; set; }
+        public string Cursor { get; set; }
+        public List<string> LaboratoryIds { get; set; }
+        public int? Limit { get; set; }
+        public List<string> SamplingLocationIds { get; set; }
+        public List<string> Search { get; set; }
+        public string Sort { get; set; }
+        public List<string> SpecimenStatuses { get; set; }
+    }
+
+    [Route("/v1/specimens", "POST")]
+    public class PostSpecimen : IReturn<SpecimenWithObservations>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public Instant? SamplingTime { get; set; }
+        public PreservativeType? Preservative { get; set; }
+        public bool? Filtered { get; set; }
+        public string FiltrationComment { get; set; }
+        public Laboratory Laboratory { get; set; }
+        public ShippingContainer ShippingContainer { get; set; }
+        public List<Surrogate> Surrogates { get; set; }
+        public AnalyticalGroup AnalyticalGroup { get; set; }
+        public Activity Activity { get; set; }
+        public List<Observation> Observations { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/specimens/{id}", "GET")]
+    public class GetSpecimen : IReturn<SpecimenWithObservations>
+    {
+        public string Id { get; set; }
+        public bool? Detail { get; set; }
+    }
+
+    [Route("/v1/specimens/{id}", "PUT")]
+    public class PutSparseSpecimen : IReturn<SpecimenWithObservations>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public Instant? SamplingTime { get; set; }
+        public PreservativeType? Preservative { get; set; }
+        public bool? Filtered { get; set; }
+        public string FiltrationComment { get; set; }
+        public Laboratory Laboratory { get; set; }
+        public ShippingContainer ShippingContainer { get; set; }
+        public List<Surrogate> Surrogates { get; set; }
+        public AnalyticalGroup AnalyticalGroup { get; set; }
+        public Activity Activity { get; set; }
+        public List<Observation> Observations { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/specimens/{id}", "DELETE")]
+    public class DeleteSpecimenById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/standards", "GET")]
+    public class GetStandards : IReturn<SearchResultStandardSimple>
+    {
+        
+    }
+
+    [Route("/v1/standards", "POST")]
+    public class PostStandard : IReturn<StandardDefinition>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string IssuingOrganization { get; set; }
+        public Interval ApplicabilityRange { get; set; }
+        public bool? Active { get; set; }
+        public List<SamplingLocationSimple> SamplingLocations { get; set; }
+        public List<ObservationStandard> ObservationStandards { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/standards/{id}", "GET")]
+    public class GetStandard : IReturn<StandardDefinition>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/standards/{id}", "PUT")]
+    public class PutSparseStandard : IReturn<StandardDefinition>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string IssuingOrganization { get; set; }
+        public Interval ApplicabilityRange { get; set; }
+        public bool? Active { get; set; }
+        public List<SamplingLocationSimple> SamplingLocations { get; set; }
+        public List<ObservationStandard> ObservationStandards { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/standards/{id}", "DELETE")]
+    public class DeleteStandard : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/taxons", "GET")]
+    public class GetTaxons : IReturn<SearchResultTaxon>
+    {
+        public string ScientificName { get; set; }
+    }
+
+    [Route("/v1/taxons", "POST")]
+    public class PostTaxon : IReturn<Taxon>
+    {
+        public string Id { get; set; }
+        public string ScientificName { get; set; }
+        public string CommonName { get; set; }
+        public string Level { get; set; }
+        public string Source { get; set; }
+        public string Comment { get; set; }
+        public string ItisTsn { get; set; }
+        public string ItisComment { get; set; }
+        public string ItisUrl { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/taxons/{id}", "GET")]
+    public class GetTaxon : IReturn<Taxon>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/taxons/{id}", "PUT")]
+    public class PutSparseTaxon : IReturn<Taxon>
+    {
+        public string Id { get; set; }
+        public string ScientificName { get; set; }
+        public string CommonName { get; set; }
+        public string Level { get; set; }
+        public string Source { get; set; }
+        public string Comment { get; set; }
+        public string ItisTsn { get; set; }
+        public string ItisComment { get; set; }
+        public string ItisUrl { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/taxons/{id}", "DELETE")]
+    public class DeleteTaxonById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/unitgroups", "GET")]
+    public class GetUnitGroups : IReturn<SearchResultUnitGroup>
+    {
+        public string CustomId { get; set; }
+        public SystemCodeType? SystemCode { get; set; }
+    }
+
+    [Route("/v1/unitgroups", "POST")]
+    public class PostUnitGroup : IReturn<UnitGroup>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public bool? SupportsConversion { get; set; }
+        public SystemCodeType? SystemCode { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/unitgroups/{id}", "GET")]
+    public class GetUnitGroup : IReturn<UnitGroup>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/unitgroups/{id}", "PUT")]
+    public class PutSparseUnitGroup : IReturn<UnitGroup>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public bool? SupportsConversion { get; set; }
+        public SystemCodeType? SystemCode { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/unitgroups/{id}", "DELETE")]
+    public class DeleteUnitGroupById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/unitgroupwithunits", "GET")]
+    public class GetUnitGroupsWithUnits : IReturn<SearchResultUnitGroupWithUnits>
+    {
+        public string CustomId { get; set; }
+        public SystemCodeType? SystemCode { get; set; }
+    }
+
+    [Route("/v1/unitgroupwithunits", "POST")]
+    public class PostUnitGroupWithUnit : IReturn<UnitGroupWithUnits>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public bool? SupportsConversion { get; set; }
+        public SystemCodeType? SystemCode { get; set; }
+        public List<Unit> Units { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/unitgroupwithunits/{id}", "GET")]
+    public class GetUnitGroupWithUnits : IReturn<UnitGroupWithUnits>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/unitgroupwithunits/{id}", "PUT")]
+    public class PutSparseUnitGroupWithUnits : IReturn<UnitGroup>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public bool? SupportsConversion { get; set; }
+        public SystemCodeType? SystemCode { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/unitgroupwithunits/{id}", "DELETE")]
+    public class DeleteUnitGroupWithUnitsById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/units", "GET")]
+    public class GetUnits : IReturn<SearchResultUnit>
+    {
+        public string CustomId { get; set; }
+        public string Unitgroup { get; set; }
+    }
+
+    [Route("/v1/units", "POST")]
+    public class PostUnit : IReturn<Unit>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public double? BaseMultiplier { get; set; }
+        public double? BaseOffset { get; set; }
+        public UnitGroup UnitGroup { get; set; }
+        public bool? BaseUnit { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/units/{id}", "GET")]
+    public class GetUnit : IReturn<Unit>
+    {
+        public string Id { get; set; }
+    }
+
+    [Route("/v1/units/{id}", "PUT")]
+    public class PutSparseUnit : IReturn<Unit>
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public double? BaseMultiplier { get; set; }
+        public double? BaseOffset { get; set; }
+        public UnitGroup UnitGroup { get; set; }
+        public bool? BaseUnit { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    [Route("/v1/units/{id}", "DELETE")]
+    public class DeleteUnitById : IReturnVoid
+    {
+        public string Id { get; set; }
+    }
+
+    public class AccessGroup
+    {
+        public AccessGroup()
+        {
+            SamplingLocationGroups = new List<SamplingLocationGroupSimple>();
+        }
+
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public bool CanEditAllData { get; set; }
+        public List<SamplingLocationGroupSimple> SamplingLocationGroups { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class Activity
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public ActivityType Type { get; set; }
+        public string ReplicateSourceActivityId { get; set; }
+        public Instant StartTime { get; set; }
+        public Instant EndTime { get; set; }
+        public string Comment { get; set; }
+        public string LoggerFileName { get; set; }
+        public Device Device { get; set; }
+        public CollectionMethod CollectionMethod { get; set; }
+        public MediumType Medium { get; set; }
+        public ActivityTemplateMinimal ActivityTemplate { get; set; }
+        public Quantity Depth { get; set; }
+        public SamplingLocation SamplingLocation { get; set; }
+        public FieldVisit FieldVisit { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class ActivityRepresentation
+    {
+        public ActivityRepresentation()
+        {
+            Specimens = new List<SpecimenNestedInActivity>();
+            Observations = new List<ObservationMinimal>();
+        }
+
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public ActivityType Type { get; set; }
+        public string ReplicateSourceActivityId { get; set; }
+        public Instant StartTime { get; set; }
+        public Instant EndTime { get; set; }
+        public string Comment { get; set; }
+        public string LoggerFileName { get; set; }
+        public Device Device { get; set; }
+        public CollectionMethod CollectionMethod { get; set; }
+        public MediumType Medium { get; set; }
+        public ActivityTemplateMinimal ActivityTemplate { get; set; }
+        public Quantity Depth { get; set; }
+        public SamplingLocation SamplingLocation { get; set; }
+        public FieldVisit FieldVisit { get; set; }
+        public List<SpecimenNestedInActivity> Specimens { get; set; }
+        public List<ObservationMinimal> Observations { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class ActivitySimple
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public ActivityType Type { get; set; }
+        public string ReplicateSourceActivityId { get; set; }
+        public Instant StartTime { get; set; }
+        public Instant EndTime { get; set; }
+        public string Comment { get; set; }
+        public string LoggerFileName { get; set; }
+        public Device Device { get; set; }
+        public CollectionMethod CollectionMethod { get; set; }
+        public MediumType Medium { get; set; }
+        public ActivityTemplateMinimal ActivityTemplate { get; set; }
+        public QuantitySimple Depth { get; set; }
+        public SamplingLocationSimple SamplingLocation { get; set; }
+    }
+
+    public class ActivityTemplate
+    {
+        public ActivityTemplate()
+        {
+            SpecimenTemplates = new List<SpecimenTemplate>();
+        }
+
+        public string Id { get; set; }
+        public List<SpecimenTemplate> SpecimenTemplates { get; set; }
+        public string CustomId { get; set; }
+        public ActivityType Type { get; set; }
+        public string Comment { get; set; }
+        public MediumType Medium { get; set; }
+        public Quantity Depth { get; set; }
+        public CollectionMethod CollectionMethod { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class ActivityTemplateMinimal
+    {
+        public string Id { get; set; }
+    }
+
+    public class Address
+    {
+        public string StreetName { get; set; }
+        public string CityName { get; set; }
+        public string StateProvinceCode { get; set; }
+        public string PostalCode { get; set; }
+        public string CountryCode { get; set; }
+        public string CountyCode { get; set; }
+        public AddressType AddressType { get; set; }
+    }
+
+    public class AnalyticalGroup
+    {
+        public AnalyticalGroup()
+        {
+            AnalyticalGroupItems = new List<AnalyticalGroupItem>();
+        }
+
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public AnalyticalGroupType Type { get; set; }
+        public int NumberOfObservedPropertiesInGroupItems { get; set; }
+        public int NumberOfAnalysisMethodsInGroupItems { get; set; }
+        public List<AnalyticalGroupItem> AnalyticalGroupItems { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class AnalyticalGroupItem
+    {
+        public ObservedProperty ObservedProperty { get; set; }
+        public string HoldingTime { get; set; }
+        public LabAnalysisMethod LabAnalysisMethod { get; set; }
+    }
+
+    public class AnalyticalGroupSimple
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public AnalyticalGroupType Type { get; set; }
+        public int NumberOfObservedPropertiesInGroupItems { get; set; }
+        public int NumberOfAnalysisMethodsInGroupItems { get; set; }
+    }
+
+    public class Attachment
+    {
+        public string Id { get; set; }
+        public string FileName { get; set; }
+        public string ContentType { get; set; }
+        public string Comment { get; set; }
+        public long FileSize { get; set; }
+        public Instant DateTaken { get; set; }
+        public string Latitude { get; set; }
+        public string Longitude { get; set; }
+        public string Resolution { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class AttachmentRepresentation
+    {
+        public string Id { get; set; }
+        public string FileName { get; set; }
+        public string ContentType { get; set; }
+        public string Comment { get; set; }
+        public long FileSize { get; set; }
+        public Instant DateTaken { get; set; }
+        public string Latitude { get; set; }
+        public string Longitude { get; set; }
+        public string Resolution { get; set; }
+        public bool Success { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class AuditAttributes
+    {
+        public UserProfile CreationUserProfile { get; set; }
+        public Instant CreationTime { get; set; }
+        public UserProfile ModificationUserProfile { get; set; }
+        public Instant ModificationTime { get; set; }
+    }
+
+    public class AuditItem
+    {
+        public string Id { get; set; }
+        public UserProfile UserProfile { get; set; }
+        public OperationType Operation { get; set; }
+        public Instant ModificationTime { get; set; }
+        public object OriginalData { get; set; }
+        public object NewData { get; set; }
+    }
+
+    public class CategoricalResult
+    {
+        public string Value { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class ChartData
+    {
+        public ChartData()
+        {
+            DataPoints = new List<ChartDataPoint>();
+        }
+
+        public ObservedProperty ObservedProperty { get; set; }
+        public SamplingLocation SamplingLocation { get; set; }
+        public Unit Unit { get; set; }
+        public List<ChartDataPoint> DataPoints { get; set; }
+    }
+
+    public class ChartDataPoint
+    {
+        public string ObservationId { get; set; }
+        public Instant ObservedTime { get; set; }
+        public double Value { get; set; }
+        public double MdlValue { get; set; }
+        public DetectionConditionType DetectionCondition { get; set; }
+    }
+
+    public class CollectionMethod
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string IdentifierOrganization { get; set; }
+        public string Name { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class Device
+    {
+        public string CustomId { get; set; }
+        public string Type { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+    }
+
+
+
+    public class DomainObjectAttachment
+    {
+        public string Id { get; set; }
+        public Attachment Attachment { get; set; }
+    }
+
+    public class ErrorInfo
+    {
+        public string Message { get; set; }
+        public string ErrorCode { get; set; }
+    }
+
+    public class FieldSheetImportSummary
+    {
+        public ImportSummaryObservation FieldResultSummary { get; set; }
+    }
+
+    public class FieldTrip
+    {
+        public FieldTrip()
+        {
+            FieldVisits = new List<FieldVisit>();
+            Attachments = new List<DomainObjectAttachment>();
+        }
+
+        public List<FieldVisit> FieldVisits { get; set; }
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public Instant StartTime { get; set; }
+        public Instant EndTime { get; set; }
+        public string Participants { get; set; }
+        public string Notes { get; set; }
+        public List<DomainObjectAttachment> Attachments { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class FieldVisit
+    {
+        public FieldVisit()
+        {
+            PlannedFieldResults = new List<PlannedFieldResult>();
+            ActivityTemplates = new List<ActivityTemplate>();
+            Attachments = new List<DomainObjectAttachment>();
+        }
+
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public Instant StartTime { get; set; }
+        public Instant EndTime { get; set; }
+        public string Participants { get; set; }
+        public string Notes { get; set; }
+        public string FieldTripId { get; set; }
+        public PlanningStatusType PlanningStatus { get; set; }
+        public SamplingLocation SamplingLocation { get; set; }
+        public List<PlannedFieldResult> PlannedFieldResults { get; set; }
+        public List<ActivityTemplate> ActivityTemplates { get; set; }
+        public List<DomainObjectAttachment> Attachments { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class FieldVisitSimple
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public Instant StartTime { get; set; }
+        public Instant EndTime { get; set; }
+        public string Participants { get; set; }
+        public string Notes { get; set; }
+        public string FieldTripId { get; set; }
+        public PlanningStatusType PlanningStatus { get; set; }
+        public SamplingLocationSimple SamplingLocation { get; set; }
+    }
+
+    public class FieldVisitStatistics
+    {
+        public long RoutineSampleCount { get; set; }
+        public long QcSampleCount { get; set; }
+        public long VerticalProfileCount { get; set; }
+        public long FieldResultCount { get; set; }
+        public long FieldSurveyCount { get; set; }
+    }
+
+    public class FieldVisitSummaryRepresentation
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public Instant StartTime { get; set; }
+    }
+
+    public class Filter
+    {
+        public Filter()
+        {
+            ObservedProperties = new List<ObservedProperty>();
+            SamplingLocations = new List<SamplingLocation>();
+        }
+
+        public Instant StartTime { get; set; }
+        public Instant EndTime { get; set; }
+        public List<ObservedProperty> ObservedProperties { get; set; }
+        public List<SamplingLocation> SamplingLocations { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class ImportChangeItem
+    {
+        public string PropertyName { get; set; }
+        public object Left { get; set; }
+        public object Right { get; set; }
+    }
+
+    public class ImportError
+    {
+        public string ErrorCode { get; set; }
+        public string ErrorMessage { get; set; }
+        public string ErrorFieldValue { get; set; }
+    }
+
+    public class ImportHistoryEventSimple
+    {
+        public string Id { get; set; }
+        public ImportType ImportType { get; set; }
+        public Instant ImportTime { get; set; }
+        public string FileName { get; set; }
+        public string TimeZoneOffset { get; set; }
+    }
+
+    public class ImportItemLabAnalysisMethod
+    {
+        public ImportItemLabAnalysisMethod()
+        {
+            Fields = new List<string>();
+            ItemComparison = new List<ImportChangeItem>();
+        }
+
+        public List<string> Fields { get; set; }
+        public object Errors { get; set; }
+        public string RowId { get; set; }
+        public string Input { get; set; }
+        public ImportItemStatusType Status { get; set; }
+        public LabAnalysisMethod Item { get; set; }
+        public LabAnalysisMethod ExistingItem { get; set; }
+        public List<ImportChangeItem> ItemComparison { get; set; }
+    }
+
+    public class ImportItemObservation
+    {
+        public ImportItemObservation()
+        {
+            Fields = new List<string>();
+            ItemComparison = new List<ImportChangeItem>();
+        }
+
+        public List<string> Fields { get; set; }
+        public object Errors { get; set; }
+        public string RowId { get; set; }
+        public string Input { get; set; }
+        public ImportItemStatusType Status { get; set; }
+        public Observation Item { get; set; }
+        public Observation ExistingItem { get; set; }
+        public List<ImportChangeItem> ItemComparison { get; set; }
+    }
+
+    public class ImportItemObservedProperty
+    {
+        public ImportItemObservedProperty()
+        {
+            Fields = new List<string>();
+            ItemComparison = new List<ImportChangeItem>();
+        }
+
+        public List<string> Fields { get; set; }
+        public object Errors { get; set; }
+        public string RowId { get; set; }
+        public string Input { get; set; }
+        public ImportItemStatusType Status { get; set; }
+        public ObservedProperty Item { get; set; }
+        public ObservedProperty ExistingItem { get; set; }
+        public List<ImportChangeItem> ItemComparison { get; set; }
+    }
+
+    public class ImportItemSamplingLocation
+    {
+        public ImportItemSamplingLocation()
+        {
+            Fields = new List<string>();
+            ItemComparison = new List<ImportChangeItem>();
+        }
+
+        public List<string> Fields { get; set; }
+        public object Errors { get; set; }
+        public string RowId { get; set; }
+        public string Input { get; set; }
+        public ImportItemStatusType Status { get; set; }
+        public SamplingLocation Item { get; set; }
+        public SamplingLocation ExistingItem { get; set; }
+        public List<ImportChangeItem> ItemComparison { get; set; }
+    }
+
+    public class ImportItemTaxon
+    {
+        public ImportItemTaxon()
+        {
+            Fields = new List<string>();
+            ItemComparison = new List<ImportChangeItem>();
+        }
+
+        public List<string> Fields { get; set; }
+        public object Errors { get; set; }
+        public string RowId { get; set; }
+        public string Input { get; set; }
+        public ImportItemStatusType Status { get; set; }
+        public Taxon Item { get; set; }
+        public Taxon ExistingItem { get; set; }
+        public List<ImportChangeItem> ItemComparison { get; set; }
+    }
+
+    public class ImportSummaryObservation
+    {
+        public ImportSummaryObservation()
+        {
+            ImportItems = new List<ImportItemObservation>();
+            ImportJobErrors = new List<ImportError>();
+        }
+
+        public ImportHistoryEventSimple ImportHistoryEventSimple { get; set; }
+        public int SuccessCount { get; set; }
+        public int SkippedCount { get; set; }
+        public int ErrorCount { get; set; }
+        public int NewCount { get; set; }
+        public int UpdateCount { get; set; }
+        public int ExpectedCount { get; set; }
+        public List<ImportItemObservation> ImportItems { get; set; }
+        public List<ImportError> ImportJobErrors { get; set; }
+    }
+
+    public class InputPart
+    {
+        public object Headers { get; set; }
+        public MediaType MediaType { get; set; }
+        public string BodyAsString { get; set; }
+        public bool ContentTypeFromMessage { get; set; }
+    }
+
+    public class LabAnalysisMethod
+    {
+        public LabAnalysisMethod()
+        {
+            ObservedProperties = new List<ObservedProperty>();
+            ImportHistoryEventSimples = new List<ImportHistoryEventSimple>();
+        }
+
+        public List<ObservedProperty> ObservedProperties { get; set; }
+        public string Id { get; set; }
+        public string MethodId { get; set; }
+        public string Name { get; set; }
+        public string Context { get; set; }
+        public string Description { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class LabAnalysisMethodImportSummary
+    {
+        public LabAnalysisMethodImportSummary()
+        {
+            ImportItems = new List<ImportItemLabAnalysisMethod>();
+            ImportJobErrors = new List<ImportError>();
+        }
+
+        public ImportHistoryEventSimple ImportHistoryEventSimple { get; set; }
+        public int SuccessCount { get; set; }
+        public int SkippedCount { get; set; }
+        public int ErrorCount { get; set; }
+        public int NewCount { get; set; }
+        public int UpdateCount { get; set; }
+        public int ExpectedCount { get; set; }
+        public List<ImportItemLabAnalysisMethod> ImportItems { get; set; }
+        public List<ImportError> ImportJobErrors { get; set; }
+    }
+
+    public class LabAnalysisMethodMinimal
+    {
+        public string Name { get; set; }
+    }
+
+    public class LabInstruction
+    {
+        public LabAnalysisMethod AnalysisMethod { get; set; }
+        public string PreparationMethod { get; set; }
+        public string AnalysisComment { get; set; }
+        public string HoldingTime { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class LabInstructionMinimal
+    {
+        public LabAnalysisMethodMinimal AnalysisMethod { get; set; }
+        public string PreparationMethod { get; set; }
+        public string AnalysisComment { get; set; }
+        public string HoldingTime { get; set; }
+    }
+
+    public class LabInstructionTemplate
+    {
+        public string Id { get; set; }
+        public LabAnalysisMethod AnalysisMethod { get; set; }
+        public ObservedProperty ObservedProperty { get; set; }
+        public string PreparationMethod { get; set; }
+        public string AnalysisComment { get; set; }
+        public string HoldingTime { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class Laboratory
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string Address { get; set; }
+        public string PointOfContact { get; set; }
+        public string EmailAddress { get; set; }
+        public string PhoneNumber { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class LabReport
+    {
+        public LabReport()
+        {
+            ImportHistoryEventSimples = new List<ImportHistoryEventSimple>();
+        }
+
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public Instant DateReceived { get; set; }
+        public string CaseNarrative { get; set; }
+        public string QcSummary { get; set; }
+        public Laboratory Laboratory { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class LabResultDetails
+    {
+        public string LabSampleId { get; set; }
+        public Laboratory Laboratory { get; set; }
+        public LabAnalysisMethod AnalysisMethod { get; set; }
+        public string PreparationMethod { get; set; }
+        public string DilutionFactor { get; set; }
+        public Instant DateReceived { get; set; }
+        public string AnalysisComment { get; set; }
+        public string QualityFlag { get; set; }
+        public Instant DatePrepared { get; set; }
+        public LabReport LabReport { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class LocationObservationsGroup
+    {
+        public LocationObservationsGroup()
+        {
+            Observations = new List<Observation>();
+        }
+
+        public List<Observation> Observations { get; set; }
+        public SamplingLocation SamplingLocation { get; set; }
+        public long TotalCount { get; set; }
+    }
+
+    public class MediaType
+    {
+        public string Type { get; set; }
+        public string Subtype { get; set; }
+        public object Parameters { get; set; }
+        public bool WildcardType { get; set; }
+        public bool WildcardSubtype { get; set; }
+    }
+
+    public class MultiChartData
+    {
+        public MultiChartData()
+        {
+            Charts = new List<ChartData>();
+        }
+
+        public List<ChartData> Charts { get; set; }
+    }
+
+    public class MultipartFormDataInput
+    {
+    }
+
+    public class NumericResult
+    {
+        public Quantity Quantity { get; set; }
+        public SampleFractionType SampleFraction { get; set; }
+        public DeterminationType DeterminationType { get; set; }
+        public DetectionConditionType DetectionCondition { get; set; }
+        public Quantity MethodDetectionLevel { get; set; }
+        public Quantity LowerMethodReportingLimit { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class Observation
+    {
+        public Observation()
+        {
+            ImportHistoryEventSimples = new List<ImportHistoryEventSimple>();
+            ValidationWarnings = new List<RuleValidationDetails>();
+        }
+
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public Activity Activity { get; set; }
+        public CollectionMethod CollectionMethod { get; set; }
+        public ObservedProperty ObservedProperty { get; set; }
+        public Specimen Specimen { get; set; }
+        public SamplingLocation SamplingLocation { get; set; }
+        public NumericResult NumericResult { get; set; }
+        public CategoricalResult CategoricalResult { get; set; }
+        public TaxonomicResult TaxonomicResult { get; set; }
+        public QualityControlType QualityControlType { get; set; }
+        public DataClassificationType DataClassification { get; set; }
+        public MediumType Medium { get; set; }
+        public string MediumSubdivision { get; set; }
+        public Instant ObservedTime { get; set; }
+        public Instant ResultTime { get; set; }
+        public Quantity Depth { get; set; }
+        public LabInstruction LabInstruction { get; set; }
+        public LabResultDetails LabResultDetails { get; set; }
+        public string Comment { get; set; }
+        public FieldVisit FieldVisit { get; set; }
+        public Device Device { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public List<RuleValidationDetails> ValidationWarnings { get; set; }
+        public ResultGradeType ResultGrade { get; set; }
+        public ResultStatusType ResultStatus { get; set; }
+        public PlannedFieldResult PlannedFieldResult { get; set; }
+        public Taxon RelatedTaxon { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class ObservationImportSummary
+    {
+        public ObservationImportSummary()
+        {
+            ImportItems = new List<ImportItemObservation>();
+            ImportJobErrors = new List<ImportError>();
+        }
+
+        public ImportHistoryEventSimple ImportHistoryEventSimple { get; set; }
+        public int SuccessCount { get; set; }
+        public int SkippedCount { get; set; }
+        public int ErrorCount { get; set; }
+        public int NewCount { get; set; }
+        public int UpdateCount { get; set; }
+        public int ExpectedCount { get; set; }
+        public List<ImportItemObservation> ImportItems { get; set; }
+        public List<ImportError> ImportJobErrors { get; set; }
+    }
+
+    public class ObservationMinimal
+    {
+        public string Id { get; set; }
+        public ObservedProperty ObservedProperty { get; set; }
+        public SpecimenNestedInActivity Specimen { get; set; }
+        public NumericResult NumericResult { get; set; }
+        public CategoricalResult CategoricalResult { get; set; }
+        public TaxonomicResult TaxonomicResult { get; set; }
+        public ResultStatusType ResultStatus { get; set; }
+        public LabInstructionMinimal LabInstruction { get; set; }
+        public DataClassificationType DataClassification { get; set; }
+    }
+
+    public class ObservationStandard
+    {
+        public ObservedProperty ObservedProperty { get; set; }
+        public Quantity ResultLowerLimit { get; set; }
+        public Quantity ResultUpperLimit { get; set; }
+        public string RuleText { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class ObservedProperty
+    {
+        public ObservedProperty()
+        {
+            ImportHistoryEventSimples = new List<ImportHistoryEventSimple>();
+        }
+
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public ResultType ResultType { get; set; }
+        public AnalysisType AnalysisType { get; set; }
+        public UnitGroup UnitGroup { get; set; }
+        public Unit DefaultUnit { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public string CasNumber { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class ObservedPropertyImportSummary
+    {
+        public ObservedPropertyImportSummary()
+        {
+            ImportItems = new List<ImportItemObservedProperty>();
+            ImportJobErrors = new List<ImportError>();
+        }
+
+        public ImportHistoryEventSimple ImportHistoryEventSimple { get; set; }
+        public int SuccessCount { get; set; }
+        public int SkippedCount { get; set; }
+        public int ErrorCount { get; set; }
+        public int NewCount { get; set; }
+        public int UpdateCount { get; set; }
+        public int ExpectedCount { get; set; }
+        public List<ImportItemObservedProperty> ImportItems { get; set; }
+        public List<ImportError> ImportJobErrors { get; set; }
+    }
+
+    public class PlannedFieldResult
+    {
+        public string Id { get; set; }
+        public ObservedProperty ObservedProperty { get; set; }
+        public MediumType Medium { get; set; }
+        public string DeviceType { get; set; }
+        public string Comment { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class Project
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public ProjectType Type { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string ScopeStatement { get; set; }
+        public bool Approved { get; set; }
+        public string ApprovalAgency { get; set; }
+        public Instant StartTime { get; set; }
+        public Instant EndTime { get; set; }
+        public Filter Filter { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class Quantity
+    {
+        public double Value { get; set; }
+        public Unit Unit { get; set; }
+    }
+
+    public class QuantitySimple
+    {
+        public double Value { get; set; }
+        public UnitSimple Unit { get; set; }
+    }
+
+    public class RuleValidationDetails
+    {
+        public string Type { get; set; }
+        public string Description { get; set; }
+        public object Properties { get; set; }
+    }
+
+    public class SamplingLocation
+    {
+        public SamplingLocation()
+        {
+            ImportHistoryEventSimples = new List<ImportHistoryEventSimple>();
+            Standards = new List<StandardSimple>();
+            Attachments = new List<DomainObjectAttachment>();
+            SamplingLocationGroups = new List<SamplingLocationGroupSimple>();
+        }
+
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public SamplingLocationType Type { get; set; }
+        public string Latitude { get; set; }
+        public string Longitude { get; set; }
+        public string HorizontalDatum { get; set; }
+        public string VerticalDatum { get; set; }
+        public string HorizontalCollectionMethod { get; set; }
+        public string VerticalCollectionMethod { get; set; }
+        public string Description { get; set; }
+        public Address Address { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public List<StandardSimple> Standards { get; set; }
+        public List<DomainObjectAttachment> Attachments { get; set; }
+        public List<SamplingLocationGroupSimple> SamplingLocationGroups { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class SamplingLocationGroup
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class SamplingLocationGroupSimple
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class SamplingLocationImportSummary
+    {
+        public SamplingLocationImportSummary()
+        {
+            ImportItems = new List<ImportItemSamplingLocation>();
+            ImportJobErrors = new List<ImportError>();
+        }
+
+        public ImportHistoryEventSimple ImportHistoryEventSimple { get; set; }
+        public int SuccessCount { get; set; }
+        public int SkippedCount { get; set; }
+        public int ErrorCount { get; set; }
+        public int NewCount { get; set; }
+        public int UpdateCount { get; set; }
+        public int ExpectedCount { get; set; }
+        public List<ImportItemSamplingLocation> ImportItems { get; set; }
+        public List<ImportError> ImportJobErrors { get; set; }
+    }
+
+    public class SamplingLocationSimple
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class SamplingLocationSummary
+    {
+        public long ObservationCount { get; set; }
+        public long FieldVisitCount { get; set; }
+        public FieldVisitSummaryRepresentation LatestFieldVisit { get; set; }
+    }
+
+    public class SearchResultAccessGroup : IPaginatedResponse<AccessGroup>
+    {
+        public SearchResultAccessGroup()
+        {
+            DomainObjects = new List<AccessGroup>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<AccessGroup> DomainObjects { get; set; }
+    }
+
+    public class SearchResultActivitySimple : IPaginatedResponse<ActivitySimple>
+    {
+        public SearchResultActivitySimple()
+        {
+            DomainObjects = new List<ActivitySimple>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<ActivitySimple> DomainObjects { get; set; }
+    }
+
+    public class SearchResultActivityTemplate : IPaginatedResponse<ActivityTemplate>
+    {
+        public SearchResultActivityTemplate()
+        {
+            DomainObjects = new List<ActivityTemplate>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<ActivityTemplate> DomainObjects { get; set; }
+    }
+
+    public class SearchResultAnalyticalGroup : IPaginatedResponse<AnalyticalGroup>
+    {
+        public SearchResultAnalyticalGroup()
+        {
+            DomainObjects = new List<AnalyticalGroup>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<AnalyticalGroup> DomainObjects { get; set; }
+    }
+
+    public class SearchResultAttachment : IPaginatedResponse<Attachment>
+    {
+        public SearchResultAttachment()
+        {
+            DomainObjects = new List<Attachment>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<Attachment> DomainObjects { get; set; }
+    }
+
+    public class SearchResultAuditItem : IPaginatedResponse<AuditItem>
+    {
+        public SearchResultAuditItem()
+        {
+            DomainObjects = new List<AuditItem>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<AuditItem> DomainObjects { get; set; }
+    }
+
+    public class SearchResultCollectionMethod : IPaginatedResponse<CollectionMethod>
+    {
+        public SearchResultCollectionMethod()
+        {
+            DomainObjects = new List<CollectionMethod>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<CollectionMethod> DomainObjects { get; set; }
+    }
+
+    public class SearchResultFieldTrip : IPaginatedResponse<FieldTrip>
+    {
+        public SearchResultFieldTrip()
+        {
+            DomainObjects = new List<FieldTrip>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<FieldTrip> DomainObjects { get; set; }
+    }
+
+    public class SearchResultFieldVisitSimple : IPaginatedResponse<FieldVisitSimple>
+    {
+        public SearchResultFieldVisitSimple()
+        {
+            DomainObjects = new List<FieldVisitSimple>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<FieldVisitSimple> DomainObjects { get; set; }
+    }
+
+    public class SearchResultLabAnalysisMethod : IPaginatedResponse<LabAnalysisMethod>
+    {
+        public SearchResultLabAnalysisMethod()
+        {
+            DomainObjects = new List<LabAnalysisMethod>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<LabAnalysisMethod> DomainObjects { get; set; }
+    }
+
+    public class SearchResultLaboratory : IPaginatedResponse<Laboratory>
+    {
+        public SearchResultLaboratory()
+        {
+            DomainObjects = new List<Laboratory>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<Laboratory> DomainObjects { get; set; }
+    }
+
+    public class SearchResultLabReport : IPaginatedResponse<LabReport>
+    {
+        public SearchResultLabReport()
+        {
+            DomainObjects = new List<LabReport>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<LabReport> DomainObjects { get; set; }
+    }
+
+    public class SearchResultLocationObservationsGroup : IPaginatedResponse<LocationObservationsGroup>
+    {
+        public SearchResultLocationObservationsGroup()
+        {
+            DomainObjects = new List<LocationObservationsGroup>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<LocationObservationsGroup> DomainObjects { get; set; }
+    }
+
+    public class SearchResultObservation : IPaginatedResponse<Observation>
+    {
+        public SearchResultObservation()
+        {
+            DomainObjects = new List<Observation>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<Observation> DomainObjects { get; set; }
+    }
+
+    public class SearchResultObservedProperty : IPaginatedResponse<ObservedProperty>
+    {
+        public SearchResultObservedProperty()
+        {
+            DomainObjects = new List<ObservedProperty>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<ObservedProperty> DomainObjects { get; set; }
+    }
+
+    public class SearchResultProject : IPaginatedResponse<Project>
+    {
+        public SearchResultProject()
+        {
+            DomainObjects = new List<Project>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<Project> DomainObjects { get; set; }
+    }
+
+    public class SearchResultSamplingLocation : IPaginatedResponse<SamplingLocation>
+    {
+        public SearchResultSamplingLocation()
+        {
+            DomainObjects = new List<SamplingLocation>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<SamplingLocation> DomainObjects { get; set; }
+    }
+
+    public class SearchResultSamplingLocationGroup : IPaginatedResponse<SamplingLocationGroup>
+    {
+        public SearchResultSamplingLocationGroup()
+        {
+            DomainObjects = new List<SamplingLocationGroup>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<SamplingLocationGroup> DomainObjects { get; set; }
+    }
+
+    public class SearchResultShippingContainer : IPaginatedResponse<ShippingContainer>
+    {
+        public SearchResultShippingContainer()
+        {
+            DomainObjects = new List<ShippingContainer>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<ShippingContainer> DomainObjects { get; set; }
+    }
+
+    public class SearchResultSpecimenView : IPaginatedResponse<SpecimenView>
+    {
+        public SearchResultSpecimenView()
+        {
+            DomainObjects = new List<SpecimenView>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<SpecimenView> DomainObjects { get; set; }
+    }
+
+    public class SearchResultStandardSimple : IPaginatedResponse<StandardSimple>
+    {
+        public SearchResultStandardSimple()
+        {
+            DomainObjects = new List<StandardSimple>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<StandardSimple> DomainObjects { get; set; }
+    }
+
+    public class SearchResultTaxon : IPaginatedResponse<Taxon>
+    {
+        public SearchResultTaxon()
+        {
+            DomainObjects = new List<Taxon>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<Taxon> DomainObjects { get; set; }
+    }
+
+    public class SearchResultUnit : IPaginatedResponse<Unit>
+    {
+        public SearchResultUnit()
+        {
+            DomainObjects = new List<Unit>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<Unit> DomainObjects { get; set; }
+    }
+
+    public class SearchResultUnitGroup : IPaginatedResponse<UnitGroup>
+    {
+        public SearchResultUnitGroup()
+        {
+            DomainObjects = new List<UnitGroup>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<UnitGroup> DomainObjects { get; set; }
+    }
+
+    public class SearchResultUnitGroupWithUnits : IPaginatedResponse<UnitGroupWithUnits>
+    {
+        public SearchResultUnitGroupWithUnits()
+        {
+            DomainObjects = new List<UnitGroupWithUnits>();
+        }
+
+        public int TotalCount { get; set; }
+        public string Cursor { get; set; }
+        public List<UnitGroupWithUnits> DomainObjects { get; set; }
+    }
+
+    public class ShippingContainer
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string TrackingId { get; set; }
+        public string Comment { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class Specimen
+    {
+        public Specimen()
+        {
+            Surrogates = new List<Surrogate>();
+        }
+
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public Instant SamplingTime { get; set; }
+        public PreservativeType Preservative { get; set; }
+        public bool Filtered { get; set; }
+        public string FiltrationComment { get; set; }
+        public Laboratory Laboratory { get; set; }
+        public ShippingContainer ShippingContainer { get; set; }
+        public List<Surrogate> Surrogates { get; set; }
+        public AnalyticalGroup AnalyticalGroup { get; set; }
+        public Activity Activity { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class SpecimenNestedInActivity
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+        public AnalyticalGroupSimple AnalyticalGroup { get; set; }
+    }
+
+    public class SpecimenTemplate
+    {
+        public SpecimenTemplate()
+        {
+            LabInstructionTemplates = new List<LabInstructionTemplate>();
+        }
+
+        public List<LabInstructionTemplate> LabInstructionTemplates { get; set; }
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public AnalyticalGroup AnalyticalGroup { get; set; }
+        public PreservativeType Preservative { get; set; }
+        public bool Filtered { get; set; }
+        public string FiltrationComment { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class SpecimenView
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public Instant SamplingTime { get; set; }
+        public PreservativeType Preservative { get; set; }
+        public bool Filtered { get; set; }
+        public string FiltrationComment { get; set; }
+        public Laboratory Laboratory { get; set; }
+        public ShippingContainer ShippingContainer { get; set; }
+        public SpecimenViewStatusType Status { get; set; }
+        public int NumberOfRequestedObservations { get; set; }
+        public int NumberOfReceivedObservations { get; set; }
+        public AnalyticalGroupSimple AnalyticalGroup { get; set; }
+        public ActivitySimple Activity { get; set; }
+    }
+
+    public class SpecimenWithObservations
+    {
+        public SpecimenWithObservations()
+        {
+            Surrogates = new List<Surrogate>();
+            Observations = new List<Observation>();
+        }
+
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public Instant SamplingTime { get; set; }
+        public PreservativeType Preservative { get; set; }
+        public bool Filtered { get; set; }
+        public string FiltrationComment { get; set; }
+        public Laboratory Laboratory { get; set; }
+        public ShippingContainer ShippingContainer { get; set; }
+        public List<Surrogate> Surrogates { get; set; }
+        public AnalyticalGroup AnalyticalGroup { get; set; }
+        public Activity Activity { get; set; }
+        public List<Observation> Observations { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class StandardDefinition
+    {
+        public StandardDefinition()
+        {
+            SamplingLocations = new List<SamplingLocationSimple>();
+            ObservationStandards = new List<ObservationStandard>();
+        }
+
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string IssuingOrganization { get; set; }
+        public Interval ApplicabilityRange { get; set; }
+        public bool Active { get; set; }
+        public List<SamplingLocationSimple> SamplingLocations { get; set; }
+        public List<ObservationStandard> ObservationStandards { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class StandardSimple
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public string IssuingOrganization { get; set; }
+        public Interval ApplicabilityRange { get; set; }
+        public bool Active { get; set; }
+    }
+
+    public class Surrogate
+    {
+        public string Id { get; set; }
+        public double PercentRecovered { get; set; }
+        public string Comment { get; set; }
+        public string ControlLimit { get; set; }
+        public ObservedProperty ObservedProperty { get; set; }
+        public Instant DateAnalyzed { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class Taxon
+    {
+        public Taxon()
+        {
+            ImportHistoryEventSimples = new List<ImportHistoryEventSimple>();
+        }
+
+        public string Id { get; set; }
+        public string ScientificName { get; set; }
+        public string CommonName { get; set; }
+        public string Level { get; set; }
+        public string Source { get; set; }
+        public string Comment { get; set; }
+        public string ItisTsn { get; set; }
+        public string ItisComment { get; set; }
+        public string ItisUrl { get; set; }
+        public List<ImportHistoryEventSimple> ImportHistoryEventSimples { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class TaxonImportSummary
+    {
+        public TaxonImportSummary()
+        {
+            ImportItems = new List<ImportItemTaxon>();
+            ImportJobErrors = new List<ImportError>();
+        }
+
+        public ImportHistoryEventSimple ImportHistoryEventSimple { get; set; }
+        public int SuccessCount { get; set; }
+        public int SkippedCount { get; set; }
+        public int ErrorCount { get; set; }
+        public int NewCount { get; set; }
+        public int UpdateCount { get; set; }
+        public int ExpectedCount { get; set; }
+        public List<ImportItemTaxon> ImportItems { get; set; }
+        public List<ImportError> ImportJobErrors { get; set; }
+    }
+
+    public class TaxonomicResult
+    {
+        public string Id { get; set; }
+        public Taxon Taxon { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class Unit
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public double BaseMultiplier { get; set; }
+        public double BaseOffset { get; set; }
+        public UnitGroup UnitGroup { get; set; }
+        public bool BaseUnit { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class UnitGroup
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public bool SupportsConversion { get; set; }
+        public SystemCodeType SystemCode { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class UnitGroupWithUnits
+    {
+        public UnitGroupWithUnits()
+        {
+            Units = new List<Unit>();
+        }
+
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public bool SupportsConversion { get; set; }
+        public SystemCodeType SystemCode { get; set; }
+        public List<Unit> Units { get; set; }
+        public AuditAttributes AuditAttributes { get; set; }
+    }
+
+    public class UnitSimple
+    {
+        public string Id { get; set; }
+        public string CustomId { get; set; }
+        public string Name { get; set; }
+        public double BaseMultiplier { get; set; }
+        public double BaseOffset { get; set; }
+        public bool BaseUnit { get; set; }
+    }
+
+    public class UserProfile
+    {
+        public string Id { get; set; }
+        public string ProviderId { get; set; }
+        public string Email { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public string FullName { get; set; }
+        public string DisplayName { get; set; }
+        public string ProfileImageUrl { get; set; }
+    }
+
+    public enum ActivityType
+    {
+        SAMPLE_INTEGRATED_VERTICAL_PROFILE,
+        SAMPLE_ROUTINE,
+        QC_SAMPLE_REPLICATE,
+        QC_TRIP_BLANK,
+        FIELD_SURVEY,
+        NONE
+    }
+
+    public enum AddressType
+    {
+        LOCATION,
+        MAILING,
+        SHIPPING
+    }
+
+    public enum AnalysisType
+    {
+        BIOLOGICAL,
+        CHEMICAL,
+        PHYSICAL
+    }
+
+    public enum AnalyticalGroupType
+    {
+        KNOWN,
+        UNKNOWN
+    }
+
+    public enum DataClassificationType
+    {
+        LAB,
+        FIELD_RESULT,
+        FIELD_SURVEY,
+        VERTICAL_PROFILE
+    }
+
+    public enum DetectionConditionType
+    {
+        NOT_REPORTED,
+        NOT_DETECTED
+    }
+
+    public enum DeterminationType
+    {
+        ACTUAL,
+        BLANK_CORRECTED_CALCULATED,
+        CALCULATED,
+        CONTROL_ADJUSTED,
+        ESTIMATED
+    }
+
+    public enum FormatType
+    {
+        CSV,
+        WQX,
+        CROSSTAB_CSV
+    }
+
+    public enum ImportItemStatusType
+    {
+        ERROR,
+        NEW,
+        UPDATE,
+        EXPECTED,
+        SKIPPED
+    }
+
+    public enum ImportType
+    {
+        OBSERVATION_CSV,
+        OBSERVATION_LABREPORT,
+        SAMPLINGLOCATION_CSV,
+        OBSERVED_PROPERTIES_CSV,
+        LAB_ANALYSIS_METHODS_CSV,
+        TAXON_CSV
+    }
+
+    public enum MediumType
+    {
+        WATER,
+        SOIL,
+        AIR,
+        BIOLOGICAL,
+        HABITAT,
+        SEDIMENT,
+        TISSUE,
+        OTHER
+    }
+
+    public enum OperationType
+    {
+        INSERT,
+        UPDATE,
+        DELETE
+    }
+
+    public enum PlanningStatusType
+    {
+        PLANNED,
+        IN_PROGRESS,
+        CANCELLED,
+        DONE
+    }
+
+    public enum PreservativeType
+    {
+        SULFURIC_ACID,
+        NITRIC_ACID,
+        HYDROCHLORIC_ACID,
+        SODIUM_HYDROXIDE,
+        ICE,
+        ISOPROPYL_ALCOHOL
+    }
+
+    public enum ProjectType
+    {
+        ROUTINE_MONITORING,
+        EVENT_BASED_MONITORING,
+        RESTORATION_PROJECT,
+        STUDY
+    }
+
+    public enum QualityControlType
+    {
+        NORMAL,
+        SAMPLE_REPLICATE,
+        TRIP_BLANK,
+        QUALITY_CONTROL
+    }
+
+    public enum ResultGradeType
+    {
+        OK,
+        SUSPECT,
+        UNKNOWN
+    }
+
+    public enum ResultStatusType
+    {
+        PRELIMINARY,
+        REVIEWED,
+        REQUESTED
+    }
+
+    public enum ResultType
+    {
+        NUMERIC,
+        CATEGORICAL,
+        TAXON
+    }
+
+    public enum SampleFractionType
+    {
+        DISSOLVED,
+        TOTAL
+    }
+
+    public enum SamplingLocationType
+    {
+        SPRING,
+        STREAM,
+        RIVER,
+        CANAL,
+        LAKE,
+        GROUNDWATER,
+        OCEAN,
+        RESERVOIR
+    }
+
+    public enum SpecimenViewStatusType
+    {
+        REQUESTED,
+        RECEIVED_SOME,
+        RECEIVED_ALL
+    }
+
+    public enum SystemCodeType
+    {
+        LENGTH
+    }
+}

--- a/src/Aquarius.Client/Samples/Client/WebServiceExceptionHandler.cs
+++ b/src/Aquarius.Client/Samples/Client/WebServiceExceptionHandler.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Net;
+using System.Runtime.Serialization;
+using ServiceStack;
+
+namespace Aquarius.Samples.Client
+{
+    public static class WebServiceExceptionHandler
+    {
+        public static SamplesApiException CreateSamplesApiExceptionFromResponse(WebServiceException e)
+        {
+            if (e.ResponseHeaders["server"] == "AmazonS3")
+                return new SamplesMaintenanceModeException(FormattableString.Invariant($"{e.Message}: AQUARIUS Samples is in maintenance mode"), e);
+
+            var errorResponse = DeserializeErrorFromResponse(e);
+            var message = ComposeMessage(e, errorResponse);
+
+            if (errorResponse?.ErrorCode == "gaia.domain.exceptions.AuthenticationException")
+                return new SamplesAuthenticationException(message, e, errorResponse);
+
+            return new SamplesApiException(message, e, errorResponse);
+        }
+
+        public static SamplesApiException CreateSamplesApiExceptionFromResponse(WebException e)
+        {
+            var response = e.Response as HttpWebResponse;
+            var statusCode = (response == null) ? 0 : (int)response.StatusCode;
+            var message = FormattableString.Invariant($"{e.Status}: {e.Message}");
+
+            return new SamplesApiException(message, e)
+            {
+                StatusCode = statusCode,
+                SamplesError = new SamplesErrorResponse
+                {
+                    ErrorCode = e.Status.ToString(),
+                    Message = e.Message
+                }
+            };
+        }
+
+        private static SamplesErrorResponse DeserializeErrorFromResponse(WebServiceException e)
+        {
+            if (string.IsNullOrWhiteSpace(e.ResponseBody))
+                return null;
+
+            var contentType = e.ResponseHeaders[HttpResponseHeader.ContentType];
+            if (!string.IsNullOrEmpty(contentType) && !contentType.ToLowerInvariant().Contains("application/json"))
+                return null;
+
+            return DeserializeErrorFromJson(e.ResponseBody);
+        }
+
+        private static SamplesErrorResponse DeserializeErrorFromJson(string responseBody)
+        {
+            try
+            {
+                return responseBody.FromJson<SamplesErrorResponse>();
+            }
+            catch (SerializationException)
+            {
+                return null;
+            }
+        }
+
+        private static string ComposeMessage(WebServiceException e, SamplesErrorResponse errorResponse)
+        {
+            if (errorResponse?.Message == null)
+                return e.Message;
+
+            return FormattableString.Invariant($"{e.Message}: {errorResponse.Message}");
+        }
+    }
+}

--- a/src/Aquarius.Client/packages.config
+++ b/src/Aquarius.Client/packages.config
@@ -1,7 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net462" />
+  <package id="Microsoft.Bcl.Build" version="1.0.14" targetFramework="net462" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net462" />
   <package id="NodaTime" version="1.3.0" targetFramework="net462" />
   <package id="ServiceStack.Client" version="4.5.6" targetFramework="net462" />
+  <package id="ServiceStack.HttpClient" version="4.5.6" targetFramework="net462" />
   <package id="ServiceStack.Interfaces" version="4.5.6" targetFramework="net462" />
   <package id="ServiceStack.Text" version="4.5.6" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
@jessemcdowell-AI Here's a first cut of a .NET Samples client, based on the methods exposed in the Swagger JSON. Let's review it in person when you're back from vacation and up to speed.

It builds upon some of the work & patterns that @DavidMills-AI started with the SamplesConnector project.

I've been able to use the client to upload attachments, import data, and make other requests.

I didn't include the hacked code generator that will regenerate the `ServiceModel.cs` file from a live Swagger file. My reasoning is that the Samples Swagger configuration needs a bit of love (like unique operationIds) to be a bit more standard. Once that work is done, most of the hacks in the code generator will go away, and we can commit that tool as well.