### PR TITLE
Issue-59 Drop the SerializedName annotation from the generated service model classes

### DIFF
--- a/src/SamplesServiceModelGenerator/CodeGenerators/JavaCodeGenerator.cs
+++ b/src/SamplesServiceModelGenerator/CodeGenerators/JavaCodeGenerator.cs
@@ -153,8 +153,7 @@ namespace SamplesServiceModelGenerator.CodeGenerators
         private string CreateDtoProperty(string propertyName, string propertyTypeName)
         {
             // TODO: Add @ApiMember annotations to show parameter.Description if not empty
-            // TODO: Add @SerializeName
-            return $"@SerializedName(\"{propertyName.ToCamelCase()}\") public {propertyTypeName} {propertyName} = null;";
+            return $"public {propertyTypeName} {propertyName} = null;";
         }
 
         private string CreateDtoPropertyAccessors(string className, string propertyName, string propertyTypeName)

--- a/src/SamplesServiceModelGenerator/Program.cs
+++ b/src/SamplesServiceModelGenerator/Program.cs
@@ -93,7 +93,6 @@ namespace SamplesServiceModelGenerator
             {TargetLanguage.Java, string.Join(";",
                 "java.time.*",
                 "java.util.*",
-                "com.google.gson.annotations.SerializedName",
                 "com.google.gson.reflect.TypeToken",
                 "net.servicestack.client.*",
                 "com.aquaticinformatics.aquarius.sdk.AquariusServerVersion")},


### PR DESCRIPTION

Both the TimeSeries and Samples Java clients will need separate field naming strategies.
The @SerializedName annotation does not take priority over other GSON settings, so this needs to be solved within code.