### PR TITLE
Issue-99 - Improve the SendBatchRequests() robustness when the server-side DTO name changes

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,9 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
+### 19.2.1
+- An internal change to improve the robustness of the `SendBatchRequests` helper method. Now it will continue to work even if a server version renames an internal request DTO class.
+
 ### 19.2.0
 - Updated the service models for the AQUARIUS Time-Series 2019.2 release.
 

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/NativeTypes/ServerRequestNameResolverTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/NativeTypes/ServerRequestNameResolverTests.cs
@@ -1,0 +1,141 @@
+﻿using System.Collections.Generic;
+using Aquarius.TimeSeries.Client.NativeTypes;
+using FluentAssertions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NUnit.Framework;
+using ServiceStack;
+
+namespace Aquarius.Client.UnitTests.TimeSeries.Client.NativeTypes
+{
+    [TestFixture]
+    public class ServerRequestNameResolverTests
+    {
+        private IServiceClient _mockEndpointClient;
+        private ServerRequestNameResolver _resolver;
+
+        [SetUp]
+        public void BeforeEachTest()
+        {
+            _mockEndpointClient = CreateMockServiceClient();
+
+            _resolver = new ServerRequestNameResolver();
+        }
+
+        private IServiceClient CreateMockServiceClient()
+        {
+            var mockServiceClient = Substitute.For<IServiceClient>();
+
+            return mockServiceClient;
+        }
+
+        private const string KnownRoute = "/items/path";
+        [Route(KnownRoute, HttpMethods.Get)]
+        public class ClientGetRequest : IReturn<DummyResponse>
+        {
+        }
+
+        [Route(KnownRoute, HttpMethods.Get)]
+        public class RenamedServerGetRequest : IReturn<DummyResponse>
+        {
+        }
+
+        public class DummyResponse
+        {
+        }
+
+        [Route(KnownRoute + "/subpath", HttpMethods.Get)]
+        public class UnknownGetRequest : IReturn<DummyResponse>
+        {
+        }
+
+        private void SetupMockEndpointWithRenamedMetadata()
+        {
+            _mockEndpointClient
+                .Get(Arg.Any<GetTypesMetadata>())
+                .Returns(new MetadataTypes
+                {
+                    Operations = new List<MetadataOperationType>
+                    {
+                        new MetadataOperationType
+                        {
+                            Request = new MetadataType
+                            {
+                                Name = typeof(RenamedServerGetRequest).Name,
+                                Routes = new List<MetadataRoute>
+                                {
+                                    new MetadataRoute
+                                    {
+                                        Path = KnownRoute
+                                    }
+                                }
+                            }
+                        }
+                    }
+                });
+        }
+
+        private void SetupMockEndPointWithoutMetadata()
+        {
+            _mockEndpointClient
+                .Get(Arg.Any<GetTypesMetadata>())
+                .Throws(new WebServiceException("Nope"));
+        }
+
+        [Test]
+        public void ResolveRequestName_WhenCalledTwice_OnlyFetchesMetadataOnce()
+        {
+            SetupMockEndpointWithRenamedMetadata();
+
+            _resolver.ResolveRequestName(_mockEndpointClient, new ClientGetRequest());
+            _resolver.ResolveRequestName(_mockEndpointClient, new ClientGetRequest());
+
+            _mockEndpointClient
+                .Received(1)
+                .Get(Arg.Any<GetTypesMetadata>());
+        }
+
+        [Test]
+        public void ResolveRequestName_WithRenamedRequestClass_ReturnsRenamedServerRequestName()
+        {
+            SetupMockEndpointWithRenamedMetadata();
+
+            var request = new ClientGetRequest();
+            var clientRequestName = request.GetType().Name;
+
+            var actual = _resolver.ResolveRequestName(_mockEndpointClient, request);
+            var expected = typeof(RenamedServerGetRequest).Name;
+
+            actual.Should().NotBe(clientRequestName);
+            actual.ShouldBeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void ResolveRequestName_WithUnknownRequestClass_ReturnsClientRequestName()
+        {
+            SetupMockEndpointWithRenamedMetadata();
+
+            var request = new UnknownGetRequest();
+            var clientRequestName = request.GetType().Name;
+
+            var actual = _resolver.ResolveRequestName(_mockEndpointClient, request);
+            var expected = clientRequestName;
+
+            actual.ShouldBeEquivalentTo(expected);
+        }
+
+        [Test]
+        public void ResolveRequestName_WithNoMetadata_ReturnsClientRequestName()
+        {
+            SetupMockEndPointWithoutMetadata();
+
+            var request = new ClientGetRequest();
+            var clientRequestName = request.GetType().Name;
+
+            var actual = _resolver.ResolveRequestName(_mockEndpointClient, request);
+            var expected = clientRequestName;
+
+            actual.ShouldBeEquivalentTo(expected);
+        }
+    }
+}

--- a/src/Aquarius.Client/TimeSeries/Client/NativeTypes/GetTypesMetadata.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/NativeTypes/GetTypesMetadata.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using ServiceStack;
+
+namespace Aquarius.TimeSeries.Client.NativeTypes
+{
+    // Lifted from ServiceStack\src\ServiceStack.Common\MetadataTypes.cs to avoid having to bring in the full server-side assembly
+    [Route("/types/metadata", HttpMethods.Get)]
+    public class GetTypesMetadata : IReturn<MetadataTypes>
+    {
+    }
+
+    // Trimmed down to a small subset of properties necessary to resolve the server-side name of a request by its route
+    public class MetadataTypes
+    {
+        public List<MetadataOperationType> Operations { get; set; }
+    }
+
+    public class MetadataOperationType
+    {
+        public List<string> Actions { get; set; }
+        public MetadataType Request { get; set; }
+    }
+
+    public class MetadataType
+    {
+        public string Name { get; set; }
+
+        public List<MetadataRoute> Routes { get; set; }
+    }
+
+    public class MetadataRoute
+    {
+        public string Path { get; set; }
+        public string Verbs { get; set; }
+        public string Notes { get; set; }
+        public string Summary { get; set; }
+    }
+}

--- a/src/Aquarius.Client/TimeSeries/Client/NativeTypes/ServerRequestNameResolver.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/NativeTypes/ServerRequestNameResolver.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using ServiceStack;
+
+namespace Aquarius.TimeSeries.Client.NativeTypes
+{
+    public class ServerRequestNameResolver
+    {
+        private readonly object _syncLock = new object();
+
+        private Dictionary<string, MetadataType> RequestsByRoute { get; set; }
+
+        public string ResolveRequestName<TRequest>(IServiceClient client, TRequest request)
+        {
+            FetchEndpointMetadataOnce(client);
+
+            var requestMetadata = FindMetadataType(request);
+
+            if (requestMetadata == null)
+                return typeof(TRequest).Name;
+
+            return requestMetadata.Name;
+        }
+
+        private void FetchEndpointMetadataOnce(IServiceClient client)
+        {
+            lock (_syncLock)
+            {
+                if (RequestsByRoute != null)
+                    return;
+
+                RequestsByRoute = new Dictionary<string, MetadataType>(StringComparer.InvariantCultureIgnoreCase);
+
+                try
+                {
+                    var response = client.Get(new GetTypesMetadata());
+
+                    foreach (var operation in response.Operations)
+                    {
+                        foreach (var route in operation.Request.Routes)
+                        {
+                            RequestsByRoute[route.Path] = operation.Request;
+                        }
+                    }
+                }
+                catch (WebServiceException)
+                {
+                    // The endpoint may be private and not have metadata exposed.
+                    // So all we can do is hope that the client request name still matches the server name
+                }
+            }
+        }
+
+        private MetadataType FindMetadataType<TRequest>(TRequest request)
+        {
+            var route = request
+                .ToRelativeUri(HttpMethods.Get)
+                .Split('?')[0];
+
+            if (RequestsByRoute.TryGetValue(route, out var metadataType))
+                return metadataType;
+
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
1) Added ServerRequestNameResolver class and unit tests

2) Modify the SendBatchRequests() method use the resolved server DTO name when it can be discovered.