### PR TITLE
PF-87 Fix connection pool for sequential connections

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,12 +4,12 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
-### 17.4.12
-- Updated the service models for the 2017.14 release of AQUARIUS Time-Series
+### 17.4.13
+- Updated the service models for the 2017.14 release of AQUARIUS Samples
 - Added connection pooling support for AQTS connections, to minimize version-probes and authentication requests. When multiple threads are independently attempting to make authenticated requests, all threads will end up sharing the same authentication session. The last thread to exit will issue the `DELETE /session` requests to clean up server-side resources. This change is hidden behind the `AquariusClient.CreateConnectedClient()` factory method, so it should be transparent to consumers of the platform SDK.
 
-### 17.4.11
-- The release broke all the AQTS connections and has been pulled from NuGet. Please use a newer version of the SDK.
+### 17.4.12 / 17.4.11
+- These versions broke the fundamental AQTS connection logic and have been pulled from NuGet. Please use a newer version of the SDK.
 
 ### 17.4.9
 - Updated the service models for the 2017.4 release of AQUARIUS Time-Series

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/ConnectionTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/ConnectionTests.cs
@@ -13,6 +13,7 @@ namespace Aquarius.UnitTests.TimeSeries.Client
         private Connection _connection;
         private int _sessionCreateCount;
         private int _sessionDeleteCount;
+        private int _connectionRemovalCount;
 
         [SetUp]
         public void BeforeEachTest()
@@ -20,8 +21,9 @@ namespace Aquarius.UnitTests.TimeSeries.Client
             _fixture = new Fixture();
             _sessionCreateCount = 0;
             _sessionDeleteCount = 0;
+            _connectionRemovalCount = 0;
 
-            _connection = new Connection(_fixture.Create<string>(), _fixture.Create<string>(), SessionTokenCreator, DeleteSession);
+            _connection = new Connection(_fixture.Create<string>(), _fixture.Create<string>(), SessionTokenCreator, DeleteSession, RemoveConnection);
         }
 
         private string SessionTokenCreator(string username, string password)
@@ -36,12 +38,18 @@ namespace Aquarius.UnitTests.TimeSeries.Client
             ++_sessionDeleteCount;
         }
 
+        private void RemoveConnection(Connection connection)
+        {
+            ++_connectionRemovalCount;
+        }
+
         [Test]
         public void NewlyConstructedConnection_TracksOneConnection()
         {
             AssertExpectedConnectionCount(1);
             AssertExpectedSessionCreateCount(1);
             AssertExpectedSessionDeleteCount(0);
+            AssertExpectedConnectionRemovalCount(0);
         }
 
         private void AssertExpectedConnectionCount(int expectedCount)
@@ -59,6 +67,11 @@ namespace Aquarius.UnitTests.TimeSeries.Client
             _sessionDeleteCount.ShouldBeEquivalentTo(expectedCount, nameof(_sessionDeleteCount));
         }
 
+        private void AssertExpectedConnectionRemovalCount(int expectedCount)
+        {
+            _connectionRemovalCount.ShouldBeEquivalentTo(expectedCount, nameof(_connectionRemovalCount));
+        }
+
         [Test]
         public void IncrementConnectionCount_IncrementsConnectionCount()
         {
@@ -67,6 +80,7 @@ namespace Aquarius.UnitTests.TimeSeries.Client
             AssertExpectedConnectionCount(2);
             AssertExpectedSessionCreateCount(1);
             AssertExpectedSessionDeleteCount(0);
+            AssertExpectedConnectionRemovalCount(0);
         }
 
         [Test]
@@ -78,6 +92,7 @@ namespace Aquarius.UnitTests.TimeSeries.Client
 
             AssertExpectedSessionCreateCount(1);
             AssertExpectedSessionDeleteCount(0);
+            AssertExpectedConnectionRemovalCount(0);
         }
 
         [Test]
@@ -87,6 +102,7 @@ namespace Aquarius.UnitTests.TimeSeries.Client
 
             AssertExpectedSessionCreateCount(1);
             AssertExpectedSessionDeleteCount(1);
+            AssertExpectedConnectionRemovalCount(1);
         }
 
         [Test]
@@ -98,6 +114,7 @@ namespace Aquarius.UnitTests.TimeSeries.Client
 
             AssertExpectedSessionCreateCount(1);
             AssertExpectedSessionDeleteCount(0);
+            AssertExpectedConnectionRemovalCount(0);
         }
 
         [Test]
@@ -109,6 +126,8 @@ namespace Aquarius.UnitTests.TimeSeries.Client
 
             AssertExpectedSessionCreateCount(1);
             AssertExpectedSessionDeleteCount(0);
+            AssertExpectedConnectionRemovalCount(0);
+
             sessionToken.ShouldBeEquivalentTo(_connection.SessionToken, "the same session token should be retained");
         }
 
@@ -121,6 +140,8 @@ namespace Aquarius.UnitTests.TimeSeries.Client
 
             AssertExpectedSessionCreateCount(2);
             AssertExpectedSessionDeleteCount(1);
+            AssertExpectedConnectionRemovalCount(0);
+
             sessionToken.Should().NotBe(_connection.SessionToken, "a new session token should be created");
         }
     }

--- a/src/Aquarius.Client/TimeSeries/Client/Connection.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/Connection.cs
@@ -8,12 +8,18 @@ namespace Aquarius.TimeSeries.Client
         private readonly object _syncLock = new object();
         private readonly Stopwatch _idleTimer = Stopwatch.StartNew();
 
-        public Connection(string username, string password, Func<string, string, string> sessionTokenCreator, Action sessionDeleteAction)
+        public Connection(
+            string username,
+            string password,
+            Func<string, string, string> sessionTokenCreator,
+            Action sessionDeleteAction,
+            Action<Connection> connectionRemovalAction)
         {
             Username = username;
             Password = password;
             SessionTokenCreator = sessionTokenCreator;
             SessionDeleteAction = sessionDeleteAction;
+            ConnectionRemovalAction = connectionRemovalAction;
 
             CreateNewSession();
             ConnectionCount = 1;
@@ -29,6 +35,7 @@ namespace Aquarius.TimeSeries.Client
 
         private Func<string, string, string> SessionTokenCreator { get; }
         private Action SessionDeleteAction { get; }
+        private Action<Connection> ConnectionRemovalAction { get; }
         private string Username { get; }
         private string Password { get; }
 
@@ -65,9 +72,10 @@ namespace Aquarius.TimeSeries.Client
 
                 if (ConnectionCount != 0)
                     return;
-
-                SessionDeleteAction();
             }
+
+            SessionDeleteAction();
+            ConnectionRemovalAction(this);
         }
 
         public void IncrementConnectionCount()

--- a/src/Aquarius.Client/TimeSeries/Client/ConnectionPool.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ConnectionPool.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Aquarius.TimeSeries.Client
 {
@@ -32,7 +33,7 @@ namespace Aquarius.TimeSeries.Client
                     return connection;
                 }
 
-                connection = new Connection(username, password, sessionTokenCreator, sessionDeleteAction);
+                connection = new Connection(username, password, sessionTokenCreator, sessionDeleteAction, Remove);
 
                 _connections.Add(connectionKey, connection);
 
@@ -59,6 +60,19 @@ namespace Aquarius.TimeSeries.Client
             foreach (var connection in _connections.Values)
             {
                 connection.Close();
+            }
+        }
+
+        private void Remove(Connection connection)
+        {
+            lock (_syncLock)
+            {
+                var itemToRemove = _connections.FirstOrDefault(kvp => kvp.Value == connection);
+
+                if (itemToRemove.Value != null)
+                {
+                    _connections.Remove(itemToRemove.Key);
+                }
             }
         }
     }


### PR DESCRIPTION
The connection pool was failing for the second connection attempt to a previously-closed connection.

Added more unit tests to cover this very-common use-case.