### PR TITLE
Issue-74 Added automatic re-authentication for expired sessions

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,9 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
+### 18.6.2
+- Automatically re-authenticate an AQTS session if it expires. This means the `SessionKeepAlive()` method becomes obsolete.
+
 ### 18.6.1
 - Updated the service models for the AQUARIUS Time-Series 2018.2 release.
 

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/ConnectionTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/ConnectionTests.cs
@@ -149,5 +149,20 @@ namespace Aquarius.UnitTests.TimeSeries.Client
 
             sessionToken.Should().NotBe(_connection.SessionToken, "a new session token should be created");
         }
+
+        [Test]
+        public void ReAuthenticate_CreatesNewSessionWithoutDeletingExistingSession()
+        {
+            var sessionToken = _connection.SessionToken;
+
+            _connection.ReAuthenticate();
+
+            AssertExpectedSessionCreateCount(2);
+            AssertExpectedConnectionCount(1);
+            AssertExpectedSessionDeleteCount(0);
+            AssertExpectedConnectionRemovalCount(0);
+
+            sessionToken.Should().NotBe(_connection.SessionToken, "a new session token should be created");
+        }
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/Connection.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/Connection.cs
@@ -53,6 +53,14 @@ namespace Aquarius.TimeSeries.Client
             }
         }
 
+        public void ReAuthenticate()
+        {
+            lock (_syncLock)
+            {
+                CreateNewSession();
+            }
+        }
+
         public void RestartIdleTimer()
         {
             lock (_syncLock)

--- a/src/Aquarius.Client/TimeSeries/Client/Helpers/ClientHelper.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/Helpers/ClientHelper.cs
@@ -17,6 +17,12 @@ namespace Aquarius.TimeSeries.Client.Helpers
             client.Headers.Add(AuthenticationHeaders.AuthenticationHeaderNameKey, authenticationToken);
         }
 
+        public static void ClearAuthenticationToken(ServiceClientBase client)
+        {
+            client.Headers.Remove(AuthenticationHeaders.AuthenticationHeaderNameKey);
+            client.ClearCookies();
+        }
+
         public static string Login(IServiceClient client, string username, string password)
         {
             var publicKey = client.Get(new GetPublicKey());
@@ -85,8 +91,10 @@ namespace Aquarius.TimeSeries.Client.Helpers
             if (client == null)
                 throw new ArgumentNullException(nameof(client));
 
-            var builder = new UriBuilder(client.BaseUri);
-            builder.Path = baseUri;
+            var builder = new UriBuilder(client.BaseUri)
+            {
+                Path = baseUri
+            };
 
             var clone = new SdkServiceClient(builder.ToString());
 
@@ -95,6 +103,10 @@ namespace Aquarius.TimeSeries.Client.Helpers
                 clone.Headers.Remove(headerKey);
                 clone.Headers.Add(headerKey, client.Headers[headerKey]);
             }
+
+            clone.Timeout = client.Timeout;
+            clone.ReadWriteTimeout = client.ReadWriteTimeout;
+            clone.OnAuthenticationRequired = client.OnAuthenticationRequired;
 
             return clone;
         }

--- a/src/Aquarius.Client/TimeSeries/Client/IAquariusClient.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/IAquariusClient.cs
@@ -28,6 +28,7 @@ namespace Aquarius.TimeSeries.Client
         IEnumerable<TResponse> SendBatchRequests<TRequest, TResponse>(IServiceClient client, int batchSize, IEnumerable<TRequest> requests, CancellationToken? cancellationToken = null)
             where TRequest : IReturn<TResponse>;
 
+        [Obsolete("Sessions will now re-authenticate automatically if they expire.")]
         ScopeAction SessionKeepAlive();
     }
 }


### PR DESCRIPTION
Use the JsonServiceClient.OnAuthenticationRequired callback to re-authenticate when a session has expired.

This internal change will help long-running AQTS connections remain valid, without any client code changes.

The SessionKeepAlive() method becomes obsolete, but we'll keep it around for a while, to avoid any breaking changes.