### PR TITLE
PF-28 Bugfix for extracting assembly paths containing spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The **AQUARIUS SDK for .NET** enables .NET developers to easily work with the [A
 ![AQUARIUS Platform](images/aquatic-informatics.png)
 
 * [AQUARIUS Time-Series](http://aquaticinformatics.com/products/aquarius-time-series/)
-* [AQUARIUS Samples](http://aquaticinformatics.com/products/aquarius-samples/) (coming soon!)
+* [AQUARIUS Samples](http://aquaticinformatics.com/products/aquarius-samples/)
 * [AQUARIUS WebPortal](http://aquaticinformatics.com/products/aquarius-webportal/) (coming soon!)
 
 View the [Release Notes](ReleaseNotes.md) here.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,11 +4,16 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
+### 17.2.29
+
+- Fixed a bug where the SDK would fail to load if the SDK assembly or the application are located in a path containing spaces.
+- Added the first cut of an AQUARIUS Samples client.
+ 
 ### 17.2.26
 
-- Fixed the file version of the SDK assembly
-- Includes the SDK version and application version in the user agent string for all requests originating from the SDK
+- Fixed the file version of the SDK assembly.
+- Includes the SDK version and application version in the user agent string for all requests originating from the SDK.
 
 ### 17.2.17
 
-- Initial public release of the SDK
+- Initial public release of the SDK.

--- a/src/Aquarius.Client/Helpers/UserAgentBuilder.cs
+++ b/src/Aquarius.Client/Helpers/UserAgentBuilder.cs
@@ -71,7 +71,9 @@ namespace Aquarius.Helpers
             if (assembly == null)
                 return string.Empty;
 
-            return new Uri(assembly.CodeBase).AbsolutePath;
+            // Lifted from http://stackoverflow.com/questions/864484/getting-the-path-of-the-current-assembly
+            var uri = new Uri(assembly.CodeBase);
+            return Path.GetFullPath(Uri.UnescapeDataString(uri.AbsolutePath));
         }
     }
 }


### PR DESCRIPTION
@erinlim-ai Can you have a look?

Previous builds were failing completely when either the SDK library or the client application was located in a path containing spaces.

This StackOverflow post describes the extra steps required: http://stackoverflow.com/questions/864484/getting-the-path-of-the-current-assembly

Added the two missing steps of:
- Removing any URL encoding of characters
- Ensuring that forward slashes are converted to backslashes