### PR TITLE
Issue-83 Refactored the connection pool authentication / reauthentican flow

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,10 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
+### 18.7.4
+- Fixed a connection pool race condition which would lose the authenticated session when the SessionKeepAlive() timer expired.
+- Clients performing multi-threaded requests are urged to update to this SDK version. See Issue #83 for details.
+
 ### 18.7.3
 - `ReadEntireResponseTimeout` now actually defaults to 5 minutes as documented, instead of 4 minutes.
 

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/AuthenticatorTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/AuthenticatorTests.cs
@@ -1,0 +1,127 @@
+﻿using System;
+using Aquarius.TimeSeries.Client;
+using NSubstitute;
+using NUnit.Framework;
+using ServiceStack;
+using DeleteSession = Aquarius.TimeSeries.Client.ServiceModels.Publish.DeleteSession;
+using PostSession = Aquarius.TimeSeries.Client.ServiceModels.Publish.PostSession;
+using GetPublicKey = Aquarius.TimeSeries.Client.ServiceModels.Publish.GetPublicKey;
+using PublicKey = Aquarius.TimeSeries.Client.ServiceModels.Publish.PublicKey;
+
+#if AUTOFIXTURE4
+using AutoFixture;
+#else
+using Ploeh.AutoFixture;
+#endif
+
+namespace Aquarius.Client.UnitTests.TimeSeries.Client
+{
+    [TestFixture]
+    public class AuthenticatorTests
+    {
+        private IFixture _fixture;
+        private IServiceClient _mockServiceClient;
+
+        [SetUp]
+        public void BeforeEachTest()
+        {
+            _fixture = new Fixture();
+            _mockServiceClient = CreateMockServiceClient();
+
+            ConfigureSystemDetectorWithMockServiceClient();
+        }
+
+        private IServiceClient CreateMockServiceClient()
+        {
+            var mockServiceClient = Substitute.For<IServiceClient>();
+
+            mockServiceClient
+                .Get(Arg.Any<GetPublicKey>())
+                .Returns(new PublicKey
+                {
+                    KeySize = 1024,
+                    Xml = "<RSAKeyValue><Modulus>3GmH/grhUyuiWlBDhNliZN3PYy2JPxJ5nG4t1CmQW8ZGPSsWY1AYIEU3b0A7eKOL3BbAiQzn0GpaSU9HT452zKhqXE+G2nxw7Y0tJYfBzsTbBSPcHaUTHd/YyqDwDhuuJ+RrCqQfgnkq+YXnlCU1CJwVlF5HUyLWWHaUgaNlEqs=</Modulus><Exponent>AQAB</Exponent></RSAKeyValue>"
+                });
+
+            mockServiceClient
+                .Post(Arg.Any<PostSession>())
+                .Returns(Guid.NewGuid().ToString("N"));
+
+            return mockServiceClient;
+        }
+
+        private void ConfigureSystemDetectorWithMockServiceClient()
+        {
+            var detector = AquariusSystemDetector.Instance;
+
+            detector.ServiceClientFactory = s => _mockServiceClient;
+            detector.Reset();
+        }
+
+        [Test]
+        public void Login_SendsExpectedRequests()
+        {
+            var authenticator = CreateAuthenticator();
+
+            authenticator.Login(_fixture.Create<string>(), _fixture.Create<string>());
+
+            _mockServiceClient
+                .Received(1)
+                .Get(Arg.Any<GetPublicKey>());
+
+            _mockServiceClient
+                .Received(1)
+                .Post(Arg.Any<PostSession>());
+        }
+
+        [Test]
+        public void Logout_WithNgConnection_CallsDeleteSession()
+        {
+            SetupMockToReturnApiVersion("16.1");
+
+            var authenticator = CreateAuthenticator();
+            
+            authenticator.Logout();
+
+            AssertExpectedDeleteSessionRequests(1);
+        }
+
+        [Test]
+        public void Logout_With3xConnection_DoesNotCallDeleteSession()
+        {
+            SetupMockToReturnApiVersion("3.10");
+
+            var authenticator = CreateAuthenticator();
+
+            authenticator.Logout();
+
+            AssertExpectedDeleteSessionRequests(0);
+        }
+
+        private IAuthenticator CreateAuthenticator()
+        {
+            var authenticator = Authenticator.Create("dummyhost") as Authenticator;
+
+            if (authenticator != null)
+            {
+                authenticator.Client = _mockServiceClient;
+            }
+
+            return authenticator;
+        }
+
+        private void SetupMockToReturnApiVersion(string apiVersion)
+        {
+            _mockServiceClient
+                .Get(Arg.Any<AquariusSystemDetector.GetVersion>())
+                .ReturnsForAnyArgs(new AquariusSystemDetector.VersionResponse {ApiVersion = apiVersion});
+        }
+
+        private void AssertExpectedDeleteSessionRequests(int count)
+        {
+            _mockServiceClient
+                .Received(count)
+                .Delete(Arg.Any<DeleteSession>());
+        }
+    }
+}

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/ConnectionPoolTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/ConnectionPoolTests.cs
@@ -1,5 +1,6 @@
 ﻿using Aquarius.TimeSeries.Client;
 using FluentAssertions;
+using NSubstitute;
 using NUnit.Framework;
 
 #if AUTOFIXTURE4
@@ -8,7 +9,7 @@ using AutoFixture;
 using Ploeh.AutoFixture;
 #endif
 
-namespace Aquarius.UnitTests.TimeSeries.Client
+namespace Aquarius.Client.UnitTests.TimeSeries.Client
 {
     [TestFixture]
     public class ConnectionPoolTests
@@ -35,16 +36,7 @@ namespace Aquarius.UnitTests.TimeSeries.Client
 
         private Connection GetConnection(string hostname, string username, string password)
         {
-            return _connectionPool.GetConnection(hostname, username, password, CreateFakeSessionToken, DeleteSession);
-        }
-
-        private string CreateFakeSessionToken(string username, string password)
-        {
-            return $"Username={username} Password={password} Session={_fixture.Create<string>()}";
-        }
-
-        private void DeleteSession()
-        {
+            return _connectionPool.GetConnection(hostname, username, password, Substitute.For<IAuthenticator>());
         }
 
         private void AssertConnectionCount(Connection connection, int expectedCount)

--- a/src/Aquarius.Client/TimeSeries/Client/AquariusSystemDetector.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/AquariusSystemDetector.cs
@@ -66,13 +66,7 @@ namespace Aquarius.TimeSeries.Client
 
         private void InitializeOverrides()
         {
-            var overridesValue =
-#if NETFULL
-                ConfigurationManager.AppSettings["SystemDetectorOverrides"];
-#else
-// TODO: Figure out .NET Config API
-                string.Empty;
-#endif
+            var overridesValue = AppSettings.Get("SystemDetectorOverrides", string.Empty);
             SetOverrides(overridesValue);
         }
 

--- a/src/Aquarius.Client/TimeSeries/Client/Authenticator.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/Authenticator.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Reflection;
+using Aquarius.Helpers;
+using Aquarius.TimeSeries.Client.EndPoints;
+using Aquarius.TimeSeries.Client.Helpers;
+using ServiceStack;
+using ServiceStack.Logging;
+
+namespace Aquarius.TimeSeries.Client
+{
+    public class Authenticator : IAuthenticator
+    {
+        private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod().DeclaringType);
+
+        public static IAuthenticator Create(string hostname)
+        {
+            return new Authenticator(hostname);
+        }
+
+        internal IServiceClient Client { get; set; }
+        private AquariusServerVersion ServerVersion { get; }
+
+        private Authenticator(string hostname)
+        {
+            Client = new SdkServiceClient(PublishV2.ResolveEndpoint(hostname));
+
+            ServerVersion = AquariusSystemDetector.Instance.GetAquariusServerVersion(hostname);
+        }
+
+        public string Login(string username, string password)
+        {
+            return ClientHelper.Login(Client, username, password);
+        }
+
+        public void Logout()
+        {
+            try
+            {
+                if (!FirstNgVersion.IsLessThan(ServerVersion)) return;
+
+                ClientHelper.Logout(Client);
+            }
+            catch (Exception exception)
+            {
+                Log.Warn("Ignoring exception during disconnect", exception);
+            }
+        }
+
+        private static readonly AquariusServerVersion FirstNgVersion = AquariusServerVersion.Create("14");
+    }
+}

--- a/src/Aquarius.Client/TimeSeries/Client/ConnectionPool.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ConnectionPool.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Concurrent;
+﻿using System.Collections.Concurrent;
 using System.Linq;
 
 namespace Aquarius.TimeSeries.Client
@@ -7,6 +6,8 @@ namespace Aquarius.TimeSeries.Client
     public class ConnectionPool
     {
         public static readonly ConnectionPool Instance = new ConnectionPool();
+
+        private readonly object _syncLock = new object();
 
         private ConnectionPool()
         {
@@ -18,17 +19,19 @@ namespace Aquarius.TimeSeries.Client
             string hostname,
             string username,
             string password,
-            Func<string, string, string> sessionTokenCreator,
-            Action sessionDeleteAction)
+            IAuthenticator authenticator)
         {
-            return _connections.AddOrUpdate(
-                CreateConnectionKey(hostname, username, password),
-                key => new Connection(username, password, sessionTokenCreator, sessionDeleteAction, Remove),
-                (key, connection) =>
-                {
-                    connection.IncrementConnectionCount();
-                    return connection;
-                });
+            lock (_syncLock)
+            {
+                return _connections.AddOrUpdate(
+                    CreateConnectionKey(hostname, username, password),
+                    key => new Connection(hostname, username, password, authenticator, Remove),
+                    (key, connection) =>
+                    {
+                        connection.IncrementConnectionCount();
+                        return connection;
+                    });
+            }
         }
 
         private static string CreateConnectionKey(string hostname, string username, string password)
@@ -38,11 +41,13 @@ namespace Aquarius.TimeSeries.Client
 
         public void Reset()
         {
+            // ReSharper disable once InconsistentlySynchronizedField
             _connections.Clear();
         }
 
         public void Cleanup()
         {
+            // ReSharper disable once InconsistentlySynchronizedField
             foreach (var connection in _connections.Values)
             {
                 connection.Close();

--- a/src/Aquarius.Client/TimeSeries/Client/Helpers/AuthenticationHeaders.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/Helpers/AuthenticationHeaders.cs
@@ -3,5 +3,6 @@
     public static class AuthenticationHeaders
     {
         public const string AuthenticationHeaderNameKey = "X-Authentication-Token";
+        public const string AuthenticationCookieName = "AQAuthToken";
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/IAuthenticator.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/IAuthenticator.cs
@@ -1,0 +1,8 @@
+﻿namespace Aquarius.TimeSeries.Client
+{
+    public interface IAuthenticator
+    {
+        string Login(string username, string password);
+        void Logout();
+    }
+}

--- a/src/Aquarius.Client/TimeSeries/Client/ScopeAction.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ScopeAction.cs
@@ -13,10 +13,7 @@ namespace Aquarius.TimeSeries.Client
 
         public void Dispose()
         {
-            if (_actionOnDispose != null)
-            {
-                _actionOnDispose();
-            }
+            _actionOnDispose?.Invoke();
         }
     }
 }


### PR DESCRIPTION
The responsibility for maintaining the session token is now correctly within the Connection class.

Added a shared request filter for all endpoint clients which adds the connection's session token to each request.

The SessionKeepAlive() method now is a true no-op.

@BlakeRaymond-AI Thanks for your review help yesterday. I refactored the logic to use a RequestFilter to set the authentication header from the Connection's SessionToken. That (plus a few other tweaks) has made the both the connection pool and reauthentication logic pretty solid.