### PR TITLE
Feature/pf 45 improve samples client testing

### DIFF
--- a/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
+++ b/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Helpers\UriHelperTests.cs" />
     <Compile Include="Helpers\UserAgentBuilderTests.cs" />
     <Compile Include="Samples\Client\FileUploaderTests.cs" />
+    <Compile Include="Samples\Client\LazyGetTests.cs" />
     <Compile Include="TimeSeries\Client\AquariusServerVersionTests.cs" />
     <Compile Include="TimeSeries\Client\AquariusSystemDetectorTests.cs" />
     <Compile Include="TimeSeries\Client\CredentialsParserTests.cs" />

--- a/src/Aquarius.Client.UnitTests/Samples/Client/LazyGetTests.cs
+++ b/src/Aquarius.Client.UnitTests/Samples/Client/LazyGetTests.cs
@@ -1,0 +1,226 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Aquarius.Samples.Client;
+using FluentAssertions;
+using NSubstitute;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+using ServiceStack;
+
+namespace Aquarius.UnitTests.Samples.Client
+{
+    [TestFixture]
+    public class LazyGetTests
+    {
+        private IServiceClient _mockServiceClient;
+        private IFixture _fixture;
+        private ISamplesClient _client;
+
+        [Route("/things", HttpMethods.Get)]
+        public class GetThings : IReturn<ThingResults>, IPaginatedRequest
+        {
+            public string Cursor { get; set; }
+        }
+
+        public class ThingResults: IPaginatedResponse<Thing>
+        {
+            public int TotalCount { get; set; }
+            public string Cursor { get; set; }
+            public List<Thing> DomainObjects { get; set; }
+        }
+
+        public class Thing
+        {
+            public string Name { get; set; }
+        }
+
+
+        [SetUp]
+        public void ForEachTest()
+        {
+            _fixture = new Fixture();
+            _mockServiceClient = Substitute.For<IServiceClient>();
+
+            SetupMockClient();
+
+            _client = SamplesClient.CreateTestClient(_mockServiceClient);
+        }
+
+        private void SetupMockClient()
+        {
+            _mockServiceClient
+                .Get(Arg.Any<SamplesClient.GetStatus>())
+                .Returns(new SamplesClient.StatusResponse {ReleaseName = "0.0"});
+        }
+
+        [Test]
+        public void LazyGet_AllResultsInFirstResponse_Succeeds()
+        {
+            _mockServiceClient
+                .Get(Arg.Any<GetThings>())
+                .Returns(
+                    x => CreateCompleteResults(2));
+
+            var items = EvaluateAllLazyLoadedItems();
+
+            AssertExpectedItemsAndLazyFetches(items, 2, 1);
+        }
+
+        private ThingResults CreateCompleteResults(int totalCount)
+        {
+            if (totalCount < 0)
+                throw new ArgumentOutOfRangeException(nameof(totalCount), $"TotalCount={totalCount} must not be negative");
+
+            return CreateResults(totalCount, totalCount);
+        }
+
+        private ThingResults CreateFinalResults(int resultCount, int totalCount)
+        {
+            if (resultCount > totalCount)
+                throw new ArgumentOutOfRangeException(nameof(resultCount), $"ResultCount={resultCount} must be less than TotalCount={totalCount}");
+
+            return CreateResults(resultCount, totalCount);
+        }
+
+        private ThingResults CreatePartialResults(int resultCount, int totalCount)
+        {
+            if (resultCount >= totalCount)
+                throw new ArgumentOutOfRangeException(nameof(resultCount), $"ResultCount={resultCount} must be strictly less than TotalCount={totalCount}");
+
+            return CreateResults(resultCount, totalCount);
+        }
+
+        private ThingResults CreateResultsWithNoCursor(int resultCount, int totalCount)
+        {
+            var results = CreatePartialResults(resultCount, totalCount);
+
+            results.Cursor = null;
+
+            return results;
+        }
+
+        private ThingResults CreateResultsWithEmptyCursor(int resultCount, int totalCount)
+        {
+            var results = CreatePartialResults(resultCount, totalCount);
+
+            results.Cursor = string.Empty;
+
+            return results;
+        }
+
+        private ThingResults CreateResults(int resultCount, int totalCount)
+        {
+            var results = new ThingResults
+            {
+                Cursor = _fixture.Create<string>(),
+                DomainObjects = new List<Thing>(),
+                TotalCount = totalCount
+            };
+
+            if (resultCount > 0)
+            {
+                results.DomainObjects = _fixture.CreateMany<Thing>(resultCount).ToList();
+            }
+            else
+            {
+                results.Cursor = null;
+            }
+
+            return results;
+        }
+
+        private List<Thing> EvaluateAllLazyLoadedItems()
+        {
+            return _client.LazyGet<Thing, GetThings, ThingResults>(new GetThings()).DomainObjects.ToList();
+        }
+
+        private void AssertExpectedItemsAndLazyFetches(List<Thing> items, int expectedTotalCount, int expectedFetchesCount)
+        {
+            items.Count.ShouldBeEquivalentTo(expectedTotalCount, "Total count of items should match");
+
+            _mockServiceClient
+                .Received(expectedFetchesCount)
+                .Get(Arg.Any<GetThings>());
+        }
+
+        [Test]
+        public void LazyGet_SecondResponseFails_Throws()
+        {
+            _mockServiceClient
+                .Get(Arg.Any<GetThings>())
+                .Returns(
+                    x => CreatePartialResults(1, 2),
+                    x => { throw new ArgumentException();});
+
+            ((Action) (() => EvaluateAllLazyLoadedItems())).ShouldThrow<ArgumentException>();
+        }
+
+        [Test]
+        public void LazyGet_SecondResponseContainsAllRemainingItems_Succeeds()
+        {
+            _mockServiceClient
+                .Get(Arg.Any<GetThings>())
+                .Returns(
+                    x => CreatePartialResults(1, 3),
+                    x => CreateFinalResults(1, 2));
+
+            var items = EvaluateAllLazyLoadedItems();
+
+            AssertExpectedItemsAndLazyFetches(items, 2, 2);
+        }
+
+        [Test]
+        public void LazyGet_SecondResponseWithNoCursor_Succeeds()
+        {
+            _mockServiceClient
+                .Get(Arg.Any<GetThings>())
+                .Returns(
+                    x => CreatePartialResults(1, 3),
+                    x => CreateResultsWithNoCursor(1, 3));
+
+            var items = EvaluateAllLazyLoadedItems();
+
+            AssertExpectedItemsAndLazyFetches(items, 2, 2);
+        }
+
+        [Test]
+        public void LazyGet_SecondResponseWithEmptyCursor_Succeeds()
+        {
+            _mockServiceClient
+                .Get(Arg.Any<GetThings>())
+                .Returns(
+                    x => CreatePartialResults(1, 3),
+                    x => CreateResultsWithEmptyCursor(1, 3));
+
+            var items = EvaluateAllLazyLoadedItems();
+
+            AssertExpectedItemsAndLazyFetches(items, 2, 2);
+        }
+
+        [Test]
+        public void LazyGet_ResponseWithNullObjects_Succeeds()
+        {
+            _mockServiceClient
+                .Get(Arg.Any<GetThings>())
+                .Returns(
+                    x => new ThingResults {TotalCount = 1, DomainObjects = null});
+
+            var items = EvaluateAllLazyLoadedItems();
+
+            AssertExpectedItemsAndLazyFetches(items, 0, 1);
+        }
+        [Test]
+        public void LazyGet_ResponseWithEmptyObjects_Succeeds()
+        {
+            _mockServiceClient
+                .Get(Arg.Any<GetThings>())
+                .Returns(
+                    x => new ThingResults {TotalCount = 1, DomainObjects = new List<Thing>()});
+
+            var items = EvaluateAllLazyLoadedItems();
+
+            AssertExpectedItemsAndLazyFetches(items, 0, 1);
+        }
+    }
+}

--- a/src/Aquarius.Client/Samples/Client/FileUploader.cs
+++ b/src/Aquarius.Client/Samples/Client/FileUploader.cs
@@ -11,9 +11,22 @@ namespace Aquarius.Samples.Client
     {
         private readonly IRestClient _restClient;
 
-        public FileUploader(JsonServiceClient client)
-            : this(new JsonHttpClient(client.BaseUri), client.Headers[SamplesClient.AuthorizationHeaderKey], client.UserAgent)
+        public static FileUploader Create(IServiceClient client)
         {
+            var baseUri = string.Empty;
+            var authHeader = string.Empty;
+            var userAgent = string.Empty;
+
+            var jsonServiceClient = client as JsonServiceClient;
+
+            if (jsonServiceClient != null)
+            {
+                baseUri = jsonServiceClient.BaseUri;
+                authHeader = jsonServiceClient.Headers[SamplesClient.AuthorizationHeaderKey];
+                userAgent = jsonServiceClient.UserAgent;
+            }
+
+            return new FileUploader(new JsonHttpClient(baseUri), authHeader, userAgent);
         }
 
         public FileUploader(IRestClient restClient, string authorizationHeader, string userAgent)

--- a/src/Aquarius.Client/Samples/Client/ServiceModel.cs
+++ b/src/Aquarius.Client/Samples/Client/ServiceModel.cs
@@ -1,6 +1,6 @@
-// Date: 2017-05-15T16:05:10.6309739-07:00
+// Date: 2017-06-14T14:56:14.1132449-07:00
 // Base URL: https://demo.aqsamples.com/api/swagger.json
-// Source: AQUARIUS Samples API (2017.6.2047)
+// Source: AQUARIUS Samples API (2017.7.2127)
 
 using System.Collections.Generic;
 using ServiceStack;
@@ -13,7 +13,7 @@ namespace Aquarius.Samples.Client.ServiceModel
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("2017.6.2047");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("2017.7.2127");
     }
 
     [Route("/v1/accessgroups", "GET")]
@@ -59,6 +59,7 @@ namespace Aquarius.Samples.Client.ServiceModel
     [Route("/v1/activities", "GET")]
     public class GetActivities : IReturn<SearchResultActivitySimple>
     {
+        public List<string> ActivityTemplateId { get; set; }
         public List<string> CollectionMethodIds { get; set; }
         public string CustomId { get; set; }
         public string FieldVisitId { get; set; }
@@ -590,6 +591,7 @@ namespace Aquarius.Samples.Client.ServiceModel
         public List<string> ResultGrades { get; set; }
         public List<string> ResultStatuses { get; set; }
         public SampleFractionType? SampleFraction { get; set; }
+        public List<string> SamplingLocationGroupIds { get; set; }
         public List<string> SamplingLocationIds { get; set; }
         public List<string> Search { get; set; }
         public string Sort { get; set; }
@@ -662,6 +664,7 @@ namespace Aquarius.Samples.Client.ServiceModel
         public List<string> ResultGrades { get; set; }
         public List<string> ResultStatuses { get; set; }
         public SampleFractionType? SampleFraction { get; set; }
+        public List<string> SamplingLocationGroupIds { get; set; }
         public List<string> SamplingLocationIds { get; set; }
         public List<string> Search { get; set; }
         public string Sort { get; set; }
@@ -700,6 +703,7 @@ namespace Aquarius.Samples.Client.ServiceModel
         public List<string> ResultGrades { get; set; }
         public List<string> ResultStatuses { get; set; }
         public SampleFractionType? SampleFraction { get; set; }
+        public List<string> SamplingLocationGroupIds { get; set; }
         public List<string> SamplingLocationIds { get; set; }
         public List<string> Search { get; set; }
         public string Sort { get; set; }
@@ -738,6 +742,7 @@ namespace Aquarius.Samples.Client.ServiceModel
         public List<string> ResultGrades { get; set; }
         public List<string> ResultStatuses { get; set; }
         public SampleFractionType? SampleFraction { get; set; }
+        public List<string> SamplingLocationGroupIds { get; set; }
         public List<string> SamplingLocationIds { get; set; }
         public List<string> Search { get; set; }
         public string Sort { get; set; }
@@ -1055,6 +1060,7 @@ namespace Aquarius.Samples.Client.ServiceModel
         public List<string> ResultGrades { get; set; }
         public List<string> ResultStatuses { get; set; }
         public SampleFractionType? SampleFraction { get; set; }
+        public List<string> SamplingLocationGroupIds { get; set; }
         public List<string> SamplingLocationIds { get; set; }
         public List<string> Search { get; set; }
         public string Sort { get; set; }
@@ -1254,6 +1260,7 @@ namespace Aquarius.Samples.Client.ServiceModel
         public List<Surrogate> Surrogates { get; set; }
         public AnalyticalGroup AnalyticalGroup { get; set; }
         public Activity Activity { get; set; }
+        public SpecimenTemplate TemplateCreatedFrom { get; set; }
         public List<Observation> Observations { get; set; }
         public AuditAttributes AuditAttributes { get; set; }
     }
@@ -1281,6 +1288,7 @@ namespace Aquarius.Samples.Client.ServiceModel
         public List<Surrogate> Surrogates { get; set; }
         public AnalyticalGroup AnalyticalGroup { get; set; }
         public Activity Activity { get; set; }
+        public SpecimenTemplate TemplateCreatedFrom { get; set; }
         public List<Observation> Observations { get; set; }
         public AuditAttributes AuditAttributes { get; set; }
     }
@@ -1771,6 +1779,7 @@ namespace Aquarius.Samples.Client.ServiceModel
     public class FieldSheetImportSummary
     {
         public ImportSummaryObservation FieldResultSummary { get; set; }
+        public ImportSummarySpecimen SpecimenSummary { get; set; }
     }
 
     public class FieldTrip
@@ -1955,6 +1964,24 @@ namespace Aquarius.Samples.Client.ServiceModel
         public List<ImportChangeItem> ItemComparison { get; set; }
     }
 
+    public class ImportItemSpecimen
+    {
+        public ImportItemSpecimen()
+        {
+            Fields = new List<string>();
+            ItemComparison = new List<ImportChangeItem>();
+        }
+
+        public List<string> Fields { get; set; }
+        public object Errors { get; set; }
+        public string RowId { get; set; }
+        public string Input { get; set; }
+        public ImportItemStatusType Status { get; set; }
+        public Specimen Item { get; set; }
+        public Specimen ExistingItem { get; set; }
+        public List<ImportChangeItem> ItemComparison { get; set; }
+    }
+
     public class ImportItemTaxon
     {
         public ImportItemTaxon()
@@ -1992,12 +2019,31 @@ namespace Aquarius.Samples.Client.ServiceModel
         public List<ImportError> ImportJobErrors { get; set; }
     }
 
+    public class ImportSummarySpecimen
+    {
+        public ImportSummarySpecimen()
+        {
+            ImportItems = new List<ImportItemSpecimen>();
+            ImportJobErrors = new List<ImportError>();
+        }
+
+        public ImportHistoryEventSimple ImportHistoryEventSimple { get; set; }
+        public int SuccessCount { get; set; }
+        public int SkippedCount { get; set; }
+        public int ErrorCount { get; set; }
+        public int NewCount { get; set; }
+        public int UpdateCount { get; set; }
+        public int ExpectedCount { get; set; }
+        public List<ImportItemSpecimen> ImportItems { get; set; }
+        public List<ImportError> ImportJobErrors { get; set; }
+    }
+
     public class InputPart
     {
         public object Headers { get; set; }
+        public bool ContentTypeFromMessage { get; set; }
         public MediaType MediaType { get; set; }
         public string BodyAsString { get; set; }
-        public bool ContentTypeFromMessage { get; set; }
     }
 
     public class LabAnalysisMethod
@@ -2730,6 +2776,7 @@ namespace Aquarius.Samples.Client.ServiceModel
         public List<Surrogate> Surrogates { get; set; }
         public AnalyticalGroup AnalyticalGroup { get; set; }
         public Activity Activity { get; set; }
+        public SpecimenTemplate TemplateCreatedFrom { get; set; }
         public AuditAttributes AuditAttributes { get; set; }
     }
 
@@ -2799,6 +2846,7 @@ namespace Aquarius.Samples.Client.ServiceModel
         public List<Surrogate> Surrogates { get; set; }
         public AnalyticalGroup AnalyticalGroup { get; set; }
         public Activity Activity { get; set; }
+        public SpecimenTemplate TemplateCreatedFrom { get; set; }
         public List<Observation> Observations { get; set; }
         public AuditAttributes AuditAttributes { get; set; }
     }
@@ -3077,8 +3125,7 @@ namespace Aquarius.Samples.Client.ServiceModel
     {
         NORMAL,
         SAMPLE_REPLICATE,
-        TRIP_BLANK,
-        QUALITY_CONTROL
+        TRIP_BLANK
     }
 
     public enum ResultGradeType


### PR DESCRIPTION
@jessemcdowell-AI Can you take a look at the 2nd commit?

It adds some test cases around the various exit conditions for retrieving paginated results from the Samples API. It covers the difference in response DTO shapes, depending on whether the results are coming straight from the DB or are pulled from a Solr index.

The callers to the SamplesClient.LazyGet() generic method will not need to worry about the specific response shape.

I should probably also ask Filip to review it as well.