### PR TITLE
PF-57 update time series service models

### DIFF
--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2017-09-12 11:13:29
+Date: 2017-09-12 16:24:15
 Version: 4.512
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: http://autoserver17/AQUARIUS/Acquisition/v2
@@ -25,11 +25,10 @@ ExportValueTypes: True
 */
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using ServiceStack;
 using ServiceStack.DataAnnotations;
+using ServiceStack.Web;
 using NodaTime;
 using Aquarius.TimeSeries.Client.ServiceModels.Acquisition;
 

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
@@ -1,8 +1,8 @@
 /* Options:
-Date: 2017-05-18 16:16:45
-Version: 4.56
+Date: 2017-09-12 11:13:29
+Version: 4.512
 Tip: To override a DTO option, remove "//" prefix before updating
-BaseUrl: http://autoserver1/AQUARIUS/Acquisition/v2
+BaseUrl: http://autoserver17/AQUARIUS/Acquisition/v2
 
 GlobalNamespace: Aquarius.TimeSeries.Client.ServiceModels.Acquisition
 MakePartial: False
@@ -72,6 +72,17 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         public int NumberOfPointsDeleted { get; set; }
     }
 
+    [Route("/attachments/reports/{ReportUniqueId}", "DELETE")]
+    public class DeleteReportAttachment
+        : IReturnVoid
+    {
+        ///<summary>
+        ///Unique ID of report
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of report", IsRequired=true, ParameterType="path")]
+        public Guid ReportUniqueId { get; set; }
+    }
+
     [Route("/timeseries/appendstatus/{AppendRequestIdentifier}", "GET")]
     public class GetTimeSeriesAppendStatus
         : IReturn<TimeSeriesAppendStatus>
@@ -111,6 +122,61 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         public Interval TimeRange { get; set; }
     }
 
+    [Route("/locations/{LocationUniqueId}/attachments/reports", "POST")]
+    public class PostReportAttachment
+        : IReturn<PostReportResponse>
+    {
+        public PostReportAttachment()
+        {
+            SourceTimeSeriesUniqueIds = new List<Guid>{};
+        }
+
+        ///<summary>
+        ///Title of the report
+        ///</summary>
+        [ApiMember(Description="Title of the report", IsRequired=true)]
+        public string Title { get; set; }
+
+        ///<summary>
+        ///Description of the report
+        ///</summary>
+        [ApiMember(Description="Description of the report")]
+        public string Description { get; set; }
+
+        ///<summary>
+        ///Comments about the report
+        ///</summary>
+        [ApiMember(Description="Comments about the report")]
+        public string Comments { get; set; }
+
+        ///<summary>
+        ///Unique ID of the location to add the report to
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the location to add the report to", IsRequired=true, ParameterType="path")]
+        public Guid LocationUniqueId { get; set; }
+
+        ///<summary>
+        ///Unique IDs of source time-series displayed in report
+        ///</summary>
+        [ApiMember(DataType="Array<string>", Description="Unique IDs of source time-series displayed in report")]
+        public List<Guid> SourceTimeSeriesUniqueIds { get; set; }
+
+        ///<summary>
+        ///Time range of source data displayed in report
+        ///</summary>
+        [ApiMember(DataType="Interval", Description="Time range of source data displayed in report")]
+        public Interval? SourceTimeRange { get; set; }
+
+        ///<summary>
+        ///Time report was created
+        ///</summary>
+        [ApiMember(DataType="Instant", Description="Time report was created")]
+        public Instant? CreatedTime { get; set; }
+
+        [Ignore]
+        [ApiMember(DataType="file", IsRequired=true, ParameterType="form")]
+        public IHttpFile File { get; set; }
+    }
 
     [Route("/timeseries/{UniqueId}/append", "POST")]
     public class PostTimeSeriesAppend
@@ -162,6 +228,21 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         public Interval TimeRange { get; set; }
     }
 
+    [Route("/locations/{LocationUniqueId}/visits/upload/plugins", "POST")]
+    public class PostVisitFile
+        : IReturn<PostVisitFileResponse>
+    {
+        ///<summary>
+        ///Unique ID of the location of visits in the file
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the location of visits in the file", IsRequired=true, ParameterType="path")]
+        public Guid LocationUniqueId { get; set; }
+
+        [Ignore]
+        [ApiMember(DataType="file", IsRequired=true, ParameterType="form")]
+        public IHttpFile File { get; set; }
+    }
+
     public class ReflectedTimeSeriesPoint
         : TimeSeriesPoint
     {
@@ -207,6 +288,43 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         public string AppendRequestIdentifier { get; set; }
     }
 
+    public class FieldDataPlugin
+    {
+        [ApiMember(DataType="string")]
+        public string Name { get; set; }
+
+        [ApiMember(DataType="string")]
+        public Guid UniqueId { get; set; }
+    }
+
+    public class PostReportResponse
+    {
+        ///<summary>
+        ///Unique ID of the created report
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the created report")]
+        public Guid ReportUniqueId { get; set; }
+    }
+
+    public class PostVisitFileResponse
+    {
+        public PostVisitFileResponse()
+        {
+            VisitUris = new List<string>{};
+        }
+
+        ///<summary>
+        ///Relative URIs of created visits
+        ///</summary>
+        [ApiMember(DataType="string", Description="Relative URIs of created visits")]
+        public List<string> VisitUris { get; set; }
+
+        ///<summary>
+        ///Registered field data plug-in that processed the file
+        ///</summary>
+        [ApiMember(DataType="FieldDataPlugin", Description="Registered field data plug-in that processed the file")]
+        public FieldDataPlugin HandledByPlugin { get; set; }
+    }
 
     [Route("/session", "DELETE")]
     public class DeleteSession
@@ -269,6 +387,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("17.2.81.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("17.3.86.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
@@ -79,7 +79,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///<summary>
         ///Identifier returned from a previous append request
         ///</summary>
-        [ApiMember(ParameterType="path", Description="Identifier returned from a previous append request", IsRequired=true)]
+        [ApiMember(Description="Identifier returned from a previous append request", IsRequired=true, ParameterType="path")]
         public string AppendRequestIdentifier { get; set; }
     }
 
@@ -95,21 +95,22 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///<summary>
         ///The unique ID (from Publish API) of the reflected time series to receive points
         ///</summary>
-        [ApiMember(ParameterType="path", IsRequired=true, Description="The unique ID (from Publish API) of the reflected time series to receive points", DataType="string")]
+        [ApiMember(DataType="string", Description="The unique ID (from Publish API) of the reflected time series to receive points", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
         ///Points to append (can be empty). All points must lie within the time range
         ///</summary>
-        [ApiMember(Description="Points to append (can be empty). All points must lie within the time range", DataType="Array<ReflectedTimeSeriesPoint>")]
+        [ApiMember(DataType="Array<ReflectedTimeSeriesPoint>", Description="Points to append (can be empty). All points must lie within the time range")]
         public List<ReflectedTimeSeriesPoint> Points { get; set; }
 
         ///<summary>
         ///Time range to update. Any existing points in the time range will be overwritten
         ///</summary>
-        [ApiMember(IsRequired=true, Description="Time range to update. Any existing points in the time range will be overwritten", DataType="Interval")]
+        [ApiMember(DataType="Interval", Description="Time range to update. Any existing points in the time range will be overwritten", IsRequired=true)]
         public Interval TimeRange { get; set; }
     }
+
 
     [Route("/timeseries/{UniqueId}/append", "POST")]
     public class PostTimeSeriesAppend
@@ -123,13 +124,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///<summary>
         ///The unique ID (from Publish API) of the time series to receive points
         ///</summary>
-        [ApiMember(ParameterType="path", IsRequired=true, Description="The unique ID (from Publish API) of the time series to receive points", DataType="string")]
+        [ApiMember(DataType="string", Description="The unique ID (from Publish API) of the time series to receive points", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
         ///Points to append (can be empty)
         ///</summary>
-        [ApiMember(Description="Points to append (can be empty)", DataType="Array<TimeSeriesPoint>")]
+        [ApiMember(DataType="Array<TimeSeriesPoint>", Description="Points to append (can be empty)")]
         public List<TimeSeriesPoint> Points { get; set; }
     }
 
@@ -145,19 +146,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///<summary>
         ///The unique ID (from Publish API) of the time series to receive points
         ///</summary>
-        [ApiMember(ParameterType="path", IsRequired=true, Description="The unique ID (from Publish API) of the time series to receive points", DataType="string")]
+        [ApiMember(DataType="string", Description="The unique ID (from Publish API) of the time series to receive points", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
         ///Points to append (can be empty). All points must lie within the time range
         ///</summary>
-        [ApiMember(Description="Points to append (can be empty). All points must lie within the time range", DataType="Array<TimeSeriesPoint>")]
+        [ApiMember(DataType="Array<TimeSeriesPoint>", Description="Points to append (can be empty). All points must lie within the time range")]
         public List<TimeSeriesPoint> Points { get; set; }
 
         ///<summary>
         ///Time range to delete before appending points
         ///</summary>
-        [ApiMember(Description="Time range to delete before appending points", DataType="Interval")]
+        [ApiMember(DataType="Interval", Description="Time range to delete before appending points")]
         public Interval TimeRange { get; set; }
     }
 
@@ -172,13 +173,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///<summary>
         ///Grade code
         ///</summary>
-        [ApiMember(Description="Grade code", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Grade code")]
         public int? GradeCode { get; set; }
 
         ///<summary>
         ///Qualifier codes
         ///</summary>
-        [ApiMember(Description="Qualifier codes", DataType="Array<string>")]
+        [ApiMember(DataType="Array<string>", Description="Qualifier codes")]
         public List<string> Qualifiers { get; set; }
     }
 
@@ -187,13 +188,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///<summary>
         ///ISO 8601 timestamp
         ///</summary>
-        [ApiMember(IsRequired=true, Description="ISO 8601 timestamp", DataType="Instant")]
+        [ApiMember(DataType="Instant", Description="ISO 8601 timestamp", IsRequired=true)]
         public Instant? Time { get; set; }
 
         ///<summary>
         ///The value of the point. Null or empty to represent a NaN
         ///</summary>
-        [ApiMember(Description="The value of the point. Null or empty to represent a NaN", DataType="double")]
+        [ApiMember(DataType="double", Description="The value of the point. Null or empty to represent a NaN")]
         public double? Value { get; set; }
     }
 
@@ -205,6 +206,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         [ApiMember(Description="A token to use in subsequent GetTimeSeriesAppendStatus calls")]
         public string AppendRequestIdentifier { get; set; }
     }
+
 
     [Route("/session", "DELETE")]
     public class DeleteSession
@@ -252,7 +254,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///<summary>
         ///RSA key size in bits
         ///</summary>
-        [ApiMember(Description="RSA key size in bits", DataType="integer")]
+        [ApiMember(DataType="integer", Description="RSA key size in bits")]
         public int KeySize { get; set; }
 
         ///<summary>

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
@@ -1,8 +1,8 @@
 /* Options:
-Date: 2017-05-18 16:16:34
-Version: 4.56
+Date: 2017-09-12 11:13:14
+Version: 4.512
 Tip: To override a DTO option, remove "//" prefix before updating
-BaseUrl: http://autoserver1/AQUARIUS/Provisioning/v1
+BaseUrl: http://autoserver17/AQUARIUS/Provisioning/v1
 
 GlobalNamespace: Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 MakePartial: False
@@ -112,6 +112,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         public string Xml { get; set; }
     }
 
+    public enum MeasurementDirection
+    {
+        Unknown,
+        FromTopToBottom,
+        FromBottomToTop,
+    }
+
     public enum NewValueLocationType
     {
         Unknown,
@@ -171,6 +178,45 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         public string Description { get; set; }
     }
 
+    [Route("/locations/{LocationUniqueId}/datumperiods", "DELETE")]
+    public class DeleteLocationDatum
+        : IReturnVoid
+    {
+        ///<summary>
+        ///Unique ID of the location
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the location", IsRequired=true, ParameterType="path")]
+        public Guid LocationUniqueId { get; set; }
+    }
+
+    [Route("/locations/{LocationUniqueId}/datumperiods", "GET")]
+    public class GetLocationDatum
+        : IReturn<LocationDatumResponse>
+    {
+        ///<summary>
+        ///Unique ID of the location
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the location", IsRequired=true, ParameterType="path")]
+        public Guid LocationUniqueId { get; set; }
+    }
+
+    [Route("/locations/{LocationUniqueId}/datumperiods", "POST")]
+    public class PostLocationDatumPeriod
+        : LocationDatumPeriodBase, IReturn<LocationDatumResponse>
+    {
+        ///<summary>
+        ///Unique ID of the location
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the location", IsRequired=true, ParameterType="path")]
+        public Guid LocationUniqueId { get; set; }
+
+        ///<summary>
+        ///Reference standard this period is related to, which must be a standard reference datum for the location
+        ///</summary>
+        [ApiMember(Description="Reference standard this period is related to, which must be a standard reference datum for the location", IsRequired=true)]
+        public string StandardIdentifier { get; set; }
+    }
+
     [Route("/locationfolders/{LocationFolderUniqueId}", "DELETE")]
     public class DeleteLocationFolder
         : IReturnVoid
@@ -191,6 +237,23 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///</summary>
         [ApiMember(DataType="string", Description="Unique ID of the location type", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
+    }
+
+    [Route("/locations/{LocationUniqueId}/referencepoints/{ReferencePointUniqueId}", "DELETE")]
+    public class DeleteReferencePoint
+        : IReturnVoid
+    {
+        ///<summary>
+        ///Unique ID of the location
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the location", IsRequired=true, ParameterType="path")]
+        public Guid LocationUniqueId { get; set; }
+
+        ///<summary>
+        ///Unique ID of the reference point
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the reference point", IsRequired=true, ParameterType="path")]
+        public Guid ReferencePointUniqueId { get; set; }
     }
 
     [Route("/locations/{LocationUniqueId}", "GET")]
@@ -219,6 +282,17 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
     public class GetLocationFolders
         : IReturn<LocationFoldersResponse>
     {
+    }
+
+    [Route("/locations/{LocationUniqueId}/referencepoints/", "GET")]
+    public class GetLocationReferencePoints
+        : IReturn<ReferencePointResponse>
+    {
+        ///<summary>
+        ///Unique ID of the location
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the location", IsRequired=true, ParameterType="path")]
+        public Guid LocationUniqueId { get; set; }
     }
 
     [Route("/locationtypes/{UniqueId}", "GET")]
@@ -271,15 +345,15 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         public string Description { get; set; }
 
         ///<summary>
-        ///Longitude
+        ///Longitude (WGS 84)
         ///</summary>
-        [ApiMember(DataType="double", Description="Longitude")]
+        [ApiMember(DataType="double", Description="Longitude (WGS 84)")]
         public double? Longitude { get; set; }
 
         ///<summary>
-        ///Latitude
+        ///Latitude (WGS 84)
         ///</summary>
-        [ApiMember(DataType="double", Description="Latitude")]
+        [ApiMember(DataType="double", Description="Latitude (WGS 84)")]
         public double? Latitude { get; set; }
 
         ///<summary>
@@ -342,9 +416,9 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         : LocationBase, IReturn<Location>
     {
         ///<summary>
-        ///ISO 8601 Duration Format
+        ///ISO 8601 duration format
         ///</summary>
-        [ApiMember(DataType="Offset", Description="ISO 8601 Duration Format")]
+        [ApiMember(DataType="Offset", Description="ISO 8601 duration format")]
         public Offset UtcOffset { get; set; }
     }
 
@@ -362,6 +436,27 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
     [Route("/locationtypes", "POST")]
     public class PostLocationType
         : LocationTypeBase, IReturn<LocationType>
+    {
+    }
+
+    [Route("/locations/{LocationUniqueId}/referencepoints", "POST")]
+    public class PostReferencePoint
+        : ReferencePointBase, IReturn<ReferencePoint>
+    {
+        public PostReferencePoint()
+        {
+            ReferencePointPeriods = new List<PostReferencePointPeriod>{};
+        }
+
+        ///<summary>
+        ///Periods of applicablity for this reference point. Must have at least one period
+        ///</summary>
+        [ApiMember(DataType="Array<PostReferencePointPeriod>", Description="Periods of applicablity for this reference point. Must have at least one period", IsRequired=true)]
+        public List<PostReferencePointPeriod> ReferencePointPeriods { get; set; }
+    }
+
+    public class PostReferencePointPeriod
+        : ReferencePointPeriodBase
     {
     }
 
@@ -396,6 +491,51 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///</summary>
         [ApiMember(DataType="string", Description="Unique ID of the location type", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
+    }
+
+    public class ReferencePointBase
+    {
+        ///<summary>
+        ///Unique ID of the location
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the location", IsRequired=true, ParameterType="path")]
+        public Guid LocationUniqueId { get; set; }
+
+        ///<summary>
+        ///Name
+        ///</summary>
+        [ApiMember(Description="Name", IsRequired=true)]
+        public string Name { get; set; }
+
+        ///<summary>
+        ///Description
+        ///</summary>
+        [ApiMember(Description="Description")]
+        public string Description { get; set; }
+
+        ///<summary>
+        ///Decommissioned date
+        ///</summary>
+        [ApiMember(DataType="Instant", Description="Decommissioned date")]
+        public Instant? DecommissionedDate { get; set; }
+
+        ///<summary>
+        ///Decommissioned reason
+        ///</summary>
+        [ApiMember(Description="Decommissioned reason")]
+        public string DecommissionedReason { get; set; }
+
+        ///<summary>
+        ///Longitude (WGS 84)
+        ///</summary>
+        [ApiMember(DataType="double", Description="Longitude (WGS 84)")]
+        public double? Longitude { get; set; }
+
+        ///<summary>
+        ///Latitude (WGS 84)
+        ///</summary>
+        [ApiMember(DataType="double", Description="Latitude (WGS 84)")]
+        public double? Latitude { get; set; }
     }
 
     [Route("/monitoringmethods/{MethodCode}", "DELETE")]
@@ -739,6 +879,78 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         public string Identifier { get; set; }
     }
 
+    [Route("/locations/{LocationUniqueId}/standardreferencedatums/{StandardIdentifier}", "DELETE")]
+    public class DeleteStandardReferenceDatum
+        : StandardReferenceDatumRequestBase, IReturnVoid
+    {
+    }
+
+    [Route("/locations/{LocationUniqueId}/standardreferencedatums", "GET")]
+    public class GetStandardReferenceDatums
+        : IReturn<StandardReferenceDatumsResponse>
+    {
+        ///<summary>
+        ///Unique ID of the location
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the location", IsRequired=true, ParameterType="path")]
+        public Guid LocationUniqueId { get; set; }
+    }
+
+    [Route("/locations/{LocationUniqueId}/standardreferencedatums/basereference", "POST")]
+    public class PostBaseStandardReferenceDatum
+        : StandardReferenceDatumRequestBase, IReturn<StandardReferenceDatum>
+    {
+    }
+
+    [Route("/locations/{LocationUniqueId}/standardreferencedatums/basereferenceoffset", "POST")]
+    public class PostBaseStandardReferenceDatumOffset
+        : StandardReferenceDatumRequestBase, IReturn<StandardReferenceDatum>
+    {
+        ///<summary>
+        ///Offset in relation to the base reference.
+        ///</summary>
+        [ApiMember(DataType="double", Description="Offset in relation to the base reference.", IsRequired=true)]
+        public double OffsetToBaseReference { get; set; }
+    }
+
+    [Route("/locations/{LocationUniqueId}/standardreferencedatums/basereferenceoffset/{StandardIdentifier}", "PUT")]
+    public class PutBaseStandardReferenceDatumOffset
+        : IReturn<StandardReferenceDatum>
+    {
+        ///<summary>
+        ///Unique ID of the location
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the location", IsRequired=true, ParameterType="path")]
+        public Guid LocationUniqueId { get; set; }
+
+        ///<summary>
+        ///Standard identifier
+        ///</summary>
+        [ApiMember(DataType="string", Description="Standard identifier", IsRequired=true, ParameterType="path")]
+        public string StandardIdentifier { get; set; }
+
+        ///<summary>
+        ///Offset in relation to the base reference.
+        ///</summary>
+        [ApiMember(DataType="double", Description="Offset in relation to the base reference.", IsRequired=true)]
+        public double OffsetToBaseReference { get; set; }
+    }
+
+    public class StandardReferenceDatumRequestBase
+    {
+        ///<summary>
+        ///Unique ID of the location
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the location", IsRequired=true, ParameterType="path")]
+        public Guid LocationUniqueId { get; set; }
+
+        ///<summary>
+        ///StandardIdentifier
+        ///</summary>
+        [ApiMember(DataType="string", Description="StandardIdentifier", IsRequired=true)]
+        public string StandardIdentifier { get; set; }
+    }
+
     [Route("/timeseries/{TimeSeriesUniqueId}", "DELETE")]
     public class DeleteTimeSeries
         : IReturnVoid
@@ -864,6 +1076,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///</summary>
         [ApiMember(DataType="integer", Description="Observation offset in minutes")]
         public int? ObservationOffsetInMinutes { get; set; }
+
+        ///<summary>
+        ///Time Step Count. Must be included for 'Statistic' derived time-series.
+        ///</summary>
+        [ApiMember(Description="Time Step Count. Must be included for 'Statistic' derived time-series.")]
+        public int? TimeStepCount { get; set; }
     }
 
     [Route("/timeseries/{TimeSeriesUniqueId}", "PUT")]
@@ -1688,15 +1906,15 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         public bool IsExternalLocation { get; set; }
 
         ///<summary>
-        ///Longitude
+        ///Longitude (WGS 84)
         ///</summary>
-        [ApiMember(DataType="double", Description="Longitude")]
+        [ApiMember(DataType="double", Description="Longitude (WGS 84)")]
         public double? Longitude { get; set; }
 
         ///<summary>
-        ///Latitude
+        ///Latitude (WGS 84)
         ///</summary>
-        [ApiMember(DataType="double", Description="Latitude")]
+        [ApiMember(DataType="double", Description="Latitude (WGS 84)")]
         public double? Latitude { get; set; }
 
         ///<summary>
@@ -1734,6 +1952,69 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///</summary>
         [ApiMember(DataType="Array<ExtendedAttributeValue>", Description="Extended attribute values")]
         public IList<ExtendedAttributeValue> ExtendedAttributeValues { get; set; }
+    }
+
+    public class LocationDatumPeriod
+        : LocationDatumPeriodBase
+    {
+        ///<summary>
+        ///Applied date
+        ///</summary>
+        [ApiMember(DataType="Instant", Description="Applied date")]
+        public Instant AppliedTimeUtc { get; set; }
+
+        ///<summary>
+        ///Applied by user
+        ///</summary>
+        [ApiMember(Description="Applied by user")]
+        public string AppliedByUser { get; set; }
+
+        ///<summary>
+        ///Reference standard this period is related to
+        ///</summary>
+        [ApiMember(DataType="StandardReferenceDatum", Description="Reference standard this period is related to")]
+        public StandardReferenceDatum ReferenceStandard { get; set; }
+    }
+
+    public class LocationDatumPeriodBase
+    {
+        ///<summary>
+        ///Time this period is valid from
+        ///</summary>
+        [ApiMember(DataType="Instant", Description="Time this period is valid from", IsRequired=true)]
+        public Instant ValidFrom { get; set; }
+
+        ///<summary>
+        ///Elevation difference from the reference standard
+        ///</summary>
+        [ApiMember(DataType="double", Description="Elevation difference from the reference standard", IsRequired=true)]
+        public double Elevation { get; set; }
+
+        ///<summary>
+        ///Direction of positive elevations in relation to the reference standard
+        ///</summary>
+        [ApiMember(DataType="MeasurementDirection", Description="Direction of positive elevations in relation to the reference standard", IsRequired=true)]
+        public MeasurementDirection MeasurementDirection { get; set; }
+
+        ///<summary>
+        ///Comment
+        ///</summary>
+        [ApiMember(Description="Comment")]
+        public string Comment { get; set; }
+    }
+
+    public class LocationDatumResponse
+    {
+        public LocationDatumResponse()
+        {
+            Results = new List<LocationDatumPeriod>{};
+        }
+
+        ///<summary>
+        ///The list of assumed local datums for the location
+        ///</summary>
+        [ApiMember(DataType="Array<LocationDatumPeriod>", Description="The list of assumed local datums for the location")]
+        public List<LocationDatumPeriod> Results { get; set; }
     }
 
     public class LocationFolder
@@ -2047,6 +2328,102 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         public List<PopulatedUnitGroup> Results { get; set; }
     }
 
+    public class ReferencePoint
+        : ReferencePointBase
+    {
+        public ReferencePoint()
+        {
+            ReferencePointPeriods = new List<ReferencePointPeriod>{};
+        }
+
+        ///<summary>
+        ///Unique ID of the reference point
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the reference point")]
+        public Guid UniqueId { get; set; }
+
+        ///<summary>
+        ///Periods of applicablity for this reference point
+        ///</summary>
+        [ApiMember(DataType="Array<ReferencePointPeriod>", Description="Periods of applicablity for this reference point")]
+        public List<ReferencePointPeriod> ReferencePointPeriods { get; set; }
+    }
+
+    public class ReferencePointPeriod
+        : ReferencePointPeriodBase
+    {
+        ///<summary>
+        ///Unique ID of the reference point
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the reference point")]
+        public Guid ReferencePointUniqueId { get; set; }
+
+        ///<summary>
+        ///Applied date
+        ///</summary>
+        [ApiMember(DataType="Instant", Description="Applied date")]
+        public Instant AppliedTimeUtc { get; set; }
+
+        ///<summary>
+        ///Applied by user
+        ///</summary>
+        [ApiMember(Description="Applied by user")]
+        public string AppliedByUser { get; set; }
+    }
+
+    public class ReferencePointPeriodBase
+    {
+        ///<summary>
+        ///Time this period is valid from
+        ///</summary>
+        [ApiMember(DataType="Instant", Description="Time this period is valid from", IsRequired=true)]
+        public Instant ValidFrom { get; set; }
+
+        ///<summary>
+        ///Standard identifier. Standard reference datum must already be defined in this location
+        ///</summary>
+        [ApiMember(Description="Standard identifier. Standard reference datum must already be defined in this location")]
+        public string StandardIdentifier { get; set; }
+
+        ///<summary>
+        ///True if this period is measured against the location's local assumed datum instead of a standard datum
+        ///</summary>
+        [ApiMember(DataType="boolean", Description="True if this period is measured against the location's local assumed datum instead of a standard datum", IsRequired=true)]
+        public bool IsMeasuredAgainstLocalAssumedDatum { get; set; }
+
+        ///<summary>
+        ///Elevation of the reference point relative to the standard or local assumed datum
+        ///</summary>
+        [ApiMember(DataType="double", Description="Elevation of the reference point relative to the standard or local assumed datum", IsRequired=true)]
+        public double Elevation { get; set; }
+
+        ///<summary>
+        ///Direction of positive elevations in relation to the reference point
+        ///</summary>
+        [ApiMember(DataType="MeasurementDirection", Description="Direction of positive elevations in relation to the reference point", IsRequired=true)]
+        public MeasurementDirection MeasurementDirection { get; set; }
+
+        ///<summary>
+        ///Comment
+        ///</summary>
+        [ApiMember(Description="Comment")]
+        public string Comment { get; set; }
+    }
+
+    public class ReferencePointResponse
+    {
+        public ReferencePointResponse()
+        {
+            Results = new List<ReferencePoint>{};
+        }
+
+        ///<summary>
+        ///The list of reference points
+        ///</summary>
+        [ApiMember(DataType="Array<ReferencePoint>", Description="The list of reference points")]
+        public List<ReferencePoint> Results { get; set; }
+    }
+
     public class StandardDatum
     {
         ///<summary>
@@ -2068,6 +2445,47 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///</summary>
         [ApiMember(DataType="Array<StandardDatum>", Description="The list of standard datums")]
         public List<StandardDatum> Results { get; set; }
+    }
+
+    public class StandardReferenceDatum
+    {
+        ///<summary>
+        ///Unique ID of the Location
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the Location")]
+        public Guid LocationUniqueId { get; set; }
+
+        ///<summary>
+        ///StandardIdentifier
+        ///</summary>
+        [ApiMember(DataType="string", Description="StandardIdentifier")]
+        public string StandardIdentifier { get; set; }
+
+        ///<summary>
+        ///True if the Standard Reference Datum is the Base Reference
+        ///</summary>
+        [ApiMember(DataType="boolean", Description="True if the Standard Reference Datum is the Base Reference")]
+        public bool IsBaseReference { get; set; }
+
+        ///<summary>
+        ///Offset in relation to the Base Reference. Not used if IsBaseReference is set to true
+        ///</summary>
+        [ApiMember(DataType="double", Description="Offset in relation to the Base Reference. Not used if IsBaseReference is set to true")]
+        public double? OffsetToBaseReference { get; set; }
+    }
+
+    public class StandardReferenceDatumsResponse
+    {
+        public StandardReferenceDatumsResponse()
+        {
+            Results = new List<StandardReferenceDatum>{};
+        }
+
+        ///<summary>
+        ///The list of Standard Reference Datums
+        ///</summary>
+        [ApiMember(DataType="Array<StandardReferenceDatum>", Description="The list of Standard Reference Datums")]
+        public List<StandardReferenceDatum> Results { get; set; }
     }
 
     public class TimeSeries
@@ -2189,9 +2607,9 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         }
 
         ///<summary>
-        ///The lsit of time series
+        ///The list of time series
         ///</summary>
-        [ApiMember(DataType="Array<TimeSeries>", Description="The lsit of time series")]
+        [ApiMember(DataType="Array<TimeSeries>", Description="The list of time series")]
         public List<TimeSeries> Results { get; set; }
     }
 
@@ -2437,6 +2855,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("17.2.81.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("17.3.86.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2017-09-12 11:13:14
+Date: 2017-09-12 16:24:03
 Version: 4.512
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: http://autoserver17/AQUARIUS/Provisioning/v1
@@ -25,11 +25,10 @@ ExportValueTypes: True
 */
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using ServiceStack;
 using ServiceStack.DataAnnotations;
+using ServiceStack.Web;
 using NodaTime;
 using Aquarius.TimeSeries.Client.ServiceModels.Provisioning;
 

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
@@ -102,7 +102,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///RSA key size in bits
         ///</summary>
-        [ApiMember(Description="RSA key size in bits", DataType="integer")]
+        [ApiMember(DataType="integer", Description="RSA key size in bits")]
         public int KeySize { get; set; }
 
         ///<summary>
@@ -132,7 +132,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the field data plug-in
         ///</summary>
-        [ApiMember(ParameterType="path", IsRequired=true, DataType="string", Description="Unique ID of the field data plug-in")]
+        [ApiMember(DataType="string", Description="Unique ID of the field data plug-in", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -149,25 +149,25 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Plug-in folder name
         ///</summary>
-        [ApiMember(IsRequired=true, DataType="string", Description="Plug-in folder name")]
+        [ApiMember(DataType="string", Description="Plug-in folder name", IsRequired=true)]
         public string PluginFolderName { get; set; }
 
         ///<summary>
         ///Assembly qualified type name
         ///</summary>
-        [ApiMember(Description="Assembly qualified type name", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Assembly qualified type name", IsRequired=true)]
         public string AssemblyQualifiedTypeName { get; set; }
 
         ///<summary>
         ///Plug-in priority; 1 has highest priority
         ///</summary>
-        [ApiMember(IsRequired=true, DataType="integer", Description="Plug-in priority; 1 has highest priority")]
+        [ApiMember(DataType="integer", Description="Plug-in priority; 1 has highest priority", IsRequired=true)]
         public int PluginPriority { get; set; }
 
         ///<summary>
         ///Description
         ///</summary>
-        [ApiMember(Description="Description", DataType="string")]
+        [ApiMember(DataType="string", Description="Description")]
         public string Description { get; set; }
     }
 
@@ -178,7 +178,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the location folder
         ///</summary>
-        [ApiMember(Description="Unique ID of the location folder", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the location folder", IsRequired=true, ParameterType="path")]
         public Guid LocationFolderUniqueId { get; set; }
     }
 
@@ -189,7 +189,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the location type
         ///</summary>
-        [ApiMember(Description="Unique ID of the location type", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the location type", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -200,7 +200,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the location
         ///</summary>
-        [ApiMember(Description="Unique ID of the location", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the location", IsRequired=true, ParameterType="path")]
         public Guid LocationUniqueId { get; set; }
     }
 
@@ -211,7 +211,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the location folder
         ///</summary>
-        [ApiMember(Description="Unique ID of the location folder", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the location folder", IsRequired=true, ParameterType="path")]
         public Guid LocationFolderUniqueId { get; set; }
     }
 
@@ -228,7 +228,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the location type
         ///</summary>
-        [ApiMember(Description="Unique ID of the location type", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the location type", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -273,13 +273,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Longitude
         ///</summary>
-        [ApiMember(Description="Longitude", DataType="double")]
+        [ApiMember(DataType="double", Description="Longitude")]
         public double? Longitude { get; set; }
 
         ///<summary>
         ///Latitude
         ///</summary>
-        [ApiMember(Description="Latitude", DataType="double")]
+        [ApiMember(DataType="double", Description="Latitude")]
         public double? Latitude { get; set; }
 
         ///<summary>
@@ -291,13 +291,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Elevation
         ///</summary>
-        [ApiMember(Description="Elevation", DataType="double")]
+        [ApiMember(DataType="double", Description="Elevation")]
         public double? Elevation { get; set; }
 
         ///<summary>
         ///Extended attribute values
         ///</summary>
-        [ApiMember(Description="Extended attribute values", DataType="Array<ExtendedAttributeValue>")]
+        [ApiMember(DataType="Array<ExtendedAttributeValue>", Description="Extended attribute values")]
         public IList<ExtendedAttributeValue> ExtendedAttributeValues { get; set; }
     }
 
@@ -344,7 +344,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///ISO 8601 Duration Format
         ///</summary>
-        [ApiMember(Description="ISO 8601 Duration Format", DataType="Offset")]
+        [ApiMember(DataType="Offset", Description="ISO 8601 Duration Format")]
         public Offset UtcOffset { get; set; }
     }
 
@@ -372,7 +372,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the location
         ///</summary>
-        [ApiMember(Description="Unique ID of the location", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the location", IsRequired=true, ParameterType="path")]
         public Guid LocationUniqueId { get; set; }
     }
 
@@ -383,7 +383,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the location folder
         ///</summary>
-        [ApiMember(Description="Unique ID of the location folder", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the location folder", IsRequired=true, ParameterType="path")]
         public Guid LocationFolderUniqueId { get; set; }
     }
 
@@ -394,7 +394,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the location type
         ///</summary>
-        [ApiMember(Description="Unique ID of the location type", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the location type", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -405,7 +405,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Method code
         ///</summary>
-        [ApiMember(Description="Method code", ParameterType="path", IsRequired=true)]
+        [ApiMember(Description="Method code", IsRequired=true, ParameterType="path")]
         public string MethodCode { get; set; }
     }
 
@@ -416,7 +416,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Method code
         ///</summary>
-        [ApiMember(Description="Method code", ParameterType="path", IsRequired=true)]
+        [ApiMember(Description="Method code", IsRequired=true, ParameterType="path")]
         public string MethodCode { get; set; }
     }
 
@@ -449,7 +449,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the method's parameter
         ///</summary>
-        [ApiMember(Description="Unique ID of the method's parameter", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the method's parameter", IsRequired=true)]
         public Guid ParameterUniqueId { get; set; }
 
         ///<summary>
@@ -506,13 +506,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///If not specified, defaults to openid
         ///</summary>
-        [ApiMember(Description="If not specified, defaults to openid", DataType="IList")]
+        [ApiMember(DataType="IList", Description="If not specified, defaults to openid")]
         public IList<string> Scopes { get; set; }
 
         ///<summary>
         ///Hosted domains
         ///</summary>
-        [ApiMember(Description="Hosted domains", DataType="Array<string>")]
+        [ApiMember(DataType="Array<string>", Description="Hosted domains")]
         public IList<string> HostedDomains { get; set; }
     }
 
@@ -540,7 +540,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the parameter
         ///</summary>
-        [ApiMember(Description="Unique ID of the parameter", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the parameter", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -551,7 +551,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the parameter
         ///</summary>
-        [ApiMember(Description="Unique ID of the parameter", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the parameter", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -596,19 +596,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Min value
         ///</summary>
-        [ApiMember(Description="Min value", DataType="double")]
+        [ApiMember(DataType="double", Description="Min value")]
         public double? MinValue { get; set; }
 
         ///<summary>
         ///Max value
         ///</summary>
-        [ApiMember(Description="Max value", DataType="double")]
+        [ApiMember(DataType="double", Description="Max value")]
         public double? MaxValue { get; set; }
 
         ///<summary>
         ///Interpolation type
         ///</summary>
-        [ApiMember(Description="Interpolation type", DataType="InterpolationType", IsRequired=true)]
+        [ApiMember(DataType="InterpolationType", Description="Interpolation type", IsRequired=true)]
         public InterpolationType InterpolationType { get; set; }
 
         ///<summary>
@@ -631,7 +631,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the parameter
         ///</summary>
-        [ApiMember(Description="Unique ID of the parameter", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the parameter", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -642,7 +642,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Grade code
         ///</summary>
-        [ApiMember(Description="Grade code", ParameterType="path", DataType="integer", IsRequired=true)]
+        [ApiMember(DataType="integer", Description="Grade code", IsRequired=true, ParameterType="path")]
         public int GradeCode { get; set; }
     }
 
@@ -653,7 +653,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Grade code
         ///</summary>
-        [ApiMember(Description="Grade code", ParameterType="path", DataType="integer", IsRequired=true)]
+        [ApiMember(DataType="integer", Description="Grade code", IsRequired=true, ParameterType="path")]
         public int GradeCode { get; set; }
     }
 
@@ -676,7 +676,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Grade code
         ///</summary>
-        [ApiMember(Description="Grade code", ParameterType="path", DataType="integer", IsRequired=true)]
+        [ApiMember(DataType="integer", Description="Grade code", IsRequired=true, ParameterType="path")]
         public int? GradeCode { get; set; }
     }
 
@@ -685,7 +685,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Grade code
         ///</summary>
-        [ApiMember(Description="Grade code", DataType="integer", IsRequired=true)]
+        [ApiMember(DataType="integer", Description="Grade code", IsRequired=true)]
         public int? GradeCode { get; set; }
 
         ///<summary>
@@ -714,7 +714,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Identifier of the standard daturm
         ///</summary>
-        [ApiMember(Description="Identifier of the standard daturm", ParameterType="path", IsRequired=true)]
+        [ApiMember(Description="Identifier of the standard daturm", IsRequired=true, ParameterType="path")]
         public string Identifier { get; set; }
     }
 
@@ -746,7 +746,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the time series
         ///</summary>
-        [ApiMember(Description="Unique ID of the time series", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the time series", IsRequired=true, ParameterType="path")]
         public Guid TimeSeriesUniqueId { get; set; }
     }
 
@@ -757,7 +757,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the location
         ///</summary>
-        [ApiMember(Description="Unique ID of the location", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the location", IsRequired=true, ParameterType="path")]
         public Guid LocationUniqueId { get; set; }
     }
 
@@ -768,7 +768,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the time series
         ///</summary>
-        [ApiMember(Description="Unique ID of the time series", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the time series", IsRequired=true, ParameterType="path")]
         public Guid TimeSeriesUniqueId { get; set; }
     }
 
@@ -785,7 +785,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///ISO 8601 Duration Format
         ///</summary>
-        [ApiMember(Description="ISO 8601 Duration Format", DataType="Duration", IsRequired=true)]
+        [ApiMember(DataType="Duration", Description="ISO 8601 Duration Format", IsRequired=true)]
         public Duration GapTolerance { get; set; }
     }
 
@@ -801,7 +801,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///List of time series unique IDs of which the order translates to x1, x2… xN with x1 being the Master
         ///</summary>
-        [ApiMember(Description="List of time series unique IDs of which the order translates to x1, x2… xN with x1 being the Master", DataType="Array<string>", IsRequired=true)]
+        [ApiMember(DataType="Array<string>", Description="List of time series unique IDs of which the order translates to x1, x2… xN with x1 being the Master", IsRequired=true)]
         public List<Guid> TimeSeriesUniqueIds { get; set; }
 
         ///<summary>
@@ -818,7 +818,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///ISO 8601 Duration Format
         ///</summary>
-        [ApiMember(Description="ISO 8601 Duration Format", DataType="Duration", IsRequired=true)]
+        [ApiMember(DataType="Duration", Description="ISO 8601 Duration Format", IsRequired=true)]
         public Duration GapTolerance { get; set; }
     }
 
@@ -829,7 +829,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the time series
         ///</summary>
-        [ApiMember(Description="Unique ID of the time series", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the time series", IsRequired=true)]
         public Guid TimeSeriesUniqueId { get; set; }
 
         [ApiMember(IsRequired=true)]
@@ -838,31 +838,31 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///New value location
         ///</summary>
-        [ApiMember(Description="New value location", DataType="NewValueLocationType")]
+        [ApiMember(DataType="NewValueLocationType", Description="New value location")]
         public NewValueLocationType NewValueLocation { get; set; }
 
         ///<summary>
         ///Require minimum coverage
         ///</summary>
-        [ApiMember(Description="Require minimum coverage", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Require minimum coverage")]
         public bool? RequireMinimumCoverage { get; set; }
 
         ///<summary>
         ///Coverage minimum percentage
         ///</summary>
-        [ApiMember(Description="Coverage minimum percentage", DataType="double")]
+        [ApiMember(DataType="double", Description="Coverage minimum percentage")]
         public double? CoverageMinimumPercentage { get; set; }
 
         ///<summary>
         ///Partial coverage grade
         ///</summary>
-        [ApiMember(Description="Partial coverage grade", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Partial coverage grade")]
         public int? PartialCoverageGrade { get; set; }
 
         ///<summary>
         ///Observation offset in minutes
         ///</summary>
-        [ApiMember(Description="Observation offset in minutes", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Observation offset in minutes")]
         public int? ObservationOffsetInMinutes { get; set; }
     }
 
@@ -873,7 +873,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the time series
         ///</summary>
-        [ApiMember(Description="Unique ID of the time series", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the time series", IsRequired=true, ParameterType="path")]
         public Guid TimeSeriesUniqueId { get; set; }
 
         ///<summary>
@@ -891,7 +891,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Publish
         ///</summary>
-        [ApiMember(Description="Publish", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Publish")]
         public bool Publish { get; set; }
 
         ///<summary>
@@ -909,7 +909,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Extended attribute values
         ///</summary>
-        [ApiMember(Description="Extended attribute values", DataType="Array<ExtendedAttributeValue>")]
+        [ApiMember(DataType="Array<ExtendedAttributeValue>", Description="Extended attribute values")]
         public IList<ExtendedAttributeValue> ExtendedAttributeValues { get; set; }
     }
 
@@ -918,7 +918,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the location for which a time series is to be created
         ///</summary>
-        [ApiMember(Description="Unique ID of the location for which a time series is to be created", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the location for which a time series is to be created", IsRequired=true)]
         public Guid LocationUniqueId { get; set; }
 
         ///<summary>
@@ -942,7 +942,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Interpolation type
         ///</summary>
-        [ApiMember(Description="Interpolation type", DataType="InterpolationType", IsRequired=true)]
+        [ApiMember(DataType="InterpolationType", Description="Interpolation type", IsRequired=true)]
         public InterpolationType InterpolationType { get; set; }
 
         ///<summary>
@@ -954,13 +954,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///ISO 8601 Duration Format
         ///</summary>
-        [ApiMember(Description="ISO 8601 Duration Format", DataType="Offset")]
+        [ApiMember(DataType="Offset", Description="ISO 8601 Duration Format")]
         public Offset UtcOffset { get; set; }
 
         ///<summary>
         ///Publish
         ///</summary>
-        [ApiMember(Description="Publish", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Publish")]
         public bool Publish { get; set; }
 
         ///<summary>
@@ -993,7 +993,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Extended attribute values
         ///</summary>
-        [ApiMember(Description="Extended attribute values", DataType="Array<ExtendedAttributeValue>")]
+        [ApiMember(DataType="Array<ExtendedAttributeValue>", Description="Extended attribute values")]
         public IList<ExtendedAttributeValue> ExtendedAttributeValues { get; set; }
     }
 
@@ -1004,7 +1004,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the unit
         ///</summary>
-        [ApiMember(Description="Unique ID of the unit", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the unit", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -1015,7 +1015,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the unit group
         ///</summary>
-        [ApiMember(Description="Unique ID of the unit group", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the unit group", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -1026,7 +1026,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the unit group
         ///</summary>
-        [ApiMember(Description="Unique ID of the unit group", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the unit group", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -1037,7 +1037,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the unit
         ///</summary>
-        [ApiMember(Description="Unique ID of the unit", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the unit", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -1048,7 +1048,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the unit group
         ///</summary>
-        [ApiMember(Description="Unique ID of the unit group", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the unit group", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -1071,7 +1071,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the unit group
         ///</summary>
-        [ApiMember(Description="Unique ID of the unit group", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the unit group", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -1140,7 +1140,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the unit
         ///</summary>
-        [ApiMember(Description="Unique ID of the unit", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the unit", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -1151,7 +1151,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the unit group
         ///</summary>
-        [ApiMember(Description="Unique ID of the unit group", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the unit group", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
@@ -1166,13 +1166,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Base multiplier
         ///</summary>
-        [ApiMember(Description="Base multiplier", DataType="double", IsRequired=true)]
+        [ApiMember(DataType="double", Description="Base multiplier", IsRequired=true)]
         public double? BaseMultiplier { get; set; }
 
         ///<summary>
         ///Base offset
         ///</summary>
-        [ApiMember(Description="Base offset", DataType="double", IsRequired=true)]
+        [ApiMember(DataType="double", Description="Base offset", IsRequired=true)]
         public double? BaseOffset { get; set; }
 
         ///<summary>
@@ -1199,43 +1199,43 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Current dimension
         ///</summary>
-        [ApiMember(Description="Current dimension", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Current dimension")]
         public int? CurrentDimension { get; set; }
 
         ///<summary>
         ///Intensity dimension
         ///</summary>
-        [ApiMember(Description="Intensity dimension", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Intensity dimension")]
         public int? IntensityDimension { get; set; }
 
         ///<summary>
         ///Length dimension
         ///</summary>
-        [ApiMember(Description="Length dimension", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Length dimension")]
         public int? LengthDimension { get; set; }
 
         ///<summary>
         ///Mass dimension
         ///</summary>
-        [ApiMember(Description="Mass dimension", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Mass dimension")]
         public int? MassDimension { get; set; }
 
         ///<summary>
         ///Substance dimension
         ///</summary>
-        [ApiMember(Description="Substance dimension", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Substance dimension")]
         public int? SubstanceDimension { get; set; }
 
         ///<summary>
         ///Temperature dimension
         ///</summary>
-        [ApiMember(Description="Temperature dimension", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Temperature dimension")]
         public int? TemperatureDimension { get; set; }
 
         ///<summary>
         ///Time dimension
         ///</summary>
-        [ApiMember(Description="Time dimension", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Time dimension")]
         public int? TimeDimension { get; set; }
     }
 
@@ -1246,7 +1246,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the user
         ///</summary>
-        [ApiMember(Description="Unique ID of the user", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the user", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -1257,7 +1257,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the user
         ///</summary>
-        [ApiMember(Description="Unique ID of the user", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the user", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -1371,7 +1371,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the user
         ///</summary>
-        [ApiMember(Description="Unique ID of the user", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the user", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -1381,7 +1381,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the user
         ///</summary>
-        [ApiMember(Description="Unique ID of the user", ParameterType="path", DataType="string", IsRequired=true)]
+        [ApiMember(DataType="string", Description="Unique ID of the user", IsRequired=true, ParameterType="path")]
         public Guid UniqueId { get; set; }
     }
 
@@ -1396,19 +1396,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Inactive users cannot log in and are not counted in licensing
         ///</summary>
-        [ApiMember(Description="Inactive users cannot log in and are not counted in licensing", DataType="boolean", IsRequired=true)]
+        [ApiMember(DataType="boolean", Description="Inactive users cannot log in and are not counted in licensing", IsRequired=true)]
         public bool Active { get; set; }
 
         ///<summary>
         ///Allow user to run AQUARIUS Manager and edit system settings
         ///</summary>
-        [ApiMember(Description="Allow user to run AQUARIUS Manager and edit system settings", DataType="boolean", IsRequired=true)]
+        [ApiMember(DataType="boolean", Description="Allow user to run AQUARIUS Manager and edit system settings", IsRequired=true)]
         public bool CanConfigureSystem { get; set; }
 
         ///<summary>
         ///Allow user to launch the Rating Development Toolbox
         ///</summary>
-        [ApiMember(Description="Allow user to launch the Rating Development Toolbox", DataType="boolean", IsRequired=true)]
+        [ApiMember(DataType="boolean", Description="Allow user to launch the Rating Development Toolbox", IsRequired=true)]
         public bool CanLaunchRatingDevelopmentToolbox { get; set; }
 
         ///<summary>
@@ -1447,43 +1447,43 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Field type
         ///</summary>
-        [ApiMember(Description="Field type", DataType="ExtendedAttributeFieldType")]
+        [ApiMember(DataType="ExtendedAttributeFieldType", Description="Field type")]
         public ExtendedAttributeFieldType FieldType { get; set; }
 
         ///<summary>
         ///Can be empty
         ///</summary>
-        [ApiMember(Description="Can be empty", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Can be empty")]
         public bool CanBeEmpty { get; set; }
 
         ///<summary>
         ///Is read only
         ///</summary>
-        [ApiMember(Description="Is read only", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is read only")]
         public bool IsReadOnly { get; set; }
 
         ///<summary>
         ///Numeric precision
         ///</summary>
-        [ApiMember(Description="Numeric precision", DataType="short")]
+        [ApiMember(DataType="short", Description="Numeric precision")]
         public short? NumericPrecision { get; set; }
 
         ///<summary>
         ///Numeric scale
         ///</summary>
-        [ApiMember(Description="Numeric scale", DataType="short")]
+        [ApiMember(DataType="short", Description="Numeric scale")]
         public short? NumericScale { get; set; }
 
         ///<summary>
         ///Column size
         ///</summary>
-        [ApiMember(Description="Column size", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Column size")]
         public int? ColumnSize { get; set; }
 
         ///<summary>
         ///Value options
         ///</summary>
-        [ApiMember(Description="Value options", DataType="Array<string>")]
+        [ApiMember(DataType="Array<string>", Description="Value options")]
         public IReadOnlyList<string> ValueOptions { get; set; }
     }
 
@@ -1492,7 +1492,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Results
         ///</summary>
-        [ApiMember(Description="Results", DataType="Array<ExtendedAttributeField>")]
+        [ApiMember(DataType="Array<ExtendedAttributeField>", Description="Results")]
         public IList<ExtendedAttributeField> Results { get; set; }
     }
 
@@ -1525,7 +1525,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the field data plug-in
         ///</summary>
-        [ApiMember(Description="Unique ID of the field data plug-in", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique ID of the field data plug-in")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
@@ -1537,7 +1537,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Assembly qualified type name
         ///</summary>
-        [ApiMember(Description="Assembly qualified type name", DataType="string")]
+        [ApiMember(DataType="string", Description="Assembly qualified type name")]
         public string AssemblyQualifiedTypeName { get; set; }
 
         ///<summary>
@@ -1549,7 +1549,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Description
         ///</summary>
-        [ApiMember(Description="Description", DataType="string")]
+        [ApiMember(DataType="string", Description="Description")]
         public string Description { get; set; }
     }
 
@@ -1572,7 +1572,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Grade code
         ///</summary>
-        [ApiMember(Description="Grade code", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Grade code")]
         public int GradeCode { get; set; }
 
         ///<summary>
@@ -1596,7 +1596,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///True if the grade is required by the system
         ///</summary>
-        [ApiMember(Description="True if the grade is required by the system", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if the grade is required by the system")]
         public bool IsSystem { get; set; }
     }
 
@@ -1610,7 +1610,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///The list of grades
         ///</summary>
-        [ApiMember(Description="The list of grades", DataType="Array<Grade>")]
+        [ApiMember(DataType="Array<Grade>", Description="The list of grades")]
         public List<Grade> Results { get; set; }
     }
 
@@ -1631,7 +1631,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Value
         ///</summary>
-        [ApiMember(Description="Value", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Value")]
         public int Value { get; set; }
     }
 
@@ -1645,7 +1645,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///The list of interpolation types
         ///</summary>
-        [ApiMember(Description="The list of interpolation types", DataType="Array<InterpolationTypeEntry>")]
+        [ApiMember(DataType="Array<InterpolationTypeEntry>", Description="The list of interpolation types")]
         public List<InterpolationTypeEntry> Results { get; set; }
     }
 
@@ -1654,31 +1654,31 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the location
         ///</summary>
-        [ApiMember(Description="Unique ID of the location", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique ID of the location")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
         ///Identifier
         ///</summary>
-        [ApiMember(Description="Identifier")]
+        [ApiMember(DataType="string", Description="Identifier")]
         public string Identifier { get; set; }
 
         ///<summary>
         ///Location name
         ///</summary>
-        [ApiMember(Description="Location name")]
+        [ApiMember(DataType="string", Description="Location name")]
         public string LocationName { get; set; }
 
         ///<summary>
         ///Location path
         ///</summary>
-        [ApiMember(Description="Location path")]
+        [ApiMember(DataType="string", Description="Location path")]
         public string LocationPath { get; set; }
 
         ///<summary>
         ///Location type
         ///</summary>
-        [ApiMember(Description="Location type")]
+        [ApiMember(DataType="string", Description="Location type")]
         public string LocationType { get; set; }
 
         ///<summary>
@@ -1690,49 +1690,49 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Longitude
         ///</summary>
-        [ApiMember(Description="Longitude", DataType="double")]
+        [ApiMember(DataType="double", Description="Longitude")]
         public double? Longitude { get; set; }
 
         ///<summary>
         ///Latitude
         ///</summary>
-        [ApiMember(Description="Latitude", DataType="double")]
+        [ApiMember(DataType="double", Description="Latitude")]
         public double? Latitude { get; set; }
 
         ///<summary>
         ///UTC offset
         ///</summary>
-        [ApiMember(Description="UTC offset", DataType="Offset")]
+        [ApiMember(DataType="Offset", Description="UTC offset")]
         public Offset UtcOffset { get; set; }
 
         ///<summary>
         ///Last modified
         ///</summary>
-        [ApiMember(Description="Last modified", DataType="Instant")]
+        [ApiMember(DataType="Instant", Description="Last modified")]
         public Instant LastModified { get; set; }
 
         ///<summary>
         ///Elevation units
         ///</summary>
-        [ApiMember(Description="Elevation units")]
+        [ApiMember(DataType="string", Description="Elevation units")]
         public string ElevationUnits { get; set; }
 
         ///<summary>
         ///Elevation
         ///</summary>
-        [ApiMember(Description="Elevation", DataType="double")]
+        [ApiMember(DataType="double", Description="Elevation")]
         public double? Elevation { get; set; }
 
         ///<summary>
         ///Description
         ///</summary>
-        [ApiMember(Description="Description")]
+        [ApiMember(DataType="string", Description="Description")]
         public string Description { get; set; }
 
         ///<summary>
         ///Extended attribute values
         ///</summary>
-        [ApiMember(Description="Extended attribute values", DataType="Array<ExtendedAttributeValue>")]
+        [ApiMember(DataType="Array<ExtendedAttributeValue>", Description="Extended attribute values")]
         public IList<ExtendedAttributeValue> ExtendedAttributeValues { get; set; }
     }
 
@@ -1741,7 +1741,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the location folder
         ///</summary>
-        [ApiMember(Description="Unique ID of the location folder", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique ID of the location folder")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
@@ -1765,7 +1765,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the parent location folder
         ///</summary>
-        [ApiMember(Description="Unique ID of the parent location folder", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique ID of the parent location folder")]
         public Guid? ParentLocationFolderUniqueId { get; set; }
 
         ///<summary>
@@ -1785,7 +1785,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///The list of location folders
         ///</summary>
-        [ApiMember(Description="The list of location folders", DataType="Array<LocationFolder>")]
+        [ApiMember(DataType="Array<LocationFolder>", Description="The list of location folders")]
         public List<LocationFolder> Results { get; set; }
     }
 
@@ -1812,13 +1812,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the location type
         ///</summary>
-        [ApiMember(Description="Unique ID of the location type", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique ID of the location type")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
         ///Extended attribute field definitions for this location type
         ///</summary>
-        [ApiMember(Description="Extended attribute field definitions for this location type", DataType="Array<ExtendedAttributeField>")]
+        [ApiMember(DataType="Array<ExtendedAttributeField>", Description="Extended attribute field definitions for this location type")]
         public IList<ExtendedAttributeField> ExtendedAttributeFields { get; set; }
     }
 
@@ -1832,7 +1832,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///The list of location types
         ///</summary>
-        [ApiMember(Description="The list of location types", DataType="Array<LocationType>")]
+        [ApiMember(DataType="Array<LocationType>", Description="The list of location types")]
         public List<LocationType> Results { get; set; }
     }
 
@@ -1865,7 +1865,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the parameter
         ///</summary>
-        [ApiMember(Description="Unique ID of the parameter", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique ID of the parameter")]
         public Guid ParameterUniqueId { get; set; }
 
         ///<summary>
@@ -1883,7 +1883,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///True if the monitoring method is required by system
         ///</summary>
-        [ApiMember(Description="True if the monitoring method is required by system", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if the monitoring method is required by system")]
         public bool System { get; set; }
     }
 
@@ -1897,7 +1897,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///The list of monitoring methods
         ///</summary>
-        [ApiMember(Description="The list of monitoring methods", DataType="Array<MonitoringMethod>")]
+        [ApiMember(DataType="Array<MonitoringMethod>", Description="The list of monitoring methods")]
         public List<MonitoringMethod> Results { get; set; }
     }
 
@@ -1930,13 +1930,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Scopes
         ///</summary>
-        [ApiMember(Description="Scopes", DataType="Array<string>")]
+        [ApiMember(DataType="Array<string>", Description="Scopes")]
         public List<string> Scopes { get; set; }
 
         ///<summary>
         ///Hosted domains
         ///</summary>
-        [ApiMember(Description="Hosted domains", DataType="Array<string>")]
+        [ApiMember(DataType="Array<string>", Description="Hosted domains")]
         public List<string> HostedDomains { get; set; }
     }
 
@@ -1945,7 +1945,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the parameter
         ///</summary>
-        [ApiMember(Description="Unique ID of the parameter", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique ID of the parameter")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
@@ -1981,19 +1981,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Min value
         ///</summary>
-        [ApiMember(Description="Min value", DataType="double")]
+        [ApiMember(DataType="double", Description="Min value")]
         public double? MinValue { get; set; }
 
         ///<summary>
         ///Max value
         ///</summary>
-        [ApiMember(Description="Max value", DataType="double")]
+        [ApiMember(DataType="double", Description="Max value")]
         public double? MaxValue { get; set; }
 
         ///<summary>
         ///Interpolation type
         ///</summary>
-        [ApiMember(Description="Interpolation type", DataType="InterpolationType")]
+        [ApiMember(DataType="InterpolationType", Description="Interpolation type")]
         public InterpolationType InterpolationType { get; set; }
 
         ///<summary>
@@ -2005,7 +2005,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///True if the parameter is required by the system
         ///</summary>
-        [ApiMember(Description="True if the parameter is required by the system", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if the parameter is required by the system")]
         public bool System { get; set; }
     }
 
@@ -2019,7 +2019,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///The list of parameters
         ///</summary>
-        [ApiMember(Description="The list of parameters", DataType="Array<Parameter>")]
+        [ApiMember(DataType="Array<Parameter>", Description="The list of parameters")]
         public List<Parameter> Results { get; set; }
     }
 
@@ -2029,7 +2029,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///The list of units within the group
         ///</summary>
-        [ApiMember(Description="The list of units within the group", DataType="Array<Unit>")]
+        [ApiMember(DataType="Array<Unit>", Description="The list of units within the group")]
         public IReadOnlyList<Unit> Units { get; set; }
     }
 
@@ -2043,7 +2043,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///The list of unit groups
         ///</summary>
-        [ApiMember(Description="The list of unit groups", DataType="Array<PopulatedUnitGroup>")]
+        [ApiMember(DataType="Array<PopulatedUnitGroup>", Description="The list of unit groups")]
         public List<PopulatedUnitGroup> Results { get; set; }
     }
 
@@ -2066,7 +2066,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///The list of standard datums
         ///</summary>
-        [ApiMember(Description="The list of standard datums", DataType="Array<StandardDatum>")]
+        [ApiMember(DataType="Array<StandardDatum>", Description="The list of standard datums")]
         public List<StandardDatum> Results { get; set; }
     }
 
@@ -2081,7 +2081,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the time series
         ///</summary>
-        [ApiMember(Description="Unique ID of the time series", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique ID of the time series")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
@@ -2105,7 +2105,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Publish
         ///</summary>
-        [ApiMember(Description="Publish", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Publish")]
         public bool Publish { get; set; }
 
         ///<summary>
@@ -2123,7 +2123,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Unique ID of the location
         ///</summary>
-        [ApiMember(Description="Unique ID of the location", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique ID of the location")]
         public Guid LocationUniqueId { get; set; }
 
         ///<summary>
@@ -2135,7 +2135,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Time series type
         ///</summary>
-        [ApiMember(Description="Time series type", DataType="TimeSeriesType")]
+        [ApiMember(DataType="TimeSeriesType", Description="Time series type")]
         public TimeSeriesType TimeSeriesType { get; set; }
 
         ///<summary>
@@ -2153,7 +2153,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///UTC offset
         ///</summary>
-        [ApiMember(Description="UTC offset", DataType="Offset")]
+        [ApiMember(DataType="Offset", Description="UTC offset")]
         public Offset UtcOffset { get; set; }
 
         ///<summary>
@@ -2171,13 +2171,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Last modified time
         ///</summary>
-        [ApiMember(Description="Last modified time", DataType="Instant")]
+        [ApiMember(DataType="Instant", Description="Last modified time")]
         public Instant LastModifiedTime { get; set; }
 
         ///<summary>
         ///Extended attribute values
         ///</summary>
-        [ApiMember(Description="Extended attribute values", DataType="Array<ExtendedAttributeValue>")]
+        [ApiMember(DataType="Array<ExtendedAttributeValue>", Description="Extended attribute values")]
         public IList<ExtendedAttributeValue> ExtendedAttributeValues { get; set; }
     }
 
@@ -2191,7 +2191,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///The lsit of time series
         ///</summary>
-        [ApiMember(Description="The lsit of time series", DataType="Array<TimeSeries>")]
+        [ApiMember(DataType="Array<TimeSeries>", Description="The lsit of time series")]
         public List<TimeSeries> Results { get; set; }
     }
 
@@ -2212,25 +2212,25 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///Base multiplier
         ///</summary>
-        [ApiMember(Description="Base multiplier", DataType="double")]
+        [ApiMember(DataType="double", Description="Base multiplier")]
         public double BaseMultiplier { get; set; }
 
         ///<summary>
         ///Base offset
         ///</summary>
-        [ApiMember(Description="Base offset", DataType="double")]
+        [ApiMember(DataType="double", Description="Base offset")]
         public double BaseOffset { get; set; }
 
         ///<summary>
         ///True if the unit is required by the system
         ///</summary>
-        [ApiMember(Description="True if the unit is required by the system", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if the unit is required by the system")]
         public bool IsSystem { get; set; }
 
         ///<summary>
         ///Unique ID of the unit
         ///</summary>
-        [ApiMember(Description="Unique ID of the unit", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique ID of the unit")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
@@ -2269,55 +2269,55 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///True if the unit group is required by the system
         ///</summary>
-        [ApiMember(Description="True if the unit group is required by the system", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if the unit group is required by the system")]
         public bool IsSystem { get; set; }
 
         ///<summary>
         ///Current dimension
         ///</summary>
-        [ApiMember(Description="Current dimension", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Current dimension")]
         public int CurrentDimension { get; set; }
 
         ///<summary>
         ///Intensity dimension
         ///</summary>
-        [ApiMember(Description="Intensity dimension", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Intensity dimension")]
         public int IntensityDimension { get; set; }
 
         ///<summary>
         ///Length dimension
         ///</summary>
-        [ApiMember(Description="Length dimension", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Length dimension")]
         public int LengthDimension { get; set; }
 
         ///<summary>
         ///Mass dimension
         ///</summary>
-        [ApiMember(Description="Mass dimension", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Mass dimension")]
         public int MassDimension { get; set; }
 
         ///<summary>
         ///Substance dimension
         ///</summary>
-        [ApiMember(Description="Substance dimension", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Substance dimension")]
         public int SubstanceDimension { get; set; }
 
         ///<summary>
         ///Temperature dimension
         ///</summary>
-        [ApiMember(Description="Temperature dimension", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Temperature dimension")]
         public int TemperatureDimension { get; set; }
 
         ///<summary>
         ///Time dimension
         ///</summary>
-        [ApiMember(Description="Time dimension", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Time dimension")]
         public int TimeDimension { get; set; }
 
         ///<summary>
         ///Unique ID of the unit group
         ///</summary>
-        [ApiMember(Description="Unique ID of the unit group", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique ID of the unit group")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
@@ -2337,7 +2337,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///The list of unit groups
         ///</summary>
-        [ApiMember(Description="The list of unit groups", DataType="Array<UnitGroup>")]
+        [ApiMember(DataType="Array<UnitGroup>", Description="The list of unit groups")]
         public List<UnitGroup> Results { get; set; }
     }
 
@@ -2351,7 +2351,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///The list of units
         ///</summary>
-        [ApiMember(Description="The list of units", DataType="Array<Unit>")]
+        [ApiMember(DataType="Array<Unit>", Description="The list of units")]
         public List<Unit> Results { get; set; }
     }
 
@@ -2390,31 +2390,31 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///True if the user is allowed to log into the system
         ///</summary>
-        [ApiMember(Description="True if the user is allowed to log into the system", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if the user is allowed to log into the system")]
         public bool Active { get; set; }
 
         ///<summary>
         ///True if the user is required to exist in the system
         ///</summary>
-        [ApiMember(Description="True if the user is required to exist in the system", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if the user is required to exist in the system")]
         public bool System { get; set; }
 
         ///<summary>
         ///True if the user has the 'Can Configure System' right
         ///</summary>
-        [ApiMember(Description="True if the user has the 'Can Configure System' right", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if the user has the 'Can Configure System' right")]
         public bool CanConfigureSystem { get; set; }
 
         ///<summary>
         ///True if the user is licenced to launch the Rating Development toolbox
         ///</summary>
-        [ApiMember(Description="True if the user is licenced to launch the Rating Development toolbox", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if the user is licenced to launch the Rating Development toolbox")]
         public bool CanLaunchRatingDevelopmentToolbox { get; set; }
 
         ///<summary>
         ///Unique ID of the user
         ///</summary>
-        [ApiMember(Description="Unique ID of the user", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique ID of the user")]
         public Guid UniqueId { get; set; }
     }
 
@@ -2428,7 +2428,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///<summary>
         ///The list of users
         ///</summary>
-        [ApiMember(Description="The list of users", DataType="Array<User>")]
+        [ApiMember(DataType="Array<User>", Description="The list of users")]
         public List<User> Results { get; set; }
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
@@ -83,7 +83,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///RSA key size in bits
         ///</summary>
-        [ApiMember(Description="RSA key size in bits", DataType="integer")]
+        [ApiMember(DataType="integer", Description="RSA key size in bits")]
         public int KeySize { get; set; }
 
         ///<summary>
@@ -99,13 +99,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Approval level
         ///</summary>
-        [ApiMember(Description="Approval level", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Approval level")]
         public int ApprovalLevel { get; set; }
 
         ///<summary>
         ///Date applied utc
         ///</summary>
-        [ApiMember(Description="Date applied utc", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Date applied utc")]
         public DateTime DateAppliedUtc { get; set; }
 
         ///<summary>
@@ -158,25 +158,25 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Type
         ///</summary>
-        [ApiMember(Description="Type", DataType="CorrectionType")]
+        [ApiMember(DataType="CorrectionType", Description="Type")]
         public CorrectionType Type { get; set; }
 
         ///<summary>
         ///Start time
         ///</summary>
-        [ApiMember(Description="Start time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Start time")]
         public DateTimeOffset StartTime { get; set; }
 
         ///<summary>
         ///End time
         ///</summary>
-        [ApiMember(Description="End time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="End time")]
         public DateTimeOffset EndTime { get; set; }
 
         ///<summary>
         ///Applied time utc
         ///</summary>
-        [ApiMember(Description="Applied time utc", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Applied time utc")]
         public DateTime AppliedTimeUtc { get; set; }
 
         ///<summary>
@@ -195,7 +195,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Processing order
         ///</summary>
-        [ApiMember(Description="Processing order", DataType="CorrectionProcessingOrder")]
+        [ApiMember(DataType="CorrectionProcessingOrder", Description="Processing order")]
         public CorrectionProcessingOrder ProcessingOrder { get; set; }
     }
 
@@ -205,20 +205,20 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Type
         ///</summary>
-        [ApiMember(Description="Type", DataType="CorrectionType")]
+        [ApiMember(DataType="CorrectionType", Description="Type")]
         public CorrectionType Type { get; set; }
 
         public IDictionary<string, Object> Parameters { get; set; }
         ///<summary>
         ///Processing order
         ///</summary>
-        [ApiMember(Description="Processing order", DataType="CorrectionProcessingOrder")]
+        [ApiMember(DataType="CorrectionProcessingOrder", Description="Processing order")]
         public CorrectionProcessingOrder ProcessingOrder { get; set; }
 
         ///<summary>
         ///Date applied utc
         ///</summary>
-        [ApiMember(Description="Date applied utc", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Date applied utc")]
         public DateTime DateAppliedUtc { get; set; }
 
         ///<summary>
@@ -230,13 +230,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Operation type
         ///</summary>
-        [ApiMember(Description="Operation type", DataType="MetadataChangeOperationType")]
+        [ApiMember(DataType="MetadataChangeOperationType", Description="Operation type")]
         public MetadataChangeOperationType OperationType { get; set; }
 
         ///<summary>
         ///Stack position
         ///</summary>
-        [ApiMember(Description="Stack position", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Stack position")]
         public int StackPosition { get; set; }
 
         ///<summary>
@@ -284,7 +284,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Numeric
         ///</summary>
-        [ApiMember(Description="Numeric", DataType="double")]
+        [ApiMember(DataType="double", Description="Numeric")]
         public double? Numeric { get; set; }
 
         ///<summary>
@@ -299,13 +299,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Timestamp
         ///</summary>
-        [ApiMember(Description="Timestamp", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Timestamp")]
         public DateTimeOffset Timestamp { get; set; }
 
         ///<summary>
         ///Value
         ///</summary>
-        [ApiMember(Description="Value", DataType="double")]
+        [ApiMember(DataType="double", Description="Value")]
         public double? Value { get; set; }
     }
 
@@ -329,7 +329,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Type
         ///</summary>
-        [ApiMember(Description="Type", DataType="RatingCurveType")]
+        [ApiMember(DataType="RatingCurveType", Description="Type")]
         public RatingCurveType Type { get; set; }
 
         ///<summary>
@@ -341,49 +341,49 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Input parameter
         ///</summary>
-        [ApiMember(Description="Input parameter", DataType="ParameterWithUnit")]
+        [ApiMember(DataType="ParameterWithUnit", Description="Input parameter")]
         public ParameterWithUnit InputParameter { get; set; }
 
         ///<summary>
         ///Output parameter
         ///</summary>
-        [ApiMember(Description="Output parameter", DataType="ParameterWithUnit")]
+        [ApiMember(DataType="ParameterWithUnit", Description="Output parameter")]
         public ParameterWithUnit OutputParameter { get; set; }
 
         ///<summary>
         ///Periods of applicability
         ///</summary>
-        [ApiMember(Description="Periods of applicability", DataType="Array<PeriodOfApplicability>")]
+        [ApiMember(DataType="Array<PeriodOfApplicability>", Description="Periods of applicability")]
         public List<PeriodOfApplicability> PeriodsOfApplicability { get; set; }
 
         ///<summary>
         ///Shifts
         ///</summary>
-        [ApiMember(Description="Shifts", DataType="Array<RatingShift>")]
+        [ApiMember(DataType="Array<RatingShift>", Description="Shifts")]
         public List<RatingShift> Shifts { get; set; }
 
         ///<summary>
         ///Offsets
         ///</summary>
-        [ApiMember(Description="Offsets", DataType="Array<OffsetPoint>")]
+        [ApiMember(DataType="Array<OffsetPoint>", Description="Offsets")]
         public List<OffsetPoint> Offsets { get; set; }
 
         ///<summary>
         ///Is blended
         ///</summary>
-        [ApiMember(Description="Is blended", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is blended")]
         public bool IsBlended { get; set; }
 
         ///<summary>
         ///Base rating table
         ///</summary>
-        [ApiMember(Description="Base rating table", DataType="Array<RatingPoint>")]
+        [ApiMember(DataType="Array<RatingPoint>", Description="Base rating table")]
         public List<RatingPoint> BaseRatingTable { get; set; }
 
         ///<summary>
         ///Adjusted rating table
         ///</summary>
-        [ApiMember(Description="Adjusted rating table", DataType="Array<RatingPoint>")]
+        [ApiMember(DataType="Array<RatingPoint>", Description="Adjusted rating table")]
         public List<RatingPoint> AdjustedRatingTable { get; set; }
     }
 
@@ -404,7 +404,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Value
         ///</summary>
-        [ApiMember(Description="Value", DataType="object")]
+        [ApiMember(DataType="object", Description="Value")]
         public Object Value { get; set; }
     }
 
@@ -440,13 +440,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Start time
         ///</summary>
-        [ApiMember(Description="Start time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Start time")]
         public DateTimeOffset? StartTime { get; set; }
 
         ///<summary>
         ///End time
         ///</summary>
-        [ApiMember(Description="End time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="End time")]
         public DateTimeOffset? EndTime { get; set; }
 
         ///<summary>
@@ -470,19 +470,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Is valid
         ///</summary>
-        [ApiMember(Description="Is valid", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is valid")]
         public bool IsValid { get; set; }
 
         ///<summary>
         ///Completed work
         ///</summary>
-        [ApiMember(Description="Completed work", DataType="CompletedWork")]
+        [ApiMember(DataType="CompletedWork", Description="Completed work")]
         public CompletedWork CompletedWork { get; set; }
 
         ///<summary>
         ///Last modified
         ///</summary>
-        [ApiMember(Description="Last modified", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Last modified")]
         public DateTimeOffset LastModified { get; set; }
     }
 
@@ -492,7 +492,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Tolerance in minutes
         ///</summary>
-        [ApiMember(Description="Tolerance in minutes", DataType="double")]
+        [ApiMember(DataType="double", Description="Tolerance in minutes")]
         public double? ToleranceInMinutes { get; set; }
     }
 
@@ -502,13 +502,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Operation type
         ///</summary>
-        [ApiMember(Description="Operation type", DataType="MetadataChangeOperationType")]
+        [ApiMember(DataType="MetadataChangeOperationType", Description="Operation type")]
         public MetadataChangeOperationType OperationType { get; set; }
 
         ///<summary>
         ///Date applied utc
         ///</summary>
-        [ApiMember(Description="Date applied utc", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Date applied utc")]
         public DateTime DateAppliedUtc { get; set; }
 
         ///<summary>
@@ -520,7 +520,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Stack position
         ///</summary>
-        [ApiMember(Description="Stack position", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Stack position")]
         public int StackPosition { get; set; }
 
         ///<summary>
@@ -573,7 +573,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Date applied utc
         ///</summary>
-        [ApiMember(Description="Date applied utc", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Date applied utc")]
         public DateTime DateAppliedUtc { get; set; }
 
         ///<summary>
@@ -585,13 +585,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Operation type
         ///</summary>
-        [ApiMember(Description="Operation type", DataType="MetadataChangeOperationType")]
+        [ApiMember(DataType="MetadataChangeOperationType", Description="Operation type")]
         public MetadataChangeOperationType OperationType { get; set; }
 
         ///<summary>
         ///Stack position
         ///</summary>
-        [ApiMember(Description="Stack position", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Stack position")]
         public int StackPosition { get; set; }
 
         ///<summary>
@@ -617,7 +617,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Date applied utc
         ///</summary>
-        [ApiMember(Description="Date applied utc", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Date applied utc")]
         public DateTime DateAppliedUtc { get; set; }
 
         ///<summary>
@@ -629,13 +629,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Operation type
         ///</summary>
-        [ApiMember(Description="Operation type", DataType="MetadataChangeOperationType")]
+        [ApiMember(DataType="MetadataChangeOperationType", Description="Operation type")]
         public MetadataChangeOperationType OperationType { get; set; }
 
         ///<summary>
         ///Stack position
         ///</summary>
-        [ApiMember(Description="Stack position", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Stack position")]
         public int StackPosition { get; set; }
 
         ///<summary>
@@ -655,13 +655,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Reference standard
         ///</summary>
-        [ApiMember(Description="Reference standard", DataType="LocationReferenceStandard")]
+        [ApiMember(DataType="LocationReferenceStandard", Description="Reference standard")]
         public LocationReferenceStandard ReferenceStandard { get; set; }
 
         ///<summary>
         ///Datum periods
         ///</summary>
-        [ApiMember(Description="Datum periods", DataType="Array<LocationDatumPeriod>")]
+        [ApiMember(DataType="Array<LocationDatumPeriod>", Description="Datum periods")]
         public List<LocationDatumPeriod> DatumPeriods { get; set; }
     }
 
@@ -676,7 +676,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Time range
         ///</summary>
-        [ApiMember(Description="Time range", DataType="TimeRange")]
+        [ApiMember(DataType="TimeRange", Description="Time range")]
         public TimeRange TimeRange { get; set; }
 
         ///<summary>
@@ -688,13 +688,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Offset to standard
         ///</summary>
-        [ApiMember(Description="Offset to standard", DataType="double")]
+        [ApiMember(DataType="double", Description="Offset to standard")]
         public double OffsetToStandard { get; set; }
 
         ///<summary>
         ///Measurement direction
         ///</summary>
-        [ApiMember(Description="Measurement direction", DataType="MeasurementDirection")]
+        [ApiMember(DataType="MeasurementDirection", Description="Measurement direction")]
         public MeasurementDirection MeasurementDirection { get; set; }
 
         ///<summary>
@@ -706,7 +706,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Applied time utc
         ///</summary>
-        [ApiMember(Description="Applied time utc", DataType="Instant")]
+        [ApiMember(DataType="Instant", Description="Applied time utc")]
         public Instant AppliedTimeUtc { get; set; }
 
         ///<summary>
@@ -738,13 +738,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Unique id
         ///</summary>
-        [ApiMember(Description="Unique id", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique id")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
         ///External locations are created by data connectors.
         ///</summary>
-        [ApiMember(Description="External locations are created by data connectors.", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="External locations are created by data connectors.")]
         public bool IsExternalLocation { get; set; }
 
         ///<summary>
@@ -756,13 +756,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Secondary folders
         ///</summary>
-        [ApiMember(Description="Secondary folders", DataType="Array<string>")]
+        [ApiMember(DataType="Array<string>", Description="Secondary folders")]
         public List<string> SecondaryFolders { get; set; }
 
         ///<summary>
         ///Last modified
         ///</summary>
-        [ApiMember(Description="Last modified", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Last modified")]
         public DateTimeOffset LastModified { get; set; }
     }
 
@@ -815,7 +815,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Reference standard offsets
         ///</summary>
-        [ApiMember(Description="Reference standard offsets", DataType="Array<ReferenceStandardOffset>")]
+        [ApiMember(DataType="Array<ReferenceStandardOffset>", Description="Reference standard offsets")]
         public List<ReferenceStandardOffset> ReferenceStandardOffsets { get; set; }
     }
 
@@ -824,19 +824,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Create time
         ///</summary>
-        [ApiMember(Description="Create time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Create time")]
         public DateTimeOffset? CreateTime { get; set; }
 
         ///<summary>
         ///From time
         ///</summary>
-        [ApiMember(Description="From time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="From time")]
         public DateTimeOffset? FromTime { get; set; }
 
         ///<summary>
         ///To time
         ///</summary>
-        [ApiMember(Description="To time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="To time")]
         public DateTimeOffset? ToTime { get; set; }
 
         ///<summary>
@@ -882,7 +882,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Applied time
         ///</summary>
-        [ApiMember(Description="Applied time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Applied time")]
         public DateTimeOffset AppliedTime { get; set; }
 
         ///<summary>
@@ -894,49 +894,49 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Content type
         ///</summary>
-        [ApiMember(Description="Content type", DataType="MetadataChangeContentType")]
+        [ApiMember(DataType="MetadataChangeContentType", Description="Content type")]
         public MetadataChangeContentType ContentType { get; set; }
 
         ///<summary>
         ///Gap tolerance operations
         ///</summary>
-        [ApiMember(Description="Gap tolerance operations", DataType="Array<GapToleranceOperation>")]
+        [ApiMember(DataType="Array<GapToleranceOperation>", Description="Gap tolerance operations")]
         public IList<GapToleranceOperation> GapToleranceOperations { get; set; }
 
         ///<summary>
         ///Grade operations
         ///</summary>
-        [ApiMember(Description="Grade operations", DataType="Array<GradeOperation>")]
+        [ApiMember(DataType="Array<GradeOperation>", Description="Grade operations")]
         public IList<GradeOperation> GradeOperations { get; set; }
 
         ///<summary>
         ///Interpolation type operations
         ///</summary>
-        [ApiMember(Description="Interpolation type operations", DataType="Array<InterpolationTypeOperation>")]
+        [ApiMember(DataType="Array<InterpolationTypeOperation>", Description="Interpolation type operations")]
         public IList<InterpolationTypeOperation> InterpolationTypeOperations { get; set; }
 
         ///<summary>
         ///Method operations
         ///</summary>
-        [ApiMember(Description="Method operations", DataType="Array<MethodOperation>")]
+        [ApiMember(DataType="Array<MethodOperation>", Description="Method operations")]
         public IList<MethodOperation> MethodOperations { get; set; }
 
         ///<summary>
         ///Note operations
         ///</summary>
-        [ApiMember(Description="Note operations", DataType="Array<NoteOperation>")]
+        [ApiMember(DataType="Array<NoteOperation>", Description="Note operations")]
         public IList<NoteOperation> NoteOperations { get; set; }
 
         ///<summary>
         ///Qualifier operations
         ///</summary>
-        [ApiMember(Description="Qualifier operations", DataType="Array<QualifierOperation>")]
+        [ApiMember(DataType="Array<QualifierOperation>", Description="Qualifier operations")]
         public IList<QualifierOperation> QualifierOperations { get; set; }
 
         ///<summary>
         ///Correction operations
         ///</summary>
-        [ApiMember(Description="Correction operations", DataType="Array<CorrectionOperation>")]
+        [ApiMember(DataType="Array<CorrectionOperation>", Description="Correction operations")]
         public IList<CorrectionOperation> CorrectionOperations { get; set; }
     }
 
@@ -956,7 +956,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Date applied utc
         ///</summary>
-        [ApiMember(Description="Date applied utc", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Date applied utc")]
         public DateTime DateAppliedUtc { get; set; }
 
         ///<summary>
@@ -968,13 +968,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Operation type
         ///</summary>
-        [ApiMember(Description="Operation type", DataType="MetadataChangeOperationType")]
+        [ApiMember(DataType="MetadataChangeOperationType", Description="Operation type")]
         public MetadataChangeOperationType OperationType { get; set; }
 
         ///<summary>
         ///Stack position
         ///</summary>
-        [ApiMember(Description="Stack position", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Stack position")]
         public int StackPosition { get; set; }
 
         ///<summary>
@@ -1033,7 +1033,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Date applied utc
         ///</summary>
-        [ApiMember(Description="Date applied utc", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Date applied utc")]
         public DateTime DateAppliedUtc { get; set; }
 
         ///<summary>
@@ -1045,7 +1045,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Operation type
         ///</summary>
-        [ApiMember(Description="Operation type", DataType="MetadataChangeOperationType")]
+        [ApiMember(DataType="MetadataChangeOperationType", Description="Operation type")]
         public MetadataChangeOperationType OperationType { get; set; }
     }
 
@@ -1054,13 +1054,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Input value
         ///</summary>
-        [ApiMember(Description="Input value", DataType="double")]
+        [ApiMember(DataType="double", Description="Input value")]
         public double? InputValue { get; set; }
 
         ///<summary>
         ///Offset
         ///</summary>
-        [ApiMember(Description="Offset", DataType="double")]
+        [ApiMember(DataType="double", Description="Offset")]
         public double Offset { get; set; }
     }
 
@@ -1123,13 +1123,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Start time
         ///</summary>
-        [ApiMember(Description="Start time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Start time")]
         public DateTimeOffset StartTime { get; set; }
 
         ///<summary>
         ///End time
         ///</summary>
-        [ApiMember(Description="End time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="End time")]
         public DateTimeOffset EndTime { get; set; }
 
         ///<summary>
@@ -1156,19 +1156,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Input time series unique ids
         ///</summary>
-        [ApiMember(Description="Input time series unique ids", DataType="Array<string>")]
+        [ApiMember(DataType="Array<string>", Description="Input time series unique ids")]
         public List<Guid> InputTimeSeriesUniqueIds { get; set; }
 
         ///<summary>
         ///Output time series unique id
         ///</summary>
-        [ApiMember(Description="Output time series unique id", DataType="string")]
+        [ApiMember(DataType="string", Description="Output time series unique id")]
         public Guid OutputTimeSeriesUniqueId { get; set; }
 
         ///<summary>
         ///Processor period
         ///</summary>
-        [ApiMember(Description="Processor period", DataType="TimeRange")]
+        [ApiMember(DataType="TimeRange", Description="Processor period")]
         public TimeRange ProcessorPeriod { get; set; }
 
         ///<summary>
@@ -1198,7 +1198,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Date applied
         ///</summary>
-        [ApiMember(Description="Date applied", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Date applied")]
         public DateTime DateApplied { get; set; }
 
         ///<summary>
@@ -1241,13 +1241,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Operation type
         ///</summary>
-        [ApiMember(Description="Operation type", DataType="MetadataChangeOperationType")]
+        [ApiMember(DataType="MetadataChangeOperationType", Description="Operation type")]
         public MetadataChangeOperationType OperationType { get; set; }
 
         ///<summary>
         ///Date applied utc
         ///</summary>
-        [ApiMember(Description="Date applied utc", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Date applied utc")]
         public DateTime DateAppliedUtc { get; set; }
 
         ///<summary>
@@ -1276,7 +1276,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Type
         ///</summary>
-        [ApiMember(Description="Type", DataType="RatingCurveType")]
+        [ApiMember(DataType="RatingCurveType", Description="Type")]
         public RatingCurveType Type { get; set; }
 
         ///<summary>
@@ -1294,37 +1294,37 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Input parameter
         ///</summary>
-        [ApiMember(Description="Input parameter", DataType="ParameterWithUnit")]
+        [ApiMember(DataType="ParameterWithUnit", Description="Input parameter")]
         public ParameterWithUnit InputParameter { get; set; }
 
         ///<summary>
         ///Output parameter
         ///</summary>
-        [ApiMember(Description="Output parameter", DataType="ParameterWithUnit")]
+        [ApiMember(DataType="ParameterWithUnit", Description="Output parameter")]
         public ParameterWithUnit OutputParameter { get; set; }
 
         ///<summary>
         ///Periods of applicability
         ///</summary>
-        [ApiMember(Description="Periods of applicability", DataType="Array<PeriodOfApplicability>")]
+        [ApiMember(DataType="Array<PeriodOfApplicability>", Description="Periods of applicability")]
         public List<PeriodOfApplicability> PeriodsOfApplicability { get; set; }
 
         ///<summary>
         ///Shifts
         ///</summary>
-        [ApiMember(Description="Shifts", DataType="Array<RatingShift>")]
+        [ApiMember(DataType="Array<RatingShift>", Description="Shifts")]
         public List<RatingShift> Shifts { get; set; }
 
         ///<summary>
         ///Base rating table
         ///</summary>
-        [ApiMember(Description="Base rating table", DataType="Array<RatingPoint>")]
+        [ApiMember(DataType="Array<RatingPoint>", Description="Base rating table")]
         public List<RatingPoint> BaseRatingTable { get; set; }
 
         ///<summary>
         ///Offsets
         ///</summary>
-        [ApiMember(Description="Offsets", DataType="Array<OffsetPoint>")]
+        [ApiMember(DataType="Array<OffsetPoint>", Description="Offsets")]
         public List<OffsetPoint> Offsets { get; set; }
     }
 
@@ -1402,13 +1402,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Last modified
         ///</summary>
-        [ApiMember(Description="Last modified", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Last modified")]
         public DateTimeOffset LastModified { get; set; }
 
         ///<summary>
         ///Publish
         ///</summary>
-        [ApiMember(Description="Publish", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Publish")]
         public bool Publish { get; set; }
     }
 
@@ -1417,13 +1417,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Input value
         ///</summary>
-        [ApiMember(Description="Input value", DataType="double")]
+        [ApiMember(DataType="double", Description="Input value")]
         public double? InputValue { get; set; }
 
         ///<summary>
         ///Output value
         ///</summary>
-        [ApiMember(Description="Output value", DataType="double")]
+        [ApiMember(DataType="double", Description="Output value")]
         public double? OutputValue { get; set; }
     }
 
@@ -1437,13 +1437,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Period of applicability
         ///</summary>
-        [ApiMember(Description="Period of applicability", DataType="PeriodOfApplicability")]
+        [ApiMember(DataType="PeriodOfApplicability", Description="Period of applicability")]
         public PeriodOfApplicability PeriodOfApplicability { get; set; }
 
         ///<summary>
         ///Shift points
         ///</summary>
-        [ApiMember(Description="Shift points", DataType="Array<RatingShiftPoint>")]
+        [ApiMember(DataType="Array<RatingShiftPoint>", Description="Shift points")]
         public List<RatingShiftPoint> ShiftPoints { get; set; }
     }
 
@@ -1452,13 +1452,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Input value
         ///</summary>
-        [ApiMember(Description="Input value", DataType="double")]
+        [ApiMember(DataType="double", Description="Input value")]
         public double InputValue { get; set; }
 
         ///<summary>
         ///Shift
         ///</summary>
-        [ApiMember(Description="Shift", DataType="double")]
+        [ApiMember(DataType="double", Description="Shift")]
         public double Shift { get; set; }
     }
 
@@ -1473,7 +1473,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Offset to reference standard
         ///</summary>
-        [ApiMember(Description="Offset to reference standard", DataType="double")]
+        [ApiMember(DataType="double", Description="Offset to reference standard")]
         public double OffsetToReferenceStandard { get; set; }
     }
 
@@ -1482,19 +1482,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Input value
         ///</summary>
-        [ApiMember(Description="Input value", DataType="double")]
+        [ApiMember(DataType="double", Description="Input value")]
         public double InputValue { get; set; }
 
         ///<summary>
         ///Correction
         ///</summary>
-        [ApiMember(Description="Correction", DataType="double")]
+        [ApiMember(DataType="double", Description="Correction")]
         public double Correction { get; set; }
 
         ///<summary>
         ///Corrected value
         ///</summary>
-        [ApiMember(Description="Corrected value", DataType="double")]
+        [ApiMember(DataType="double", Description="Corrected value")]
         public double CorrectedValue { get; set; }
     }
 
@@ -1503,13 +1503,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Date time offset
         ///</summary>
-        [ApiMember(Description="Date time offset", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Date time offset")]
         public DateTimeOffset DateTimeOffset { get; set; }
 
         ///<summary>
         ///Represents end of time period
         ///</summary>
-        [ApiMember(Description="Represents end of time period", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Represents end of time period")]
         public bool RepresentsEndOfTimePeriod { get; set; }
     }
 
@@ -1518,13 +1518,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Start time
         ///</summary>
-        [ApiMember(Description="Start time", DataType="StatisticalDateTimeOffset")]
+        [ApiMember(DataType="StatisticalDateTimeOffset", Description="Start time")]
         public StatisticalDateTimeOffset StartTime { get; set; }
 
         ///<summary>
         ///End time
         ///</summary>
-        [ApiMember(Description="End time", DataType="StatisticalDateTimeOffset")]
+        [ApiMember(DataType="StatisticalDateTimeOffset", Description="End time")]
         public StatisticalDateTimeOffset EndTime { get; set; }
     }
 
@@ -2022,7 +2022,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Unique id
         ///</summary>
-        [ApiMember(Description="Unique id", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique id")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
@@ -2067,13 +2067,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Start time
         ///</summary>
-        [ApiMember(Description="Start time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Start time")]
         public DateTimeOffset StartTime { get; set; }
 
         ///<summary>
         ///End time
         ///</summary>
-        [ApiMember(Description="End time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="End time")]
         public DateTimeOffset EndTime { get; set; }
     }
 
@@ -2088,7 +2088,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Unique id
         ///</summary>
-        [ApiMember(Description="Unique id", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique id")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
@@ -2112,31 +2112,31 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Utc offset
         ///</summary>
-        [ApiMember(Description="Utc offset", DataType="double")]
+        [ApiMember(DataType="double", Description="Utc offset")]
         public double UtcOffset { get; set; }
 
         ///<summary>
         ///Utc offset iso duration
         ///</summary>
-        [ApiMember(Description="Utc offset iso duration", DataType="Offset")]
+        [ApiMember(DataType="Offset", Description="Utc offset iso duration")]
         public Offset UtcOffsetIsoDuration { get; set; }
 
         ///<summary>
         ///Last modified
         ///</summary>
-        [ApiMember(Description="Last modified", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Last modified")]
         public DateTimeOffset LastModified { get; set; }
 
         ///<summary>
         ///Raw start time
         ///</summary>
-        [ApiMember(Description="Raw start time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Raw start time")]
         public DateTimeOffset? RawStartTime { get; set; }
 
         ///<summary>
         ///Raw end time
         ///</summary>
-        [ApiMember(Description="Raw end time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Raw end time")]
         public DateTimeOffset? RawEndTime { get; set; }
 
         ///<summary>
@@ -2166,7 +2166,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Publish
         ///</summary>
-        [ApiMember(Description="Publish", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Publish")]
         public bool Publish { get; set; }
 
         ///<summary>
@@ -2190,13 +2190,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Extended attributes
         ///</summary>
-        [ApiMember(Description="Extended attributes", DataType="Array<ExtendedAttribute>")]
+        [ApiMember(DataType="Array<ExtendedAttribute>", Description="Extended attributes")]
         public IList<ExtendedAttribute> ExtendedAttributes { get; set; }
 
         ///<summary>
         ///Thresholds
         ///</summary>
-        [ApiMember(Description="Thresholds", DataType="Array<TimeSeriesThreshold>")]
+        [ApiMember(DataType="Array<TimeSeriesThreshold>", Description="Thresholds")]
         public IList<TimeSeriesThreshold> Thresholds { get; set; }
     }
 
@@ -2205,13 +2205,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Timestamp
         ///</summary>
-        [ApiMember(Description="Timestamp", DataType="StatisticalDateTimeOffset")]
+        [ApiMember(DataType="StatisticalDateTimeOffset", Description="Timestamp")]
         public StatisticalDateTimeOffset Timestamp { get; set; }
 
         ///<summary>
         ///Value
         ///</summary>
-        [ApiMember(Description="Value", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Value")]
         public DoubleWithDisplay Value { get; set; }
     }
 
@@ -2243,13 +2243,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Severity
         ///</summary>
-        [ApiMember(Description="Severity", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Severity")]
         public int Severity { get; set; }
 
         ///<summary>
         ///Type
         ///</summary>
-        [ApiMember(Description="Type", DataType="ThresholdType")]
+        [ApiMember(DataType="ThresholdType", Description="Type")]
         public ThresholdType Type { get; set; }
 
         ///<summary>
@@ -2261,7 +2261,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Periods
         ///</summary>
-        [ApiMember(Description="Periods", DataType="Array<TimeSeriesThresholdPeriod>")]
+        [ApiMember(DataType="Array<TimeSeriesThresholdPeriod>", Description="Periods")]
         public List<TimeSeriesThresholdPeriod> Periods { get; set; }
     }
 
@@ -2270,19 +2270,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Start time
         ///</summary>
-        [ApiMember(Description="Start time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Start time")]
         public DateTimeOffset StartTime { get; set; }
 
         ///<summary>
         ///End time
         ///</summary>
-        [ApiMember(Description="End time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="End time")]
         public DateTimeOffset EndTime { get; set; }
 
         ///<summary>
         ///Applied time
         ///</summary>
-        [ApiMember(Description="Applied time", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Applied time")]
         public DateTime AppliedTime { get; set; }
 
         ///<summary>
@@ -2294,19 +2294,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Reference value
         ///</summary>
-        [ApiMember(Description="Reference value", DataType="double")]
+        [ApiMember(DataType="double", Description="Reference value")]
         public double ReferenceValue { get; set; }
 
         ///<summary>
         ///Secondary reference value
         ///</summary>
-        [ApiMember(Description="Secondary reference value", DataType="double")]
+        [ApiMember(DataType="double", Description="Secondary reference value")]
         public double? SecondaryReferenceValue { get; set; }
 
         ///<summary>
         ///Suppress data
         ///</summary>
-        [ApiMember(Description="Suppress data", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Suppress data")]
         public bool SuppressData { get; set; }
     }
 
@@ -2315,19 +2315,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Unique id
         ///</summary>
-        [ApiMember(Description="Unique id", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique id")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
         ///First point changed
         ///</summary>
-        [ApiMember(Description="First point changed", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="First point changed")]
         public DateTimeOffset? FirstPointChanged { get; set; }
 
         ///<summary>
         ///Has attribute change
         ///</summary>
-        [ApiMember(Description="Has attribute change", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Has attribute change")]
         public bool? HasAttributeChange { get; set; }
     }
 
@@ -2375,73 +2375,73 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Discharge channel measurement
         ///</summary>
-        [ApiMember(Description="Discharge channel measurement", DataType="DischargeChannelMeasurement")]
+        [ApiMember(DataType="DischargeChannelMeasurement", Description="Discharge channel measurement")]
         public DischargeChannelMeasurement DischargeChannelMeasurement { get; set; }
 
         ///<summary>
         ///Is valid
         ///</summary>
-        [ApiMember(Description="Is valid", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is valid")]
         public bool IsValid { get; set; }
 
         ///<summary>
         ///Number of transects
         ///</summary>
-        [ApiMember(Description="Number of transects", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Number of transects")]
         public int? NumberOfTransects { get; set; }
 
         ///<summary>
         ///Magnetic variation
         ///</summary>
-        [ApiMember(Description="Magnetic variation", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Magnetic variation")]
         public DoubleWithDisplay MagneticVariation { get; set; }
 
         ///<summary>
         ///Discharge coefficient variation
         ///</summary>
-        [ApiMember(Description="Discharge coefficient variation", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Discharge coefficient variation")]
         public DoubleWithDisplay DischargeCoefficientVariation { get; set; }
 
         ///<summary>
         ///Percent of discharge measured
         ///</summary>
-        [ApiMember(Description="Percent of discharge measured", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Percent of discharge measured")]
         public DoubleWithDisplay PercentOfDischargeMeasured { get; set; }
 
         ///<summary>
         ///Top estimate exponent
         ///</summary>
-        [ApiMember(Description="Top estimate exponent", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Top estimate exponent")]
         public DoubleWithDisplay TopEstimateExponent { get; set; }
 
         ///<summary>
         ///Bottom estimate exponent
         ///</summary>
-        [ApiMember(Description="Bottom estimate exponent", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Bottom estimate exponent")]
         public DoubleWithDisplay BottomEstimateExponent { get; set; }
 
         ///<summary>
         ///Width
         ///</summary>
-        [ApiMember(Description="Width", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Width")]
         public QuantityWithDisplay Width { get; set; }
 
         ///<summary>
         ///Area
         ///</summary>
-        [ApiMember(Description="Area", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Area")]
         public QuantityWithDisplay Area { get; set; }
 
         ///<summary>
         ///Velocity average
         ///</summary>
-        [ApiMember(Description="Velocity average", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Velocity average")]
         public QuantityWithDisplay VelocityAverage { get; set; }
 
         ///<summary>
         ///Transducer depth
         ///</summary>
-        [ApiMember(Description="Transducer depth", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Transducer depth")]
         public QuantityWithDisplay TransducerDepth { get; set; }
 
         ///<summary>
@@ -2516,19 +2516,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Adjustment amount
         ///</summary>
-        [ApiMember(Description="Adjustment amount", DataType="double")]
+        [ApiMember(DataType="double", Description="Adjustment amount")]
         public double? AdjustmentAmount { get; set; }
 
         ///<summary>
         ///Adjustment type
         ///</summary>
-        [ApiMember(Description="Adjustment type", DataType="AdjustmentType")]
+        [ApiMember(DataType="AdjustmentType", Description="Adjustment type")]
         public AdjustmentType AdjustmentType { get; set; }
 
         ///<summary>
         ///Reason for adjustment
         ///</summary>
-        [ApiMember(Description="Reason for adjustment", DataType="ReasonForAdjustmentType")]
+        [ApiMember(DataType="ReasonForAdjustmentType", Description="Reason for adjustment")]
         public ReasonForAdjustmentType ReasonForAdjustment { get; set; }
     }
 
@@ -2537,13 +2537,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Attachment type
         ///</summary>
-        [ApiMember(Description="Attachment type", DataType="AttachmentType")]
+        [ApiMember(DataType="AttachmentType", Description="Attachment type")]
         public AttachmentType AttachmentType { get; set; }
 
         ///<summary>
         ///Attachment category
         ///</summary>
-        [ApiMember(Description="Attachment category", DataType="AttachmentCategory")]
+        [ApiMember(DataType="AttachmentCategory", Description="Attachment category")]
         public AttachmentCategory AttachmentCategory { get; set; }
 
         ///<summary>
@@ -2555,19 +2555,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Date created
         ///</summary>
-        [ApiMember(Description="Date created", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Date created")]
         public DateTimeOffset DateCreated { get; set; }
 
         ///<summary>
         ///Date uploaded
         ///</summary>
-        [ApiMember(Description="Date uploaded", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Date uploaded")]
         public DateTimeOffset DateUploaded { get; set; }
 
         ///<summary>
         ///Date last accessed
         ///</summary>
-        [ApiMember(Description="Date last accessed", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Date last accessed")]
         public DateTimeOffset? DateLastAccessed { get; set; }
 
         ///<summary>
@@ -2585,13 +2585,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Gps latitude
         ///</summary>
-        [ApiMember(Description="Gps latitude", DataType="double")]
+        [ApiMember(DataType="double", Description="Gps latitude")]
         public double? GpsLatitude { get; set; }
 
         ///<summary>
         ///Gps longitude
         ///</summary>
-        [ApiMember(Description="Gps longitude", DataType="double")]
+        [ApiMember(DataType="double", Description="Gps longitude")]
         public double? GpsLongitude { get; set; }
 
         ///<summary>
@@ -2612,13 +2612,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Standard
         ///</summary>
-        [ApiMember(Description="Standard", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Standard")]
         public DoubleWithDisplay Standard { get; set; }
 
         ///<summary>
         ///Standard details
         ///</summary>
-        [ApiMember(Description="Standard details", DataType="StandardDetails")]
+        [ApiMember(DataType="StandardDetails", Description="Standard details")]
         public StandardDetails StandardDetails { get; set; }
 
         ///<summary>
@@ -2630,19 +2630,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Value
         ///</summary>
-        [ApiMember(Description="Value", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Value")]
         public DoubleWithDisplay Value { get; set; }
 
         ///<summary>
         ///Difference
         ///</summary>
-        [ApiMember(Description="Difference", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Difference")]
         public DoubleWithDisplay Difference { get; set; }
 
         ///<summary>
         ///Percent difference
         ///</summary>
-        [ApiMember(Description="Percent difference", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Percent difference")]
         public DoubleWithDisplay PercentDifference { get; set; }
 
         ///<summary>
@@ -2654,7 +2654,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Calibration check type
         ///</summary>
-        [ApiMember(Description="Calibration check type", DataType="CalibrationCheckType")]
+        [ApiMember(DataType="CalibrationCheckType", Description="Calibration check type")]
         public CalibrationCheckType CalibrationCheckType { get; set; }
 
         ///<summary>
@@ -2678,7 +2678,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Time
         ///</summary>
-        [ApiMember(Description="Time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Time")]
         public DateTimeOffset? Time { get; set; }
 
         ///<summary>
@@ -2702,13 +2702,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Publish
         ///</summary>
-        [ApiMember(Description="Publish", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Publish")]
         public bool Publish { get; set; }
 
         ///<summary>
         ///Is valid
         ///</summary>
-        [ApiMember(Description="Is valid", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is valid")]
         public bool IsValid { get; set; }
     }
 
@@ -2723,49 +2723,49 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Biological sample taken
         ///</summary>
-        [ApiMember(Description="Biological sample taken", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Biological sample taken")]
         public bool BiologicalSampleTaken { get; set; }
 
         ///<summary>
         ///Ground water level performed
         ///</summary>
-        [ApiMember(Description="Ground water level performed", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Ground water level performed")]
         public bool GroundWaterLevelPerformed { get; set; }
 
         ///<summary>
         ///Levels performed
         ///</summary>
-        [ApiMember(Description="Levels performed", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Levels performed")]
         public bool LevelsPerformed { get; set; }
 
         ///<summary>
         ///Other sample taken
         ///</summary>
-        [ApiMember(Description="Other sample taken", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Other sample taken")]
         public bool OtherSampleTaken { get; set; }
 
         ///<summary>
         ///Recorder data collected
         ///</summary>
-        [ApiMember(Description="Recorder data collected", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Recorder data collected")]
         public bool RecorderDataCollected { get; set; }
 
         ///<summary>
         ///Sediment sample taken
         ///</summary>
-        [ApiMember(Description="Sediment sample taken", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Sediment sample taken")]
         public bool SedimentSampleTaken { get; set; }
 
         ///<summary>
         ///Safety inspection performed
         ///</summary>
-        [ApiMember(Description="Safety inspection performed", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Safety inspection performed")]
         public bool SafetyInspectionPerformed { get; set; }
 
         ///<summary>
         ///Water quality sample taken
         ///</summary>
-        [ApiMember(Description="Water quality sample taken", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Water quality sample taken")]
         public bool WaterQualitySampleTaken { get; set; }
     }
 
@@ -2786,25 +2786,25 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Control cleaned
         ///</summary>
-        [ApiMember(Description="Control cleaned", DataType="ControlCleanedType")]
+        [ApiMember(DataType="ControlCleanedType", Description="Control cleaned")]
         public ControlCleanedType ControlCleaned { get; set; }
 
         ///<summary>
         ///Control condition
         ///</summary>
-        [ApiMember(Description="Control condition", DataType="ControlConditionType")]
+        [ApiMember(DataType="ControlConditionType", Description="Control condition")]
         public ControlConditionType ControlCondition { get; set; }
 
         ///<summary>
         ///Date cleaned
         ///</summary>
-        [ApiMember(Description="Date cleaned", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Date cleaned")]
         public DateTimeOffset? DateCleaned { get; set; }
 
         ///<summary>
         ///Distance to gage
         ///</summary>
-        [ApiMember(Description="Distance to gage", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Distance to gage")]
         public QuantityWithDisplay DistanceToGage { get; set; }
 
         ///<summary>
@@ -2822,7 +2822,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Is valid
         ///</summary>
-        [ApiMember(Description="Is valid", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is valid")]
         public bool IsValid { get; set; }
     }
 
@@ -2840,37 +2840,37 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Discharge summary
         ///</summary>
-        [ApiMember(Description="Discharge summary", DataType="DischargeSummary")]
+        [ApiMember(DataType="DischargeSummary", Description="Discharge summary")]
         public DischargeSummary DischargeSummary { get; set; }
 
         ///<summary>
         ///Volumetric discharge activities
         ///</summary>
-        [ApiMember(Description="Volumetric discharge activities", DataType="Array<VolumetricDischargeActivity>")]
+        [ApiMember(DataType="Array<VolumetricDischargeActivity>", Description="Volumetric discharge activities")]
         public List<VolumetricDischargeActivity> VolumetricDischargeActivities { get; set; }
 
         ///<summary>
         ///Engineered structure discharge activities
         ///</summary>
-        [ApiMember(Description="Engineered structure discharge activities", DataType="Array<EngineeredStructureDischargeActivity>")]
+        [ApiMember(DataType="Array<EngineeredStructureDischargeActivity>", Description="Engineered structure discharge activities")]
         public List<EngineeredStructureDischargeActivity> EngineeredStructureDischargeActivities { get; set; }
 
         ///<summary>
         ///Point velocity discharge activities
         ///</summary>
-        [ApiMember(Description="Point velocity discharge activities", DataType="Array<PointVelocityDischargeActivity>")]
+        [ApiMember(DataType="Array<PointVelocityDischargeActivity>", Description="Point velocity discharge activities")]
         public List<PointVelocityDischargeActivity> PointVelocityDischargeActivities { get; set; }
 
         ///<summary>
         ///Other method discharge activities
         ///</summary>
-        [ApiMember(Description="Other method discharge activities", DataType="Array<OtherMethodDischargeActivity>")]
+        [ApiMember(DataType="Array<OtherMethodDischargeActivity>", Description="Other method discharge activities")]
         public List<OtherMethodDischargeActivity> OtherMethodDischargeActivities { get; set; }
 
         ///<summary>
         ///Adcp discharge activities
         ///</summary>
-        [ApiMember(Description="Adcp discharge activities", DataType="Array<AdcpDischargeActivity>")]
+        [ApiMember(DataType="Array<AdcpDischargeActivity>", Description="Adcp discharge activities")]
         public List<AdcpDischargeActivity> AdcpDischargeActivities { get; set; }
     }
 
@@ -2885,19 +2885,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Start time
         ///</summary>
-        [ApiMember(Description="Start time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Start time")]
         public DateTimeOffset? StartTime { get; set; }
 
         ///<summary>
         ///End time
         ///</summary>
-        [ApiMember(Description="End time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="End time")]
         public DateTimeOffset? EndTime { get; set; }
 
         ///<summary>
         ///Discharge
         ///</summary>
-        [ApiMember(Description="Discharge", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Discharge")]
         public QuantityWithDisplay Discharge { get; set; }
 
         ///<summary>
@@ -2915,67 +2915,67 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Distance to gage
         ///</summary>
-        [ApiMember(Description="Distance to gage", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Distance to gage")]
         public QuantityWithDisplay DistanceToGage { get; set; }
 
         ///<summary>
         ///Horizontal flow
         ///</summary>
-        [ApiMember(Description="Horizontal flow", DataType="HorizontalFlowType")]
+        [ApiMember(DataType="HorizontalFlowType", Description="Horizontal flow")]
         public HorizontalFlowType HorizontalFlow { get; set; }
 
         ///<summary>
         ///Channel stability
         ///</summary>
-        [ApiMember(Description="Channel stability", DataType="ChannelStabilityType")]
+        [ApiMember(DataType="ChannelStabilityType", Description="Channel stability")]
         public ChannelStabilityType ChannelStability { get; set; }
 
         ///<summary>
         ///Channel material
         ///</summary>
-        [ApiMember(Description="Channel material", DataType="ChannelMaterialType")]
+        [ApiMember(DataType="ChannelMaterialType", Description="Channel material")]
         public ChannelMaterialType ChannelMaterial { get; set; }
 
         ///<summary>
         ///Channel evenness
         ///</summary>
-        [ApiMember(Description="Channel evenness", DataType="ChannelEvennessType")]
+        [ApiMember(DataType="ChannelEvennessType", Description="Channel evenness")]
         public ChannelEvennessType ChannelEvenness { get; set; }
 
         ///<summary>
         ///Vertical velocity distribution
         ///</summary>
-        [ApiMember(Description="Vertical velocity distribution", DataType="VerticalVelocityDistributionType")]
+        [ApiMember(DataType="VerticalVelocityDistributionType", Description="Vertical velocity distribution")]
         public VerticalVelocityDistributionType VerticalVelocityDistribution { get; set; }
 
         ///<summary>
         ///Velocity variation
         ///</summary>
-        [ApiMember(Description="Velocity variation", DataType="VelocityVariationType")]
+        [ApiMember(DataType="VelocityVariationType", Description="Velocity variation")]
         public VelocityVariationType VelocityVariation { get; set; }
 
         ///<summary>
         ///Measurement location to gage
         ///</summary>
-        [ApiMember(Description="Measurement location to gage", DataType="MeasurementLocationToGageType")]
+        [ApiMember(DataType="MeasurementLocationToGageType", Description="Measurement location to gage")]
         public MeasurementLocationToGageType MeasurementLocationToGage { get; set; }
 
         ///<summary>
         ///Meter suspension
         ///</summary>
-        [ApiMember(Description="Meter suspension", DataType="MeterSuspensionType")]
+        [ApiMember(DataType="MeterSuspensionType", Description="Meter suspension")]
         public MeterSuspensionType MeterSuspension { get; set; }
 
         ///<summary>
         ///Deployment method
         ///</summary>
-        [ApiMember(Description="Deployment method", DataType="DeploymentMethodType")]
+        [ApiMember(DataType="DeploymentMethodType", Description="Deployment method")]
         public DeploymentMethodType DeploymentMethod { get; set; }
 
         ///<summary>
         ///Current meter
         ///</summary>
-        [ApiMember(Description="Current meter", DataType="CurrentMeterType")]
+        [ApiMember(DataType="CurrentMeterType", Description="Current meter")]
         public CurrentMeterType CurrentMeter { get; set; }
 
         ///<summary>
@@ -2995,19 +2995,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Measurement start time
         ///</summary>
-        [ApiMember(Description="Measurement start time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Measurement start time")]
         public DateTimeOffset? MeasurementStartTime { get; set; }
 
         ///<summary>
         ///Measurement end time
         ///</summary>
-        [ApiMember(Description="Measurement end time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Measurement end time")]
         public DateTimeOffset? MeasurementEndTime { get; set; }
 
         ///<summary>
         ///Measurement time
         ///</summary>
-        [ApiMember(Description="Measurement time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Measurement time")]
         public DateTimeOffset MeasurementTime { get; set; }
 
         ///<summary>
@@ -3019,25 +3019,25 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Base flow
         ///</summary>
-        [ApiMember(Description="Base flow", DataType="BaseFlowType")]
+        [ApiMember(DataType="BaseFlowType", Description="Base flow")]
         public BaseFlowType BaseFlow { get; set; }
 
         ///<summary>
         ///Adjustment
         ///</summary>
-        [ApiMember(Description="Adjustment", DataType="Adjustment")]
+        [ApiMember(DataType="Adjustment", Description="Adjustment")]
         public Adjustment Adjustment { get; set; }
 
         ///<summary>
         ///Alternate rating discharge
         ///</summary>
-        [ApiMember(Description="Alternate rating discharge", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Alternate rating discharge")]
         public QuantityWithDisplay AlternateRatingDischarge { get; set; }
 
         ///<summary>
         ///Discharge
         ///</summary>
-        [ApiMember(Description="Discharge", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Discharge")]
         public QuantityWithDisplay Discharge { get; set; }
 
         ///<summary>
@@ -3049,7 +3049,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Mean gage height
         ///</summary>
-        [ApiMember(Description="Mean gage height", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Mean gage height")]
         public QuantityWithDisplay MeanGageHeight { get; set; }
 
         ///<summary>
@@ -3061,13 +3061,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Mean index velocity
         ///</summary>
-        [ApiMember(Description="Mean index velocity", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Mean index velocity")]
         public QuantityWithDisplay MeanIndexVelocity { get; set; }
 
         ///<summary>
         ///Discharge measurement reason
         ///</summary>
-        [ApiMember(Description="Discharge measurement reason", DataType="DischargeMeasurementReasonType")]
+        [ApiMember(DataType="DischargeMeasurementReasonType", Description="Discharge measurement reason")]
         public DischargeMeasurementReasonType DischargeMeasurementReason { get; set; }
 
         ///<summary>
@@ -3079,31 +3079,31 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Gage height calculation
         ///</summary>
-        [ApiMember(Description="Gage height calculation", DataType="GageHeightCalculationType")]
+        [ApiMember(DataType="GageHeightCalculationType", Description="Gage height calculation")]
         public GageHeightCalculationType GageHeightCalculation { get; set; }
 
         ///<summary>
         ///Gage height readings
         ///</summary>
-        [ApiMember(Description="Gage height readings", DataType="Array<GageHeightReading>")]
+        [ApiMember(DataType="Array<GageHeightReading>", Description="Gage height readings")]
         public List<GageHeightReading> GageHeightReadings { get; set; }
 
         ///<summary>
         ///Difference during visit
         ///</summary>
-        [ApiMember(Description="Difference during visit", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Difference during visit")]
         public DoubleWithDisplay DifferenceDuringVisit { get; set; }
 
         ///<summary>
         ///Duration in hours
         ///</summary>
-        [ApiMember(Description="Duration in hours", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Duration in hours")]
         public DoubleWithDisplay DurationInHours { get; set; }
 
         ///<summary>
         ///Measurement grade
         ///</summary>
-        [ApiMember(Description="Measurement grade", DataType="MeasurementGradeType")]
+        [ApiMember(DataType="MeasurementGradeType", Description="Measurement grade")]
         public MeasurementGradeType MeasurementGrade { get; set; }
 
         ///<summary>
@@ -3121,13 +3121,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Is valid
         ///</summary>
-        [ApiMember(Description="Is valid", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is valid")]
         public bool IsValid { get; set; }
 
         ///<summary>
         ///Publish
         ///</summary>
-        [ApiMember(Description="Publish", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Publish")]
         public bool Publish { get; set; }
     }
 
@@ -3136,7 +3136,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Discharge channel measurement
         ///</summary>
-        [ApiMember(Description="Discharge channel measurement", DataType="DischargeChannelMeasurement")]
+        [ApiMember(DataType="DischargeChannelMeasurement", Description="Discharge channel measurement")]
         public DischargeChannelMeasurement DischargeChannelMeasurement { get; set; }
 
         ///<summary>
@@ -3154,13 +3154,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Mean head
         ///</summary>
-        [ApiMember(Description="Mean head", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Mean head")]
         public QuantityWithDisplay MeanHead { get; set; }
 
         ///<summary>
         ///Is valid
         ///</summary>
-        [ApiMember(Description="Is valid", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is valid")]
         public bool IsValid { get; set; }
     }
 
@@ -3169,7 +3169,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Approval level
         ///</summary>
-        [ApiMember(Description="Approval level", DataType="long integer")]
+        [ApiMember(DataType="long integer", Description="Approval level")]
         public long ApprovalLevel { get; set; }
 
         ///<summary>
@@ -3184,31 +3184,31 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Observed date
         ///</summary>
-        [ApiMember(Description="Observed date", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Observed date")]
         public DateTimeOffset? ObservedDate { get; set; }
 
         ///<summary>
         ///Applicable since
         ///</summary>
-        [ApiMember(Description="Applicable since", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Applicable since")]
         public DateTimeOffset? ApplicableSince { get; set; }
 
         ///<summary>
         ///Zero flow height
         ///</summary>
-        [ApiMember(Description="Zero flow height", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Zero flow height")]
         public DoubleWithDisplay ZeroFlowHeight { get; set; }
 
         ///<summary>
         ///Is observed
         ///</summary>
-        [ApiMember(Description="Is observed", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is observed")]
         public bool IsObserved { get; set; }
 
         ///<summary>
         ///Calculated details
         ///</summary>
-        [ApiMember(Description="Calculated details", DataType="GageHeightAtZeroFlowCalculatedDetails")]
+        [ApiMember(DataType="GageHeightAtZeroFlowCalculatedDetails", Description="Calculated details")]
         public GageHeightAtZeroFlowCalculatedDetails CalculatedDetails { get; set; }
 
         ///<summary>
@@ -3232,7 +3232,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Is valid
         ///</summary>
-        [ApiMember(Description="Is valid", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is valid")]
         public bool IsValid { get; set; }
     }
 
@@ -3241,19 +3241,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Stage
         ///</summary>
-        [ApiMember(Description="Stage", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Stage")]
         public DoubleWithDisplay Stage { get; set; }
 
         ///<summary>
         ///Depth
         ///</summary>
-        [ApiMember(Description="Depth", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Depth")]
         public DoubleWithDisplay Depth { get; set; }
 
         ///<summary>
         ///Depth certainty
         ///</summary>
-        [ApiMember(Description="Depth certainty", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Depth certainty")]
         public DoubleWithDisplay DepthCertainty { get; set; }
     }
 
@@ -3262,19 +3262,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Is used
         ///</summary>
-        [ApiMember(Description="Is used", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is used")]
         public bool IsUsed { get; set; }
 
         ///<summary>
         ///Reading time
         ///</summary>
-        [ApiMember(Description="Reading time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Reading time")]
         public DateTimeOffset? ReadingTime { get; set; }
 
         ///<summary>
         ///Gage height
         ///</summary>
-        [ApiMember(Description="Gage height", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Gage height")]
         public DoubleWithDisplay GageHeight { get; set; }
     }
 
@@ -3283,7 +3283,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Inspection type
         ///</summary>
-        [ApiMember(Description="Inspection type", DataType="InspectionType")]
+        [ApiMember(DataType="InspectionType", Description="Inspection type")]
         public InspectionType InspectionType { get; set; }
 
         ///<summary>
@@ -3307,7 +3307,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Time
         ///</summary>
-        [ApiMember(Description="Time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Time")]
         public DateTimeOffset? Time { get; set; }
 
         ///<summary>
@@ -3341,25 +3341,25 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Readings
         ///</summary>
-        [ApiMember(Description="Readings", DataType="Array<Reading>")]
+        [ApiMember(DataType="Array<Reading>", Description="Readings")]
         public List<Reading> Readings { get; set; }
 
         ///<summary>
         ///Calibration checks
         ///</summary>
-        [ApiMember(Description="Calibration checks", DataType="Array<CalibrationCheck>")]
+        [ApiMember(DataType="Array<CalibrationCheck>", Description="Calibration checks")]
         public List<CalibrationCheck> CalibrationChecks { get; set; }
 
         ///<summary>
         ///Inspections
         ///</summary>
-        [ApiMember(Description="Inspections", DataType="Array<Inspection>")]
+        [ApiMember(DataType="Array<Inspection>", Description="Inspections")]
         public List<Inspection> Inspections { get; set; }
 
         ///<summary>
         ///Is valid
         ///</summary>
-        [ApiMember(Description="Is valid", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is valid")]
         public bool IsValid { get; set; }
     }
 
@@ -3368,13 +3368,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Discharge channel measurement
         ///</summary>
-        [ApiMember(Description="Discharge channel measurement", DataType="DischargeChannelMeasurement")]
+        [ApiMember(DataType="DischargeChannelMeasurement", Description="Discharge channel measurement")]
         public DischargeChannelMeasurement DischargeChannelMeasurement { get; set; }
 
         ///<summary>
         ///Is valid
         ///</summary>
-        [ApiMember(Description="Is valid", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is valid")]
         public bool IsValid { get; set; }
     }
 
@@ -3383,73 +3383,73 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Discharge channel measurement
         ///</summary>
-        [ApiMember(Description="Discharge channel measurement", DataType="DischargeChannelMeasurement")]
+        [ApiMember(DataType="DischargeChannelMeasurement", Description="Discharge channel measurement")]
         public DischargeChannelMeasurement DischargeChannelMeasurement { get; set; }
 
         ///<summary>
         ///Distance to meter
         ///</summary>
-        [ApiMember(Description="Distance to meter", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Distance to meter")]
         public QuantityWithDisplay DistanceToMeter { get; set; }
 
         ///<summary>
         ///Width
         ///</summary>
-        [ApiMember(Description="Width", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Width")]
         public QuantityWithDisplay Width { get; set; }
 
         ///<summary>
         ///Area
         ///</summary>
-        [ApiMember(Description="Area", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Area")]
         public QuantityWithDisplay Area { get; set; }
 
         ///<summary>
         ///Velocity average
         ///</summary>
-        [ApiMember(Description="Velocity average", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Velocity average")]
         public QuantityWithDisplay VelocityAverage { get; set; }
 
         ///<summary>
         ///Mean observation duration in seconds
         ///</summary>
-        [ApiMember(Description="Mean observation duration in seconds", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Mean observation duration in seconds")]
         public DoubleWithDisplay MeanObservationDurationInSeconds { get; set; }
 
         ///<summary>
         ///Suspension coefficient used
         ///</summary>
-        [ApiMember(Description="Suspension coefficient used", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Suspension coefficient used")]
         public bool SuspensionCoefficientUsed { get; set; }
 
         ///<summary>
         ///Method coefficient used
         ///</summary>
-        [ApiMember(Description="Method coefficient used", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Method coefficient used")]
         public bool MethodCoefficientUsed { get; set; }
 
         ///<summary>
         ///Horizontal coefficient used
         ///</summary>
-        [ApiMember(Description="Horizontal coefficient used", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Horizontal coefficient used")]
         public bool HorizontalCoefficientUsed { get; set; }
 
         ///<summary>
         ///Meter inspected before
         ///</summary>
-        [ApiMember(Description="Meter inspected before", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Meter inspected before")]
         public bool? MeterInspectedBefore { get; set; }
 
         ///<summary>
         ///Meter inspected after
         ///</summary>
-        [ApiMember(Description="Meter inspected after", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Meter inspected after")]
         public bool? MeterInspectedAfter { get; set; }
 
         ///<summary>
         ///Number of panels
         ///</summary>
-        [ApiMember(Description="Number of panels", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Number of panels")]
         public int? NumberOfPanels { get; set; }
 
         ///<summary>
@@ -3479,7 +3479,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Discharge method
         ///</summary>
-        [ApiMember(Description="Discharge method", DataType="DischargeMethodType")]
+        [ApiMember(DataType="DischargeMethodType", Description="Discharge method")]
         public DischargeMethodType DischargeMethod { get; set; }
 
         ///<summary>
@@ -3509,7 +3509,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Start point
         ///</summary>
-        [ApiMember(Description="Start point", DataType="StartPointType")]
+        [ApiMember(DataType="StartPointType", Description="Start point")]
         public StartPointType StartPoint { get; set; }
 
         ///<summary>
@@ -3521,7 +3521,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Is valid
         ///</summary>
-        [ApiMember(Description="Is valid", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is valid")]
         public bool IsValid { get; set; }
     }
 
@@ -3552,7 +3552,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Value
         ///</summary>
-        [ApiMember(Description="Value", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Value")]
         public DoubleWithDisplay Value { get; set; }
 
         ///<summary>
@@ -3564,13 +3564,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Uncertainty
         ///</summary>
-        [ApiMember(Description="Uncertainty", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Uncertainty")]
         public DoubleWithDisplay Uncertainty { get; set; }
 
         ///<summary>
         ///Reading type
         ///</summary>
-        [ApiMember(Description="Reading type", DataType="ReadingType")]
+        [ApiMember(DataType="ReadingType", Description="Reading type")]
         public ReadingType ReadingType { get; set; }
 
         ///<summary>
@@ -3594,7 +3594,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Time
         ///</summary>
-        [ApiMember(Description="Time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Time")]
         public DateTimeOffset? Time { get; set; }
 
         ///<summary>
@@ -3618,13 +3618,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Publish
         ///</summary>
-        [ApiMember(Description="Publish", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Publish")]
         public bool Publish { get; set; }
 
         ///<summary>
         ///Is valid
         ///</summary>
-        [ApiMember(Description="Is valid", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is valid")]
         public bool IsValid { get; set; }
     }
 
@@ -3645,13 +3645,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Temperature
         ///</summary>
-        [ApiMember(Description="Temperature", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Temperature")]
         public DoubleWithDisplay Temperature { get; set; }
 
         ///<summary>
         ///Expiration date
         ///</summary>
-        [ApiMember(Description="Expiration date", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Expiration date")]
         public DateTimeOffset? ExpirationDate { get; set; }
     }
 
@@ -3665,31 +3665,31 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Discharge channel measurement
         ///</summary>
-        [ApiMember(Description="Discharge channel measurement", DataType="DischargeChannelMeasurement")]
+        [ApiMember(DataType="DischargeChannelMeasurement", Description="Discharge channel measurement")]
         public DischargeChannelMeasurement DischargeChannelMeasurement { get; set; }
 
         ///<summary>
         ///Volumetric discharge readings
         ///</summary>
-        [ApiMember(Description="Volumetric discharge readings", DataType="Array<VolumetricDischargeReading>")]
+        [ApiMember(DataType="Array<VolumetricDischargeReading>", Description="Volumetric discharge readings")]
         public List<VolumetricDischargeReading> VolumetricDischargeReadings { get; set; }
 
         ///<summary>
         ///Measurement container volume
         ///</summary>
-        [ApiMember(Description="Measurement container volume", DataType="QuantityWithDisplay")]
+        [ApiMember(DataType="QuantityWithDisplay", Description="Measurement container volume")]
         public QuantityWithDisplay MeasurementContainerVolume { get; set; }
 
         ///<summary>
         ///Is observed
         ///</summary>
-        [ApiMember(Description="Is observed", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is observed")]
         public bool IsObserved { get; set; }
 
         ///<summary>
         ///Is valid
         ///</summary>
-        [ApiMember(Description="Is valid", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is valid")]
         public bool IsValid { get; set; }
     }
 
@@ -3704,37 +3704,37 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Duration in seconds
         ///</summary>
-        [ApiMember(Description="Duration in seconds", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Duration in seconds")]
         public DoubleWithDisplay DurationInSeconds { get; set; }
 
         ///<summary>
         ///Starting volume
         ///</summary>
-        [ApiMember(Description="Starting volume", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Starting volume")]
         public DoubleWithDisplay StartingVolume { get; set; }
 
         ///<summary>
         ///Ending volume
         ///</summary>
-        [ApiMember(Description="Ending volume", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Ending volume")]
         public DoubleWithDisplay EndingVolume { get; set; }
 
         ///<summary>
         ///Discharge
         ///</summary>
-        [ApiMember(Description="Discharge", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Discharge")]
         public DoubleWithDisplay Discharge { get; set; }
 
         ///<summary>
         ///Is used
         ///</summary>
-        [ApiMember(Description="Is used", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Is used")]
         public bool IsUsed { get; set; }
 
         ///<summary>
         ///Volume change
         ///</summary>
-        [ApiMember(Description="Volume change", DataType="DoubleWithDisplay")]
+        [ApiMember(DataType="DoubleWithDisplay", Description="Volume change")]
         public DoubleWithDisplay VolumeChange { get; set; }
     }
 
@@ -3748,13 +3748,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Visit date
         ///</summary>
-        [ApiMember(Description="Visit date", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Visit date")]
         public DateTimeOffset FirstUsedDate { get; set; }
 
         ///<summary>
         ///Equations
         ///</summary>
-        [ApiMember(Description="Equations", DataType="Array<ActiveMeterCalibrationEquation>")]
+        [ApiMember(DataType="Array<ActiveMeterCalibrationEquation>", Description="Equations")]
         public List<ActiveMeterCalibrationEquation> Equations { get; set; }
     }
 
@@ -3763,25 +3763,25 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Range start
         ///</summary>
-        [ApiMember(Description="Range start", DataType="double")]
+        [ApiMember(DataType="double", Description="Range start")]
         public double? RangeStart { get; set; }
 
         ///<summary>
         ///Range end
         ///</summary>
-        [ApiMember(Description="Range end", DataType="double")]
+        [ApiMember(DataType="double", Description="Range end")]
         public double? RangeEnd { get; set; }
 
         ///<summary>
         ///Slope
         ///</summary>
-        [ApiMember(Description="Slope", DataType="double")]
+        [ApiMember(DataType="double", Description="Slope")]
         public double Slope { get; set; }
 
         ///<summary>
         ///Intercept
         ///</summary>
-        [ApiMember(Description="Intercept", DataType="double")]
+        [ApiMember(DataType="double", Description="Intercept")]
         public double Intercept { get; set; }
 
         ///<summary>
@@ -3801,7 +3801,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Meter type
         ///</summary>
-        [ApiMember(Description="Meter type", DataType="MeterType")]
+        [ApiMember(DataType="MeterType", Description="Meter type")]
         public MeterType? MeterType { get; set; }
 
         ///<summary>
@@ -3843,7 +3843,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Meter calibrations
         ///</summary>
-        [ApiMember(Description="Meter calibrations", DataType="Array<ActiveMeterCalibration>")]
+        [ApiMember(DataType="Array<ActiveMeterCalibration>", Description="Meter calibrations")]
         public List<ActiveMeterCalibration> MeterCalibrations { get; set; }
     }
 
@@ -3890,6 +3890,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         WinRiver,
         LoggerFile,
         GeneratedReport,
+        Csv,
     }
 
     public enum BaseFlowType
@@ -4174,19 +4175,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///The unique ID of the time series
         ///</summary>
-        [ApiMember(IsRequired=true, Description="The unique ID of the time series", DataType="string")]
+        [ApiMember(DataType="string", Description="The unique ID of the time series", IsRequired=true)]
         public Guid TimeSeriesUniqueId { get; set; }
 
         ///<summary>
         ///Filter results to items with a StartTime at or after the QueryFrom time
         ///</summary>
-        [ApiMember(Description="Filter results to items with a StartTime at or after the QueryFrom time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items with a StartTime at or after the QueryFrom time")]
         public DateTimeOffset? QueryFrom { get; set; }
 
         ///<summary>
         ///Filter results to items with an EndTime at or before the QueryTo time
         ///</summary>
-        [ApiMember(Description="Filter results to items with an EndTime at or before the QueryTo time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items with an EndTime at or before the QueryTo time")]
         public DateTimeOffset? QueryTo { get; set; }
     }
 
@@ -4197,19 +4198,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Rating model identifier
         ///</summary>
-        [ApiMember(IsRequired=true, Description="Rating model identifier")]
+        [ApiMember(Description="Rating model identifier", IsRequired=true)]
         public string RatingModelIdentifier { get; set; }
 
         ///<summary>
         ///Filter results to items with a ProcessorPeriod.StartTime at or after the QueryFrom time
         ///</summary>
-        [ApiMember(Description="Filter results to items with a ProcessorPeriod.StartTime at or after the QueryFrom time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items with a ProcessorPeriod.StartTime at or after the QueryFrom time")]
         public DateTimeOffset? QueryFrom { get; set; }
 
         ///<summary>
         ///Filter results to items with a ProcessorPeriod.EndTime at or before the QueryTo time
         ///</summary>
-        [ApiMember(Description="Filter results to items with a ProcessorPeriod.EndTime at or before the QueryTo time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items with a ProcessorPeriod.EndTime at or before the QueryTo time")]
         public DateTimeOffset? QueryTo { get; set; }
     }
 
@@ -4220,19 +4221,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Unique ID of the time series
         ///</summary>
-        [ApiMember(IsRequired=true, Description="Unique ID of the time series", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique ID of the time series", IsRequired=true)]
         public Guid TimeSeriesUniqueId { get; set; }
 
         ///<summary>
         ///Filter results to items with a ProcessorPeriod.StartTime at or after the QueryFrom time
         ///</summary>
-        [ApiMember(Description="Filter results to items with a ProcessorPeriod.StartTime at or after the QueryFrom time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items with a ProcessorPeriod.StartTime at or after the QueryFrom time")]
         public DateTimeOffset? QueryFrom { get; set; }
 
         ///<summary>
         ///Filter results to items with a ProcessorPeriod.EndTime at or before the QueryTo time
         ///</summary>
-        [ApiMember(Description="Filter results to items with a ProcessorPeriod.EndTime at or before the QueryTo time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items with a ProcessorPeriod.EndTime at or before the QueryTo time")]
         public DateTimeOffset? QueryTo { get; set; }
     }
 
@@ -4243,37 +4244,37 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Rating model identifier
         ///</summary>
-        [ApiMember(IsRequired=true, Description="Rating model identifier")]
+        [ApiMember(Description="Rating model identifier", IsRequired=true)]
         public string RatingModelIdentifier { get; set; }
 
         ///<summary>
         ///Table step size increment. Defaults to 0.01
         ///</summary>
-        [ApiMember(Description="Table step size increment. Defaults to 0.01", DataType="double")]
+        [ApiMember(DataType="double", Description="Table step size increment. Defaults to 0.01")]
         public double? StepSize { get; set; }
 
         ///<summary>
         ///Forces the response time values to a specific UTC offset. Defaults to the location UTC offset
         ///</summary>
-        [ApiMember(Description="Forces the response time values to a specific UTC offset. Defaults to the location UTC offset", DataType="double")]
+        [ApiMember(DataType="double", Description="Forces the response time values to a specific UTC offset. Defaults to the location UTC offset")]
         public double? UtcOffset { get; set; }
 
         ///<summary>
         ///Table start value. Required for equation-based ratings. Defaults to minimum table value for table-based ratings
         ///</summary>
-        [ApiMember(Description="Table start value. Required for equation-based ratings. Defaults to minimum table value for table-based ratings", DataType="double")]
+        [ApiMember(DataType="double", Description="Table start value. Required for equation-based ratings. Defaults to minimum table value for table-based ratings")]
         public double? StartValue { get; set; }
 
         ///<summary>
         ///Table end value. Required for equation-based ratings. Defaults to maximum table value for table-based ratings
         ///</summary>
-        [ApiMember(Description="Table end value. Required for equation-based ratings. Defaults to maximum table value for table-based ratings", DataType="double")]
+        [ApiMember(DataType="double", Description="Table end value. Required for equation-based ratings. Defaults to maximum table value for table-based ratings")]
         public double? EndValue { get; set; }
 
         ///<summary>
         ///Effective time of the calculation. Defaults to the current time if not specified
         ///</summary>
-        [ApiMember(Description="Effective time of the calculation. Defaults to the current time if not specified", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Effective time of the calculation. Defaults to the current time if not specified")]
         public DateTimeOffset? EffectiveTime { get; set; }
     }
 
@@ -4284,31 +4285,31 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///The unique ID of the time series
         ///</summary>
-        [ApiMember(IsRequired=true, Description="The unique ID of the time series", DataType="string")]
+        [ApiMember(DataType="string", Description="The unique ID of the time series", IsRequired=true)]
         public Guid TimeSeriesUniqueId { get; set; }
 
         ///<summary>
         ///Table step size increment. Defaults to 0.01
         ///</summary>
-        [ApiMember(Description="Table step size increment. Defaults to 0.01", DataType="double")]
+        [ApiMember(DataType="double", Description="Table step size increment. Defaults to 0.01")]
         public double? StepSize { get; set; }
 
         ///<summary>
         ///Forces the response time values to a specific UTC offset. Defaults to the time series UTC offset
         ///</summary>
-        [ApiMember(Description="Forces the response time values to a specific UTC offset. Defaults to the time series UTC offset", DataType="double")]
+        [ApiMember(DataType="double", Description="Forces the response time values to a specific UTC offset. Defaults to the time series UTC offset")]
         public double? UtcOffset { get; set; }
 
         ///<summary>
         ///Table starting value
         ///</summary>
-        [ApiMember(IsRequired=true, Description="Table starting value", DataType="double")]
+        [ApiMember(DataType="double", Description="Table starting value", IsRequired=true)]
         public double? StartValue { get; set; }
 
         ///<summary>
         ///Table ending value
         ///</summary>
-        [ApiMember(IsRequired=true, Description="Table ending value", DataType="double")]
+        [ApiMember(DataType="double", Description="Table ending value", IsRequired=true)]
         public double? EndValue { get; set; }
     }
 
@@ -4319,7 +4320,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Field visit identifier
         ///</summary>
-        [ApiMember(IsRequired=true, Description="Field visit identifier")]
+        [ApiMember(Description="Field visit identifier", IsRequired=true)]
         public string FieldVisitIdentifier { get; set; }
 
         ///<summary>
@@ -4331,19 +4332,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///True if node details (raw JSON of each specific activity) should be included
         ///</summary>
-        [ApiMember(Description="True if node details (raw JSON of each specific activity) should be included", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if node details (raw JSON of each specific activity) should be included")]
         public bool? IncludeNodeDetails { get; set; }
 
         ///<summary>
         ///True if invalid activities (requiring operator intervention) should be included
         ///</summary>
-        [ApiMember(Description="True if invalid activities (requiring operator intervention) should be included", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if invalid activities (requiring operator intervention) should be included")]
         public bool? IncludeInvalidActivities { get; set; }
 
         ///<summary>
         ///True if data values should have rounding rules applied
         ///</summary>
-        [ApiMember(Description="True if data values should have rounding rules applied", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if data values should have rounding rules applied")]
         public bool? ApplyRounding { get; set; }
     }
 
@@ -4360,7 +4361,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Filter results to items with a StartTime at or after the QueryFrom time
         ///</summary>
-        [ApiMember(Description="Filter results to items with a StartTime at or after the QueryFrom time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items with a StartTime at or after the QueryFrom time")]
         public DateTimeOffset? QueryFrom { get; set; }
 
         ///<summary>
@@ -4372,13 +4373,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///True if the results should include invalid field visits which require operator attention.
         ///</summary>
-        [ApiMember(Description="True if the results should include invalid field visits which require operator attention.", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if the results should include invalid field visits which require operator attention.")]
         public bool? IncludeInvalidFieldVisits { get; set; }
 
         ///<summary>
         ///Filter results to items modified at or after the ChangesSinceToken time
         ///</summary>
-        [ApiMember(Description="Filter results to items modified at or after the ChangesSinceToken time", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Filter results to items modified at or after the ChangesSinceToken time")]
         public DateTime? ChangesSinceToken { get; set; }
     }
 
@@ -4418,13 +4419,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Location identifier
         ///</summary>
-        [ApiMember(IsRequired=true, Description="Location identifier")]
+        [ApiMember(Description="Location identifier", IsRequired=true)]
         public string LocationIdentifier { get; set; }
 
         ///<summary>
         ///True if location attachments should be included in the results
         ///</summary>
-        [ApiMember(Description="True if location attachments should be included in the results", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if location attachments should be included in the results")]
         public bool? IncludeLocationAttachments { get; set; }
     }
 
@@ -4458,13 +4459,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Filter results to items matching the given extended attribute values
         ///</summary>
-        [ApiMember(Description="Filter results to items matching the given extended attribute values", DataType="Array<ExtendedAttributeFilter>")]
+        [ApiMember(DataType="Array<ExtendedAttributeFilter>", Description="Filter results to items matching the given extended attribute values")]
         public List<ExtendedAttributeFilter> ExtendedFilters { get; set; }
 
         ///<summary>
         ///Filter results to items modified at or after the ChangesSinceToken time
         ///</summary>
-        [ApiMember(Description="Filter results to items modified at or after the ChangesSinceToken time", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Filter results to items modified at or after the ChangesSinceToken time")]
         public DateTime? ChangesSinceToken { get; set; }
     }
 
@@ -4475,19 +4476,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///The unique ID of the time series
         ///</summary>
-        [ApiMember(IsRequired=true, Description="The unique ID of the time series", DataType="string")]
+        [ApiMember(DataType="string", Description="The unique ID of the time series", IsRequired=true)]
         public Guid TimeSeriesUniqueId { get; set; }
 
         ///<summary>
         ///Filter results to items with a StartTime at or after the QueryFrom time
         ///</summary>
-        [ApiMember(Description="Filter results to items with a StartTime at or after the QueryFrom time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items with a StartTime at or after the QueryFrom time")]
         public DateTimeOffset? QueryFrom { get; set; }
 
         ///<summary>
         ///Filter results to items with an EndTime at or before the QueryTo time
         ///</summary>
-        [ApiMember(Description="Filter results to items with an EndTime at or before the QueryTo time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items with an EndTime at or before the QueryTo time")]
         public DateTimeOffset? QueryTo { get; set; }
     }
 
@@ -4516,25 +4517,25 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Rating model identifier
         ///</summary>
-        [ApiMember(IsRequired=true, Description="Rating model identifier")]
+        [ApiMember(Description="Rating model identifier", IsRequired=true)]
         public string RatingModelIdentifier { get; set; }
 
         ///<summary>
         ///Forces the response time values to a specific UTC offset. Defaults to the location UTC offset
         ///</summary>
-        [ApiMember(Description="Forces the response time values to a specific UTC offset. Defaults to the location UTC offset", DataType="double")]
+        [ApiMember(DataType="double", Description="Forces the response time values to a specific UTC offset. Defaults to the location UTC offset")]
         public double? UtcOffset { get; set; }
 
         ///<summary>
         ///Filter results to curves with a Period.StartTime at or after the QueryFrom time
         ///</summary>
-        [ApiMember(Description="Filter results to curves with a Period.StartTime at or after the QueryFrom time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to curves with a Period.StartTime at or after the QueryFrom time")]
         public DateTimeOffset? QueryFrom { get; set; }
 
         ///<summary>
         ///Filter results to curves with a Period.EndTime at or before the QueryTo time
         ///</summary>
-        [ApiMember(Description="Filter results to curves with a Period.EndTime at or before the QueryTo time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to curves with a Period.EndTime at or before the QueryTo time")]
         public DateTimeOffset? QueryTo { get; set; }
     }
 
@@ -4551,7 +4552,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Filter results to items matching the Publish value
         ///</summary>
-        [ApiMember(Description="Filter results to items matching the Publish value", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Filter results to items matching the Publish value")]
         public bool? Publish { get; set; }
 
         ///<summary>
@@ -4569,7 +4570,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Filter results to items modified at or after the ChangesSinceToken time
         ///</summary>
-        [ApiMember(Description="Filter results to items modified at or after the ChangesSinceToken time", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Filter results to items modified at or after the ChangesSinceToken time")]
         public DateTime? ChangesSinceToken { get; set; }
     }
 
@@ -4580,25 +4581,25 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Unique ID of the input time series
         ///</summary>
-        [ApiMember(IsRequired=true, Description="Unique ID of the input time series", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique ID of the input time series", IsRequired=true)]
         public Guid TimeSeriesUniqueId { get; set; }
 
         ///<summary>
         ///Rating model identifier
         ///</summary>
-        [ApiMember(IsRequired=true, Description="Rating model identifier")]
+        [ApiMember(Description="Rating model identifier", IsRequired=true)]
         public string RatingModelIdentifier { get; set; }
 
         ///<summary>
         ///Read the input time series starting at the QueryFrom time. Defaults to beginning of record
         ///</summary>
-        [ApiMember(Description="Read the input time series starting at the QueryFrom time. Defaults to beginning of record", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Read the input time series starting at the QueryFrom time. Defaults to beginning of record")]
         public DateTimeOffset? QueryFrom { get; set; }
 
         ///<summary>
         ///Read the input time series ending at the QueryTo time. Defaults to the end of record.
         ///</summary>
-        [ApiMember(Description="Read the input time series ending at the QueryTo time. Defaults to the end of record.", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Read the input time series ending at the QueryTo time. Defaults to the end of record.")]
         public DateTimeOffset? QueryTo { get; set; }
     }
 
@@ -4614,19 +4615,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Rating model identifier
         ///</summary>
-        [ApiMember(IsRequired=true, Description="Rating model identifier")]
+        [ApiMember(Description="Rating model identifier", IsRequired=true)]
         public string RatingModelIdentifier { get; set; }
 
         ///<summary>
         ///Output values
         ///</summary>
-        [ApiMember(IsRequired=true, Description="Output values", DataType="Array<double>")]
+        [ApiMember(DataType="Array<double>", Description="Output values", IsRequired=true)]
         public List<double> OutputValues { get; set; }
 
         ///<summary>
         ///Effective time of the calculation. Defaults to the current time if not specified
         ///</summary>
-        [ApiMember(Description="Effective time of the calculation. Defaults to the current time if not specified", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Effective time of the calculation. Defaults to the current time if not specified")]
         public DateTimeOffset? EffectiveTime { get; set; }
     }
 
@@ -4648,19 +4649,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Input values
         ///</summary>
-        [ApiMember(Description="Input values", DataType="Array<double>")]
+        [ApiMember(DataType="Array<double>", Description="Input values")]
         public List<double> InputValues { get; set; }
 
         ///<summary>
         ///Effective time of the calculation. Defaults to the current time if not specified
         ///</summary>
-        [ApiMember(Description="Effective time of the calculation. Defaults to the current time if not specified", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Effective time of the calculation. Defaults to the current time if not specified")]
         public DateTimeOffset? EffectiveTime { get; set; }
 
         ///<summary>
         ///Set to false to disable rating curve shifts, otherwise true
         ///</summary>
-        [ApiMember(Description="Set to false to disable rating curve shifts, otherwise true", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Set to false to disable rating curve shifts, otherwise true")]
         public bool? ApplyShifts { get; set; }
     }
 
@@ -4671,7 +4672,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Location identifier
         ///</summary>
-        [ApiMember(IsRequired=true, Description="Location identifier")]
+        [ApiMember(Description="Location identifier", IsRequired=true)]
         public string LocationIdentifier { get; set; }
     }
 
@@ -4688,37 +4689,37 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///The unique IDs of the time-series to retrieve
         ///</summary>
-        [ApiMember(IsRequired=true, Description="The unique IDs of the time-series to retrieve", DataType="Array<string>")]
+        [ApiMember(DataType="Array<string>", Description="The unique IDs of the time-series to retrieve", IsRequired=true)]
         public List<Guid> TimeSeriesUniqueIds { get; set; }
 
         ///<summary>
         ///The unit identifiers for points. Defaults to the time-series unit
         ///</summary>
-        [ApiMember(Description="The unit identifiers for points. Defaults to the time-series unit", DataType="Array<string>")]
+        [ApiMember(DataType="Array<string>", Description="The unit identifiers for points. Defaults to the time-series unit")]
         public List<string> TimeSeriesOutputUnitIds { get; set; }
 
         ///<summary>
         ///Filter results to items at or after the QueryFrom time
         ///</summary>
-        [ApiMember(Description="Filter results to items at or after the QueryFrom time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items at or after the QueryFrom time")]
         public DateTimeOffset? QueryFrom { get; set; }
 
         ///<summary>
         ///Filter results to items at or before the QueryTo time
         ///</summary>
-        [ApiMember(Description="Filter results to items at or before the QueryTo time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items at or before the QueryTo time")]
         public DateTimeOffset? QueryTo { get; set; }
 
         ///<summary>
         ///Forces the response time values to a specific UTC offset. Defaults to the UTC offset of the first time-series
         ///</summary>
-        [ApiMember(Description="Forces the response time values to a specific UTC offset. Defaults to the UTC offset of the first time-series", DataType="double")]
+        [ApiMember(DataType="double", Description="Forces the response time values to a specific UTC offset. Defaults to the UTC offset of the first time-series")]
         public double? UtcOffset { get; set; }
 
         ///<summary>
         ///True if data values should have rounding rules applied
         ///</summary>
-        [ApiMember(Description="True if data values should have rounding rules applied", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if data values should have rounding rules applied")]
         public bool? ApplyRounding { get; set; }
 
         ///<summary>
@@ -4735,19 +4736,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///The unique ID of the time series
         ///</summary>
-        [ApiMember(IsRequired=true, Description="The unique ID of the time series", DataType="string")]
+        [ApiMember(DataType="string", Description="The unique ID of the time series", IsRequired=true)]
         public Guid TimeSeriesUniqueId { get; set; }
 
         ///<summary>
         ///Filter results to items with a StartTime at or after the QueryFrom time
         ///</summary>
-        [ApiMember(Description="Filter results to items with a StartTime at or after the QueryFrom time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items with a StartTime at or after the QueryFrom time")]
         public DateTimeOffset? QueryFrom { get; set; }
 
         ///<summary>
         ///Filter results to items with an EndTime at or before the QueryTo time
         ///</summary>
-        [ApiMember(Description="Filter results to items with an EndTime at or before the QueryTo time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items with an EndTime at or before the QueryTo time")]
         public DateTimeOffset? QueryTo { get; set; }
     }
 
@@ -4758,19 +4759,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///The unique ID of the time series
         ///</summary>
-        [ApiMember(IsRequired=true, Description="The unique ID of the time series", DataType="string")]
+        [ApiMember(DataType="string", Description="The unique ID of the time series", IsRequired=true)]
         public Guid TimeSeriesUniqueId { get; set; }
 
         ///<summary>
         ///Filter results to items at or after the QueryFrom time
         ///</summary>
-        [ApiMember(Description="Filter results to items at or after the QueryFrom time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items at or after the QueryFrom time")]
         public DateTimeOffset? QueryFrom { get; set; }
 
         ///<summary>
         ///Filter results to items at or before the QueryTo time
         ///</summary>
-        [ApiMember(Description="Filter results to items at or before the QueryTo time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items at or before the QueryTo time")]
         public DateTimeOffset? QueryTo { get; set; }
 
         ///<summary>
@@ -4788,25 +4789,25 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Forces the response time values to a specific UTC offset. Defaults to the time series UTC offset
         ///</summary>
-        [ApiMember(Description="Forces the response time values to a specific UTC offset. Defaults to the time series UTC offset", DataType="double")]
+        [ApiMember(DataType="double", Description="Forces the response time values to a specific UTC offset. Defaults to the time series UTC offset")]
         public double? UtcOffset { get; set; }
 
         ///<summary>
         ///True if data values should have rounding rules applied
         ///</summary>
-        [ApiMember(Description="True if data values should have rounding rules applied", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if data values should have rounding rules applied")]
         public bool? ApplyRounding { get; set; }
 
         ///<summary>
         ///Defaults to false. See the API reference guide for details
         ///</summary>
-        [ApiMember(Description="Defaults to false. See the API reference guide for details", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Defaults to false. See the API reference guide for details")]
         public bool? ReturnFullCoverage { get; set; }
 
         ///<summary>
         ///True if the point results should include gap markers
         ///</summary>
-        [ApiMember(Description="True if the point results should include gap markers", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if the point results should include gap markers")]
         public bool? IncludeGapMarkers { get; set; }
     }
 
@@ -4817,19 +4818,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///The unique ID of the time series
         ///</summary>
-        [ApiMember(IsRequired=true, Description="The unique ID of the time series", DataType="string")]
+        [ApiMember(DataType="string", Description="The unique ID of the time series", IsRequired=true)]
         public Guid TimeSeriesUniqueId { get; set; }
 
         ///<summary>
         ///Filter results to items at or after the QueryFrom time
         ///</summary>
-        [ApiMember(Description="Filter results to items at or after the QueryFrom time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items at or after the QueryFrom time")]
         public DateTimeOffset? QueryFrom { get; set; }
 
         ///<summary>
         ///Filter results to items at or before the QueryTo time
         ///</summary>
-        [ApiMember(Description="Filter results to items at or before the QueryTo time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items at or before the QueryTo time")]
         public DateTimeOffset? QueryTo { get; set; }
 
         ///<summary>
@@ -4847,13 +4848,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Forces the response time values to a specific UTC offset. Defaults to the time series UTC offset
         ///</summary>
-        [ApiMember(Description="Forces the response time values to a specific UTC offset. Defaults to the time series UTC offset", DataType="double")]
+        [ApiMember(DataType="double", Description="Forces the response time values to a specific UTC offset. Defaults to the time series UTC offset")]
         public double? UtcOffset { get; set; }
 
         ///<summary>
         ///True if data values should have rounding rules applied
         ///</summary>
-        [ApiMember(Description="True if data values should have rounding rules applied", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="True if data values should have rounding rules applied")]
         public bool? ApplyRounding { get; set; }
     }
 
@@ -4869,7 +4870,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///A collection of time series unique IDs to query. Limited to roughly 60 items per request.
         ///</summary>
-        [ApiMember(Description="A collection of time series unique IDs to query. Limited to roughly 60 items per request.", DataType="Array<string>")]
+        [ApiMember(DataType="Array<string>", Description="A collection of time series unique IDs to query. Limited to roughly 60 items per request.")]
         public List<Guid> TimeSeriesUniqueIds { get; set; }
     }
 
@@ -4897,7 +4898,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Filter results to items matching the Publish value
         ///</summary>
-        [ApiMember(Description="Filter results to items matching the Publish value", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Filter results to items matching the Publish value")]
         public bool? Publish { get; set; }
 
         ///<summary>
@@ -4915,7 +4916,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Filter results to items matching the given extended attribute values
         ///</summary>
-        [ApiMember(Description="Filter results to items matching the given extended attribute values", DataType="Array<ExtendedAttributeFilter>")]
+        [ApiMember(DataType="Array<ExtendedAttributeFilter>", Description="Filter results to items matching the given extended attribute values")]
         public List<ExtendedAttributeFilter> ExtendedFilters { get; set; }
     }
 
@@ -4931,7 +4932,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Filter results to items modified at or after the ChangesSinceToken time
         ///</summary>
-        [ApiMember(Description="Filter results to items modified at or after the ChangesSinceToken time", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Filter results to items modified at or after the ChangesSinceToken time")]
         public DateTime? ChangesSinceToken { get; set; }
 
         ///<summary>
@@ -4955,7 +4956,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Filter results to items matching the Publish value
         ///</summary>
-        [ApiMember(Description="Filter results to items matching the Publish value", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Filter results to items matching the Publish value")]
         public bool? Publish { get; set; }
 
         ///<summary>
@@ -4973,7 +4974,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Filter results to items matching the given extended attribute values
         ///</summary>
-        [ApiMember(Description="Filter results to items matching the given extended attribute values", DataType="Array<ExtendedAttributeFilter>")]
+        [ApiMember(DataType="Array<ExtendedAttributeFilter>", Description="Filter results to items matching the given extended attribute values")]
         public List<ExtendedAttributeFilter> ExtendedFilters { get; set; }
     }
 
@@ -4990,19 +4991,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Unique ID of the time series
         ///</summary>
-        [ApiMember(IsRequired=true, Description="Unique ID of the time series", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique ID of the time series", IsRequired=true)]
         public Guid TimeSeriesUniqueId { get; set; }
 
         ///<summary>
         ///Filter results to items with a ProcessorPeriod.StartTime at or after the QueryFrom time
         ///</summary>
-        [ApiMember(Description="Filter results to items with a ProcessorPeriod.StartTime at or after the QueryFrom time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items with a ProcessorPeriod.StartTime at or after the QueryFrom time")]
         public DateTimeOffset? QueryFrom { get; set; }
 
         ///<summary>
         ///Filter results to items with a ProcessorPeriod.EndTime at or before the QueryTo time
         ///</summary>
-        [ApiMember(Description="Filter results to items with a ProcessorPeriod.EndTime at or before the QueryTo time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items with a ProcessorPeriod.EndTime at or before the QueryTo time")]
         public DateTimeOffset? QueryTo { get; set; }
     }
 
@@ -5016,19 +5017,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
         ///Current meter details
         ///</summary>
-        [ApiMember(Description="Current meter details", DataType="Array<ActiveMeterDetails>")]
+        [ApiMember(DataType="Array<ActiveMeterDetails>", Description="Current meter details")]
         public List<ActiveMeterDetails> ActiveMeterDetails { get; set; }
     }
 
@@ -5042,13 +5043,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5060,7 +5061,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Approvals
         ///</summary>
-        [ApiMember(Description="Approvals", DataType="Array<ApprovalMetadata>")]
+        [ApiMember(DataType="Array<ApprovalMetadata>", Description="Approvals")]
         public List<ApprovalMetadata> Approvals { get; set; }
     }
 
@@ -5074,13 +5075,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5092,7 +5093,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Corrections
         ///</summary>
-        [ApiMember(Description="Corrections", DataType="Array<Correction>")]
+        [ApiMember(DataType="Array<Correction>", Description="Corrections")]
         public List<Correction> Corrections { get; set; }
     }
 
@@ -5101,13 +5102,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5119,7 +5120,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Expanded rating curve
         ///</summary>
-        [ApiMember(Description="Expanded rating curve", DataType="ExpandedRatingCurve")]
+        [ApiMember(DataType="ExpandedRatingCurve", Description="Expanded rating curve")]
         public ExpandedRatingCurve ExpandedRatingCurve { get; set; }
     }
 
@@ -5134,13 +5135,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5152,13 +5153,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Expanded stage table
         ///</summary>
-        [ApiMember(Description="Expanded stage table", DataType="Array<StagePoint>")]
+        [ApiMember(DataType="Array<StagePoint>", Description="Expanded stage table")]
         public List<StagePoint> ExpandedStageTable { get; set; }
 
         ///<summary>
         ///Corrections
         ///</summary>
-        [ApiMember(Description="Corrections", DataType="Array<Correction>")]
+        [ApiMember(DataType="Array<Correction>", Description="Corrections")]
         public List<Correction> Corrections { get; set; }
     }
 
@@ -5173,13 +5174,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5191,37 +5192,37 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Attachments
         ///</summary>
-        [ApiMember(Description="Attachments", DataType="Array<Attachment>")]
+        [ApiMember(DataType="Array<Attachment>", Description="Attachments")]
         public List<Attachment> Attachments { get; set; }
 
         ///<summary>
         ///Discharge activities
         ///</summary>
-        [ApiMember(Description="Discharge activities", DataType="Array<DischargeActivity>")]
+        [ApiMember(DataType="Array<DischargeActivity>", Description="Discharge activities")]
         public List<DischargeActivity> DischargeActivities { get; set; }
 
         ///<summary>
         ///Gage height at zero flow activity
         ///</summary>
-        [ApiMember(Description="Gage height at zero flow activity", DataType="GageHeightAtZeroFlowActivity")]
+        [ApiMember(DataType="GageHeightAtZeroFlowActivity", Description="Gage height at zero flow activity")]
         public GageHeightAtZeroFlowActivity GageHeightAtZeroFlowActivity { get; set; }
 
         ///<summary>
         ///Control condition activity
         ///</summary>
-        [ApiMember(Description="Control condition activity", DataType="ControlConditionActivity")]
+        [ApiMember(DataType="ControlConditionActivity", Description="Control condition activity")]
         public ControlConditionActivity ControlConditionActivity { get; set; }
 
         ///<summary>
         ///Inspection activity
         ///</summary>
-        [ApiMember(Description="Inspection activity", DataType="InspectionActivity")]
+        [ApiMember(DataType="InspectionActivity", Description="Inspection activity")]
         public InspectionActivity InspectionActivity { get; set; }
 
         ///<summary>
         ///Approval
         ///</summary>
-        [ApiMember(Description="Approval", DataType="FieldVisitApproval")]
+        [ApiMember(DataType="FieldVisitApproval", Description="Approval")]
         public FieldVisitApproval Approval { get; set; }
     }
 
@@ -5235,13 +5236,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5253,13 +5254,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Field visit descriptions
         ///</summary>
-        [ApiMember(Description="Field visit descriptions", DataType="Array<FieldVisitDescription>")]
+        [ApiMember(DataType="Array<FieldVisitDescription>", Description="Field visit descriptions")]
         public List<FieldVisitDescription> FieldVisitDescriptions { get; set; }
 
         ///<summary>
         ///Next token
         ///</summary>
-        [ApiMember(Description="Next token", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Next token")]
         public DateTime? NextToken { get; set; }
     }
 
@@ -5273,13 +5274,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5291,7 +5292,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Grades
         ///</summary>
-        [ApiMember(Description="Grades", DataType="Array<GradeMetadata>")]
+        [ApiMember(DataType="Array<GradeMetadata>", Description="Grades")]
         public List<GradeMetadata> Grades { get; set; }
     }
 
@@ -5307,13 +5308,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5343,7 +5344,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Unique id
         ///</summary>
-        [ApiMember(Description="Unique id", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique id")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
@@ -5361,19 +5362,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Latitude
         ///</summary>
-        [ApiMember(Description="Latitude", DataType="double")]
+        [ApiMember(DataType="double", Description="Latitude")]
         public double Latitude { get; set; }
 
         ///<summary>
         ///Longitude
         ///</summary>
-        [ApiMember(Description="Longitude", DataType="double")]
+        [ApiMember(DataType="double", Description="Longitude")]
         public double Longitude { get; set; }
 
         ///<summary>
         ///Srid
         ///</summary>
-        [ApiMember(Description="Srid", DataType="double")]
+        [ApiMember(DataType="double", Description="Srid")]
         public double Srid { get; set; }
 
         ///<summary>
@@ -5385,37 +5386,37 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Elevation
         ///</summary>
-        [ApiMember(Description="Elevation", DataType="double")]
+        [ApiMember(DataType="double", Description="Elevation")]
         public double Elevation { get; set; }
 
         ///<summary>
         ///Utc offset
         ///</summary>
-        [ApiMember(Description="Utc offset", DataType="double")]
+        [ApiMember(DataType="double", Description="Utc offset")]
         public double UtcOffset { get; set; }
 
         ///<summary>
         ///Extended attributes
         ///</summary>
-        [ApiMember(Description="Extended attributes", DataType="Array<ExtendedAttribute>")]
+        [ApiMember(DataType="Array<ExtendedAttribute>", Description="Extended attributes")]
         public List<ExtendedAttribute> ExtendedAttributes { get; set; }
 
         ///<summary>
         ///Location remarks
         ///</summary>
-        [ApiMember(Description="Location remarks", DataType="Array<LocationRemark>")]
+        [ApiMember(DataType="Array<LocationRemark>", Description="Location remarks")]
         public List<LocationRemark> LocationRemarks { get; set; }
 
         ///<summary>
         ///Attachments
         ///</summary>
-        [ApiMember(Description="Attachments", DataType="Array<Attachment>")]
+        [ApiMember(DataType="Array<Attachment>", Description="Attachments")]
         public List<Attachment> Attachments { get; set; }
 
         ///<summary>
         ///Location datum
         ///</summary>
-        [ApiMember(Description="Location datum", DataType="LocationDatum")]
+        [ApiMember(DataType="LocationDatum", Description="Location datum")]
         public LocationDatum LocationDatum { get; set; }
     }
 
@@ -5429,13 +5430,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5447,13 +5448,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Location descriptions
         ///</summary>
-        [ApiMember(Description="Location descriptions", DataType="Array<LocationDescription>")]
+        [ApiMember(DataType="Array<LocationDescription>", Description="Location descriptions")]
         public List<LocationDescription> LocationDescriptions { get; set; }
 
         ///<summary>
         ///Next token
         ///</summary>
-        [ApiMember(Description="Next token", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Next token")]
         public DateTime? NextToken { get; set; }
     }
 
@@ -5462,13 +5463,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5480,7 +5481,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Metadata change transactions
         ///</summary>
-        [ApiMember(Description="Metadata change transactions", DataType="Array<MetadataChangeTransaction>")]
+        [ApiMember(DataType="Array<MetadataChangeTransaction>", Description="Metadata change transactions")]
         public IList<MetadataChangeTransaction> MetadataChangeTransactions { get; set; }
     }
 
@@ -5494,13 +5495,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Response time")]
         public DateTime ResponseTime { get; set; }
 
         ///<summary>
@@ -5512,7 +5513,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Monitoring methods
         ///</summary>
-        [ApiMember(Description="Monitoring methods", DataType="Array<MonitoringMethod>")]
+        [ApiMember(DataType="Array<MonitoringMethod>", Description="Monitoring methods")]
         public List<MonitoringMethod> MonitoringMethods { get; set; }
     }
 
@@ -5526,13 +5527,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5544,7 +5545,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Parameters
         ///</summary>
-        [ApiMember(Description="Parameters", DataType="Array<ParameterMetadata>")]
+        [ApiMember(DataType="Array<ParameterMetadata>", Description="Parameters")]
         public List<ParameterMetadata> Parameters { get; set; }
     }
 
@@ -5558,13 +5559,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5576,7 +5577,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Processors
         ///</summary>
-        [ApiMember(Description="Processors", DataType="Array<Processor>")]
+        [ApiMember(DataType="Array<Processor>", Description="Processors")]
         public List<Processor> Processors { get; set; }
     }
 
@@ -5590,13 +5591,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5608,7 +5609,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Qualifiers
         ///</summary>
-        [ApiMember(Description="Qualifiers", DataType="Array<QualifierMetadata>")]
+        [ApiMember(DataType="Array<QualifierMetadata>", Description="Qualifiers")]
         public List<QualifierMetadata> Qualifiers { get; set; }
     }
 
@@ -5617,13 +5618,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5635,13 +5636,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Rating curves
         ///</summary>
-        [ApiMember(Description="Rating curves", DataType="Array<RatingCurve>")]
+        [ApiMember(DataType="Array<RatingCurve>", Description="Rating curves")]
         public IList<RatingCurve> RatingCurves { get; set; }
 
         ///<summary>
         ///Approvals
         ///</summary>
-        [ApiMember(Description="Approvals", DataType="Array<Approval>")]
+        [ApiMember(DataType="Array<Approval>", Description="Approvals")]
         public IList<Approval> Approvals { get; set; }
     }
 
@@ -5650,13 +5651,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5668,13 +5669,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Rating model descriptions
         ///</summary>
-        [ApiMember(Description="Rating model descriptions", DataType="Array<RatingModelDescription>")]
+        [ApiMember(DataType="Array<RatingModelDescription>", Description="Rating model descriptions")]
         public IList<RatingModelDescription> RatingModelDescriptions { get; set; }
 
         ///<summary>
         ///Next token
         ///</summary>
-        [ApiMember(Description="Next token", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Next token")]
         public DateTime? NextToken { get; set; }
     }
 
@@ -5688,13 +5689,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5706,7 +5707,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Effective shifts
         ///</summary>
-        [ApiMember(Description="Effective shifts", DataType="Array<EffectiveShift>")]
+        [ApiMember(DataType="Array<EffectiveShift>", Description="Effective shifts")]
         public List<EffectiveShift> EffectiveShifts { get; set; }
     }
 
@@ -5720,13 +5721,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5738,7 +5739,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Input values
         ///</summary>
-        [ApiMember(Description="Input values", DataType="double")]
+        [ApiMember(DataType="double", Description="Input values")]
         public List<Nullable<Double>> InputValues { get; set; }
     }
 
@@ -5752,13 +5753,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5770,7 +5771,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Output values
         ///</summary>
-        [ApiMember(Description="Output values", DataType="double")]
+        [ApiMember(DataType="double", Description="Output values")]
         public List<Nullable<Double>> OutputValues { get; set; }
     }
 
@@ -5784,13 +5785,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5802,7 +5803,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Monitoring methods
         ///</summary>
-        [ApiMember(Description="Monitoring methods", DataType="Array<LocationMonitoringMethod>")]
+        [ApiMember(DataType="Array<LocationMonitoringMethod>", Description="Monitoring methods")]
         public List<LocationMonitoringMethod> MonitoringMethods { get; set; }
     }
 
@@ -5817,13 +5818,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5835,13 +5836,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Summary info of the retrieved time-series
         ///</summary>
-        [ApiMember(Description="Summary info of the retrieved time-series", DataType="Array<TimeAlignedTimeSeriesInfo>")]
+        [ApiMember(DataType="Array<TimeAlignedTimeSeriesInfo>", Description="Summary info of the retrieved time-series")]
         public List<TimeAlignedTimeSeriesInfo> TimeSeries { get; set; }
 
         ///<summary>
         ///Time range
         ///</summary>
-        [ApiMember(Description="Time range", DataType="TimeRange")]
+        [ApiMember(DataType="TimeRange", Description="Time range")]
         public TimeRange TimeRange { get; set; }
 
         ///<summary>
@@ -5853,7 +5854,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Points
         ///</summary>
-        [ApiMember(Description="Points", DataType="Array<TimeAlignedPoint>")]
+        [ApiMember(DataType="Array<TimeAlignedPoint>", Description="Points")]
         public List<TimeAlignedPoint> Points { get; set; }
     }
 
@@ -5862,13 +5863,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5880,7 +5881,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Approvals transactions
         ///</summary>
-        [ApiMember(Description="Approvals transactions", DataType="Array<ApprovalsTransaction>")]
+        [ApiMember(DataType="Array<ApprovalsTransaction>", Description="Approvals transactions")]
         public IList<ApprovalsTransaction> ApprovalsTransactions { get; set; }
     }
 
@@ -5901,13 +5902,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -5919,7 +5920,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Unique id
         ///</summary>
-        [ApiMember(Description="Unique id", DataType="string")]
+        [ApiMember(DataType="string", Description="Unique id")]
         public Guid UniqueId { get; set; }
 
         ///<summary>
@@ -5943,7 +5944,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Num points
         ///</summary>
-        [ApiMember(Description="Num points", DataType="long integer")]
+        [ApiMember(DataType="long integer", Description="Num points")]
         public long? NumPoints { get; set; }
 
         ///<summary>
@@ -5955,55 +5956,55 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Approvals
         ///</summary>
-        [ApiMember(Description="Approvals", DataType="Array<Approval>")]
+        [ApiMember(DataType="Array<Approval>", Description="Approvals")]
         public List<Approval> Approvals { get; set; }
 
         ///<summary>
         ///Qualifiers
         ///</summary>
-        [ApiMember(Description="Qualifiers", DataType="Array<Qualifier>")]
+        [ApiMember(DataType="Array<Qualifier>", Description="Qualifiers")]
         public List<Qualifier> Qualifiers { get; set; }
 
         ///<summary>
         ///Methods
         ///</summary>
-        [ApiMember(Description="Methods", DataType="Array<Method>")]
+        [ApiMember(DataType="Array<Method>", Description="Methods")]
         public List<Method> Methods { get; set; }
 
         ///<summary>
         ///Grades
         ///</summary>
-        [ApiMember(Description="Grades", DataType="Array<Grade>")]
+        [ApiMember(DataType="Array<Grade>", Description="Grades")]
         public List<Grade> Grades { get; set; }
 
         ///<summary>
         ///Gap tolerances
         ///</summary>
-        [ApiMember(Description="Gap tolerances", DataType="Array<GapTolerance>")]
+        [ApiMember(DataType="Array<GapTolerance>", Description="Gap tolerances")]
         public List<GapTolerance> GapTolerances { get; set; }
 
         ///<summary>
         ///Interpolation types
         ///</summary>
-        [ApiMember(Description="Interpolation types", DataType="Array<InterpolationType>")]
+        [ApiMember(DataType="Array<InterpolationType>", Description="Interpolation types")]
         public List<InterpolationType> InterpolationTypes { get; set; }
 
         ///<summary>
         ///Notes
         ///</summary>
-        [ApiMember(Description="Notes", DataType="Array<Note>")]
+        [ApiMember(DataType="Array<Note>", Description="Notes")]
         public List<Note> Notes { get; set; }
 
         ///<summary>
         ///Time range
         ///</summary>
-        [ApiMember(Description="Time range", DataType="StatisticalTimeRange")]
+        [ApiMember(DataType="StatisticalTimeRange", Description="Time range")]
         public StatisticalTimeRange TimeRange { get; set; }
 
         ///<summary>
         ///Points
         ///</summary>
-        [ApiMember(Description="Points", DataType="Array<TimeSeriesPoint>")]
+        [ApiMember(DataType="Array<TimeSeriesPoint>", Description="Points")]
         public List<TimeSeriesPoint> Points { get; set; }
     }
 
@@ -6017,13 +6018,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -6035,7 +6036,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Time series descriptions
         ///</summary>
-        [ApiMember(Description="Time series descriptions", DataType="Array<TimeSeriesDescription>")]
+        [ApiMember(DataType="Array<TimeSeriesDescription>", Description="Time series descriptions")]
         public List<TimeSeriesDescription> TimeSeriesDescriptions { get; set; }
     }
 
@@ -6049,13 +6050,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -6067,7 +6068,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Time series descriptions
         ///</summary>
-        [ApiMember(Description="Time series descriptions", DataType="Array<TimeSeriesDescription>")]
+        [ApiMember(DataType="Array<TimeSeriesDescription>", Description="Time series descriptions")]
         public List<TimeSeriesDescription> TimeSeriesDescriptions { get; set; }
     }
 
@@ -6081,13 +6082,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -6099,19 +6100,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Token expired
         ///</summary>
-        [ApiMember(Description="Token expired", DataType="boolean")]
+        [ApiMember(DataType="boolean", Description="Token expired")]
         public bool? TokenExpired { get; set; }
 
         ///<summary>
         ///Next token
         ///</summary>
-        [ApiMember(Description="Next token", DataType="DateTime")]
+        [ApiMember(DataType="DateTime", Description="Next token")]
         public DateTime? NextToken { get; set; }
 
         ///<summary>
         ///Time series unique ids
         ///</summary>
-        [ApiMember(Description="Time series unique ids", DataType="Array<TimeSeriesUniqueIds>")]
+        [ApiMember(DataType="Array<TimeSeriesUniqueIds>", Description="Time series unique ids")]
         public List<TimeSeriesUniqueIds> TimeSeriesUniqueIds { get; set; }
     }
 
@@ -6125,13 +6126,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Response version
         ///</summary>
-        [ApiMember(Description="Response version", DataType="integer")]
+        [ApiMember(DataType="integer", Description="Response version")]
         public int ResponseVersion { get; set; }
 
         ///<summary>
         ///Response time
         ///</summary>
-        [ApiMember(Description="Response time", DataType="DateTimeOffset")]
+        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
         public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
@@ -6143,7 +6144,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///<summary>
         ///Units
         ///</summary>
-        [ApiMember(Description="Units", DataType="Array<UnitMetadata>")]
+        [ApiMember(DataType="Array<UnitMetadata>", Description="Units")]
         public List<UnitMetadata> Units { get; set; }
     }
 

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2017-09-12 11:13:12
+Date: 2017-09-12 16:24:02
 Version: 4.512
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: http://autoserver17/AQUARIUS/Publish/v2
@@ -25,11 +25,10 @@ ExportValueTypes: True
 */
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Runtime.Serialization;
 using ServiceStack;
 using ServiceStack.DataAnnotations;
+using ServiceStack.Web;
 using NodaTime;
 using Aquarius.TimeSeries.Client.ServiceModels.Publish;
 

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
@@ -1,8 +1,8 @@
 /* Options:
-Date: 2017-05-18 16:16:30
-Version: 4.56
+Date: 2017-09-12 11:13:12
+Version: 4.512
 Tip: To override a DTO option, remove "//" prefix before updating
-BaseUrl: http://autoserver1/AQUARIUS/Publish/v2
+BaseUrl: http://autoserver17/AQUARIUS/Publish/v2
 
 GlobalNamespace: Aquarius.TimeSeries.Client.ServiceModels.Publish
 MakePartial: False
@@ -692,9 +692,9 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         public double OffsetToStandard { get; set; }
 
         ///<summary>
-        ///Measurement direction
+        ///Direction that positive measurements are taken in relation to the reference point
         ///</summary>
-        [ApiMember(DataType="MeasurementDirection", Description="Measurement direction")]
+        [ApiMember(DataType="MeasurementDirection", Description="Direction that positive measurements are taken in relation to the reference point")]
         public MeasurementDirection MeasurementDirection { get; set; }
 
         ///<summary>
@@ -861,8 +861,8 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public enum MeasurementDirection
     {
         Unknown,
-        TopDown,
-        BottomUp,
+        FromTopToBottom,
+        FromBottomToTop,
     }
 
     public enum MetadataChangeContentType
@@ -1462,6 +1462,119 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         public double Shift { get; set; }
     }
 
+    public class ReferencePoint
+    {
+        public ReferencePoint()
+        {
+            ReferencePointPeriods = new List<ReferencePointPeriod>{};
+        }
+
+        ///<summary>
+        ///Unique ID of the reference point
+        ///</summary>
+        [ApiMember(DataType="string", Description="Unique ID of the reference point")]
+        public Guid UniqueId { get; set; }
+
+        ///<summary>
+        ///Name
+        ///</summary>
+        [ApiMember(Description="Name")]
+        public string Name { get; set; }
+
+        ///<summary>
+        ///Description
+        ///</summary>
+        [ApiMember(Description="Description")]
+        public string Description { get; set; }
+
+        ///<summary>
+        ///Decommissioned date
+        ///</summary>
+        [ApiMember(DataType="DateTimeOffset", Description="Decommissioned date")]
+        public DateTimeOffset? DecommissionedDate { get; set; }
+
+        ///<summary>
+        ///Decommissioned reason
+        ///</summary>
+        [ApiMember(Description="Decommissioned reason")]
+        public string DecommissionedReason { get; set; }
+
+        ///<summary>
+        ///Latitude (WGS 84)
+        ///</summary>
+        [ApiMember(DataType="double", Description="Latitude (WGS 84)")]
+        public double? Latitude { get; set; }
+
+        ///<summary>
+        ///Longitude (WGS 84)
+        ///</summary>
+        [ApiMember(DataType="double", Description="Longitude (WGS 84)")]
+        public double? Longitude { get; set; }
+
+        ///<summary>
+        ///Periods of applicability
+        ///</summary>
+        [ApiMember(DataType="Array<ReferencePointPeriod>", Description="Periods of applicability")]
+        public List<ReferencePointPeriod> ReferencePointPeriods { get; set; }
+    }
+
+    public class ReferencePointPeriod
+    {
+        ///<summary>
+        ///Standard Identifier. Empty when the elevation is measured against the local assumed datum.
+        ///</summary>
+        [ApiMember(Description="Standard Identifier. Empty when the elevation is measured against the local assumed datum.")]
+        public string StandardIdentifier { get; set; }
+
+        ///<summary>
+        ///True if this period is measured against the location's local assumed datum instead of a standard datum
+        ///</summary>
+        [ApiMember(DataType="boolean", Description="True if this period is measured against the location's local assumed datum instead of a standard datum")]
+        public bool IsMeasuredAgainstLocalAssumedDatum { get; set; }
+
+        ///<summary>
+        ///Time this period is valid from
+        ///</summary>
+        [ApiMember(DataType="DateTimeOffset", Description="Time this period is valid from")]
+        public DateTimeOffset ValidFrom { get; set; }
+
+        ///<summary>
+        ///Unit identifier
+        ///</summary>
+        [ApiMember(Description="Unit identifier")]
+        public string Unit { get; set; }
+
+        ///<summary>
+        ///Elevation of the reference point relative to the standard or local assumed datum
+        ///</summary>
+        [ApiMember(DataType="double", Description="Elevation of the reference point relative to the standard or local assumed datum")]
+        public double Elevation { get; set; }
+
+        ///<summary>
+        ///Direction of positive elevations in relation to the reference point
+        ///</summary>
+        [ApiMember(DataType="MeasurementDirection", Description="Direction of positive elevations in relation to the reference point")]
+        public MeasurementDirection MeasurementDirection { get; set; }
+
+        ///<summary>
+        ///Comment
+        ///</summary>
+        [ApiMember(Description="Comment")]
+        public string Comment { get; set; }
+
+        ///<summary>
+        ///Applied date
+        ///</summary>
+        [ApiMember(DataType="DateTimeOffset", Description="Applied date")]
+        public DateTimeOffset AppliedTime { get; set; }
+
+        ///<summary>
+        ///Applied by user
+        ///</summary>
+        [ApiMember(Description="Applied by user")]
+        public string AppliedByUser { get; set; }
+    }
+
     public class ReferenceStandardOffset
     {
         ///<summary>
@@ -1475,6 +1588,86 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///</summary>
         [ApiMember(DataType="double", Description="Offset to reference standard")]
         public double OffsetToReferenceStandard { get; set; }
+    }
+
+    public class Report
+    {
+        public Report()
+        {
+            SourceTimeSeriesUniqueIds = new List<Guid>{};
+        }
+
+        ///<summary>
+        ///ReportUniqueId
+        ///</summary>
+        [ApiMember(DataType="string", Description="ReportUniqueId")]
+        public Guid ReportUniqueId { get; set; }
+
+        ///<summary>
+        ///Title
+        ///</summary>
+        [ApiMember(Description="Title")]
+        public string Title { get; set; }
+
+        ///<summary>
+        ///Description
+        ///</summary>
+        [ApiMember(Description="Description")]
+        public string Description { get; set; }
+
+        ///<summary>
+        ///Comments
+        ///</summary>
+        [ApiMember(Description="Comments")]
+        public string Comments { get; set; }
+
+        ///<summary>
+        ///Created time (UTC)
+        ///</summary>
+        [ApiMember(DataType="DateTime", Description="Created time (UTC)")]
+        public DateTime CreatedTime { get; set; }
+
+        ///<summary>
+        ///Time range of source data displayed in report (UTC)
+        ///</summary>
+        [ApiMember(DataType="TimeRange", Description="Time range of source data displayed in report (UTC)")]
+        public TimeRange SourceTimeRange { get; set; }
+
+        ///<summary>
+        ///Is transient
+        ///</summary>
+        [ApiMember(DataType="boolean", Description="Is transient")]
+        public bool IsTransient { get; set; }
+
+        ///<summary>
+        ///Source time-series unique IDs
+        ///</summary>
+        [ApiMember(DataType="Array<string>", Description="Source time-series unique IDs")]
+        public List<Guid> SourceTimeSeriesUniqueIds { get; set; }
+
+        ///<summary>
+        ///Location unique ID
+        ///</summary>
+        [ApiMember(DataType="string", Description="Location unique ID")]
+        public Guid LocationUniqueId { get; set; }
+
+        ///<summary>
+        ///Report creator's user unique ID
+        ///</summary>
+        [ApiMember(DataType="string", Description="Report creator's user unique ID")]
+        public Guid UserUniqueId { get; set; }
+
+        ///<summary>
+        ///Report creator's user name
+        ///</summary>
+        [ApiMember(Description="Report creator's user name")]
+        public string UserName { get; set; }
+
+        ///<summary>
+        ///Attachment URL
+        ///</summary>
+        [ApiMember(Description="Attachment URL")]
+        public string Url { get; set; }
     }
 
     public class StagePoint
@@ -3891,6 +4084,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         LoggerFile,
         GeneratedReport,
         Csv,
+        FieldDataPlugin,
     }
 
     public enum BaseFlowType
@@ -4665,6 +4859,40 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         public bool? ApplyShifts { get; set; }
     }
 
+    [Route("/GetReportList", "GET")]
+    public class ReportListServiceRequest
+        : IReturn<ReportListServiceResponse>
+    {
+        public ReportListServiceRequest()
+        {
+            TimeSeriesUniqueIds = new List<Guid>{};
+        }
+
+        ///<summary>
+        ///Location unique ID
+        ///</summary>
+        [ApiMember(DataType="string", Description="Location unique ID")]
+        public Guid? LocationUniqueId { get; set; }
+
+        ///<summary>
+        ///Source time-series unique IDs
+        ///</summary>
+        [ApiMember(DataType="Array<string>", Description="Source time-series unique IDs")]
+        public List<Guid> TimeSeriesUniqueIds { get; set; }
+
+        ///<summary>
+        ///Report creator's user unique ID
+        ///</summary>
+        [ApiMember(DataType="string", Description="Report creator's user unique ID")]
+        public Guid? UserUniqueId { get; set; }
+
+        ///<summary>
+        ///Filter results to items created at or after the CreatedFrom time
+        ///</summary>
+        [ApiMember(DataType="DateTimeOffset", Description="Filter results to items created at or after the CreatedFrom time")]
+        public DateTimeOffset? CreatedFrom { get; set; }
+    }
+
     [Route("/GetSensorsAndGauges", "GET")]
     public class SensorsAndGaugesServiceRequest
         : IReturn<SensorsAndGaugesServiceResponse>
@@ -5008,23 +5236,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class ActiveMetersAndCalibrationsServiceResponse
+        : PublishServiceResponse
     {
         public ActiveMetersAndCalibrationsServiceResponse()
         {
             ActiveMeterDetails = new List<ActiveMeterDetails>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
 
         ///<summary>
         ///Current meter details
@@ -5034,29 +5251,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class ApprovalListServiceResponse
+        : PublishServiceResponse
     {
         public ApprovalListServiceResponse()
         {
             Approvals = new List<ApprovalMetadata>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Approvals
@@ -5066,29 +5266,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class CorrectionListServiceResponse
+        : PublishServiceResponse
     {
         public CorrectionListServiceResponse()
         {
             Corrections = new List<Correction>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Corrections
@@ -5098,25 +5281,8 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class EffectiveRatingCurveServiceResponse
+        : PublishServiceResponse
     {
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
-
         ///<summary>
         ///Expanded rating curve
         ///</summary>
@@ -5125,30 +5291,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class ExpandedStageTableServiceResponse
+        : PublishServiceResponse
     {
         public ExpandedStageTableServiceResponse()
         {
             ExpandedStageTable = new List<StagePoint>{};
             Corrections = new List<Correction>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Expanded stage table
@@ -5164,30 +5313,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class FieldVisitDataServiceResponse
+        : PublishServiceResponse
     {
         public FieldVisitDataServiceResponse()
         {
             Attachments = new List<Attachment>{};
             DischargeActivities = new List<DischargeActivity>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Attachments
@@ -5227,29 +5359,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class FieldVisitDescriptionListServiceResponse
+        : PublishServiceResponse
     {
         public FieldVisitDescriptionListServiceResponse()
         {
             FieldVisitDescriptions = new List<FieldVisitDescription>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Field visit descriptions
@@ -5265,29 +5380,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class GradeListServiceResponse
+        : PublishServiceResponse
     {
         public GradeListServiceResponse()
         {
             Grades = new List<GradeMetadata>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Grades
@@ -5297,31 +5395,15 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class LocationDataServiceResponse
+        : PublishServiceResponse
     {
         public LocationDataServiceResponse()
         {
             ExtendedAttributes = new List<ExtendedAttribute>{};
             LocationRemarks = new List<LocationRemark>{};
             Attachments = new List<Attachment>{};
+            ReferencePoints = new List<ReferencePoint>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Location name
@@ -5418,32 +5500,21 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///</summary>
         [ApiMember(DataType="LocationDatum", Description="Location datum")]
         public LocationDatum LocationDatum { get; set; }
+
+        ///<summary>
+        ///Reference points
+        ///</summary>
+        [ApiMember(DataType="Array<ReferencePoint>", Description="Reference points")]
+        public List<ReferencePoint> ReferencePoints { get; set; }
     }
 
     public class LocationDescriptionListServiceResponse
+        : PublishServiceResponse
     {
         public LocationDescriptionListServiceResponse()
         {
             LocationDescriptions = new List<LocationDescription>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Location descriptions
@@ -5459,25 +5530,8 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class MetadataChangeTransactionListServiceResponse
+        : PublishServiceResponse
     {
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
-
         ///<summary>
         ///Metadata change transactions
         ///</summary>
@@ -5518,29 +5572,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class ParameterListServiceResponse
+        : PublishServiceResponse
     {
         public ParameterListServiceResponse()
         {
             Parameters = new List<ParameterMetadata>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Parameters
@@ -5550,29 +5587,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class ProcessorListServiceResponse
+        : PublishServiceResponse
     {
         public ProcessorListServiceResponse()
         {
             Processors = new List<Processor>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Processors
@@ -5581,13 +5601,8 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         public List<Processor> Processors { get; set; }
     }
 
-    public class QualifierListServiceResponse
+    public class PublishServiceResponse
     {
-        public QualifierListServiceResponse()
-        {
-            Qualifiers = new List<QualifierMetadata>{};
-        }
-
         ///<summary>
         ///Response version
         ///</summary>
@@ -5605,6 +5620,15 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///</summary>
         [ApiMember(Description="Summary")]
         public string Summary { get; set; }
+    }
+
+    public class QualifierListServiceResponse
+        : PublishServiceResponse
+    {
+        public QualifierListServiceResponse()
+        {
+            Qualifiers = new List<QualifierMetadata>{};
+        }
 
         ///<summary>
         ///Qualifiers
@@ -5614,25 +5638,8 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class RatingCurveListServiceResponse
+        : PublishServiceResponse
     {
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
-
         ///<summary>
         ///Rating curves
         ///</summary>
@@ -5647,25 +5654,8 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class RatingModelDescriptionListServiceResponse
+        : PublishServiceResponse
     {
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
-
         ///<summary>
         ///Rating model descriptions
         ///</summary>
@@ -5680,29 +5670,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class RatingModelEffectiveShiftsServiceResponse
+        : PublishServiceResponse
     {
         public RatingModelEffectiveShiftsServiceResponse()
         {
             EffectiveShifts = new List<EffectiveShift>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Effective shifts
@@ -5712,29 +5685,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class RatingModelInputValuesServiceResponse
+        : PublishServiceResponse
     {
         public RatingModelInputValuesServiceResponse()
         {
             InputValues = new List<Nullable<Double>>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Input values
@@ -5744,29 +5700,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class RatingModelOutputValuesServiceResponse
+        : PublishServiceResponse
     {
         public RatingModelOutputValuesServiceResponse()
         {
             OutputValues = new List<Nullable<Double>>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Output values
@@ -5775,30 +5714,28 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         public List<Nullable<Double>> OutputValues { get; set; }
     }
 
+    public class ReportListServiceResponse
+        : PublishServiceResponse
+    {
+        public ReportListServiceResponse()
+        {
+            Reports = new List<Report>{};
+        }
+
+        ///<summary>
+        ///Reports
+        ///</summary>
+        [ApiMember(DataType="Array<Report>", Description="Reports")]
+        public List<Report> Reports { get; set; }
+    }
+
     public class SensorsAndGaugesServiceResponse
+        : PublishServiceResponse
     {
         public SensorsAndGaugesServiceResponse()
         {
             MonitoringMethods = new List<LocationMonitoringMethod>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Monitoring methods
@@ -5808,30 +5745,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class TimeAlignedDataServiceResponse
+        : PublishServiceResponse
     {
         public TimeAlignedDataServiceResponse()
         {
             TimeSeries = new List<TimeAlignedTimeSeriesInfo>{};
             Points = new List<TimeAlignedPoint>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Summary info of the retrieved time-series
@@ -5859,25 +5779,8 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class TimeSeriesApprovalsTransactionListServiceResponse
+        : PublishServiceResponse
     {
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
-
         ///<summary>
         ///Approvals transactions
         ///</summary>
@@ -5886,6 +5789,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class TimeSeriesDataServiceResponse
+        : PublishServiceResponse
     {
         public TimeSeriesDataServiceResponse()
         {
@@ -5898,24 +5802,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
             Notes = new List<Note>{};
             Points = new List<TimeSeriesPoint>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Unique id
@@ -6009,29 +5895,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class TimeSeriesDescriptionListByUniqueIdServiceResponse
+        : PublishServiceResponse
     {
         public TimeSeriesDescriptionListByUniqueIdServiceResponse()
         {
             TimeSeriesDescriptions = new List<TimeSeriesDescription>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Time series descriptions
@@ -6041,29 +5910,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class TimeSeriesDescriptionListServiceResponse
+        : PublishServiceResponse
     {
         public TimeSeriesDescriptionListServiceResponse()
         {
             TimeSeriesDescriptions = new List<TimeSeriesDescription>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Time series descriptions
@@ -6073,29 +5925,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class TimeSeriesUniqueIdListServiceResponse
+        : PublishServiceResponse
     {
         public TimeSeriesUniqueIdListServiceResponse()
         {
             TimeSeriesUniqueIds = new List<TimeSeriesUniqueIds>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Token expired
@@ -6117,29 +5952,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     }
 
     public class UnitListServiceResponse
+        : PublishServiceResponse
     {
         public UnitListServiceResponse()
         {
             Units = new List<UnitMetadata>{};
         }
-
-        ///<summary>
-        ///Response version
-        ///</summary>
-        [ApiMember(DataType="integer", Description="Response version")]
-        public int ResponseVersion { get; set; }
-
-        ///<summary>
-        ///Response time
-        ///</summary>
-        [ApiMember(DataType="DateTimeOffset", Description="Response time")]
-        public DateTimeOffset ResponseTime { get; set; }
-
-        ///<summary>
-        ///Summary
-        ///</summary>
-        [ApiMember(Description="Summary")]
-        public string Summary { get; set; }
 
         ///<summary>
         ///Units
@@ -6161,6 +5979,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("17.2.81.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("17.3.86.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/generate_code_from_live_endpoint.sh
+++ b/src/Aquarius.Client/TimeSeries/Client/generate_code_from_live_endpoint.sh
@@ -37,7 +37,7 @@ ApiVersion=`echo "$ApiVersionJson" | sed -e "s/{\"ApiVersion\":\"//" -e "s/\"}//
 
 echo "Generating $OutputFile ..."
 OutputFile=$OutputPath/$EndPointName.cs
-curl -s -o "$OutputFile" "http://$ServerName/AQUARIUS/$EndPoint/types/csharp?MakePartial=false&MakeVirtual=false&ExportValueTypes=true&GlobalNamespace=$GlobalNamespace&DefaultNamespaces=System,System.Collections,System.Collections.Generic,System.Runtime.Serialization,ServiceStack,ServiceStack.DataAnnotations,NodaTime" || exit_abort "Can't read endpoint"
+curl -s -o "$OutputFile" "http://$ServerName/AQUARIUS/$EndPoint/types/csharp?MakePartial=false&MakeVirtual=false&ExportValueTypes=true&GlobalNamespace=$GlobalNamespace&DefaultNamespaces=System,System.Collections.Generic,ServiceStack,ServiceStack.DataAnnotations,ServiceStack.Web,NodaTime" || exit_abort "Can't read endpoint"
 
 # Append the generated version to the code
 echo "namespace $GlobalNamespace" >> "$OutputFile"


### PR DESCRIPTION
@erinlim-ai Will you have time to review this?
@BillChen-AI Can you have a look too?

I've regenerated the AQTS service models to pickup the new 17.3 API footprint.

It's best to review each of the 3 commits individually.

aeb2a96 - This is a noisy commit that actually has no real affect. It just reordered the properties of the `[ApiMember]` attributes of the AQTS 2017.2 DTOs, to make the diff of the *next* commit much simpler.

2aa2e01 - This is the real commit, the difference in the public API footprint from 2017.2 vs 2017.3.
