### PR TITLE
Issue-115 - Upgrade to ServiceStack 5.8.0

### DIFF
--- a/src/Aquarius.Client.Legacy/Aquarius.Client.Legacy.csproj
+++ b/src/Aquarius.Client.Legacy/Aquarius.Client.Legacy.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 
   <PropertyGroup>
@@ -26,10 +26,10 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="NodaTime" Version="2.2.3" />
-    <PackageReference Include="ServiceStack.Client.Core" Version="1.0.44" />
-    <PackageReference Include="ServiceStack.HttpClient.Core" Version="1.0.44" />
-    <PackageReference Include="ServiceStack.Interfaces.Core" Version="1.0.44" />
-    <PackageReference Include="ServiceStack.Text.Core" Version="1.0.44" />
+    <PackageReference Include="ServiceStack.Client.Core" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.HttpClient.Core" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.Interfaces.Core" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.Text.Core" Version="5.8.0" />
   </ItemGroup>
 
   <!-- .NET 4.5 references, compilation flags and build options -->
@@ -44,10 +44,10 @@
     <Reference Include="System.Xml" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageReference Include="NodaTime" Version="1.3.0" />
-    <PackageReference Include="ServiceStack.Client" Version="4.5.12" />
-    <PackageReference Include="ServiceStack.HttpClient" Version="4.5.12" />
-    <PackageReference Include="ServiceStack.Interfaces" Version="4.5.12" />
-    <PackageReference Include="ServiceStack.Text" Version="4.5.12" />
+    <PackageReference Include="ServiceStack.Client" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.HttpClient" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.Interfaces" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.Text" Version="5.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Aquarius.Client\Aquarius.Client.csproj" />

--- a/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
+++ b/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
@@ -21,9 +21,9 @@
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="ServiceStack.Client.Core" Version="1.0.44" />
-    <PackageReference Include="ServiceStack.Interfaces.Core" Version="1.0.44" />
-    <PackageReference Include="ServiceStack.Text.Core" Version="1.0.44" />
+    <PackageReference Include="ServiceStack.Client.Core" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.Interfaces.Core" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.Text.Core" Version="5.8.0" />
   </ItemGroup>
 
   <!-- .NET 4.5 references, compilation flags and build options -->
@@ -38,9 +38,9 @@
     <Reference Include="System.Xml" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageReference Include="NodaTime" Version="1.3.0" />
-    <PackageReference Include="ServiceStack.Client" Version="4.5.12" />
-    <PackageReference Include="ServiceStack.Interfaces" Version="4.5.12" />
-    <PackageReference Include="ServiceStack.Text" Version="4.5.12" />
+    <PackageReference Include="ServiceStack.Client" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.Interfaces" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.Text" Version="5.8.0" />
     <PackageReference Include="AutoFixture" Version="3.51.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/JsonSerializationTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/JsonSerializationTests.cs
@@ -11,6 +11,7 @@ using NUnit.Framework;
 using ServiceStack;
 using ServiceStack.Logging;
 using ServiceStack.Text;
+using ServiceStack.Text.Common;
 
 namespace Aquarius.UnitTests.TimeSeries.Client
 {
@@ -142,15 +143,19 @@ namespace Aquarius.UnitTests.TimeSeries.Client
         }
 
 
-        [Test]
-        public void DateTime_SerializesToExpectedText()
+        private static readonly IEnumerable<TestCaseData> FractionalSecondsTestCases = new[]
         {
-            var input = ArbitraryUtcDate;
-            const string expected = "\"1901-02-03T04:05:06.789Z\"";
+            new TestCaseData(ArbitraryUtcDate.Subtract(TimeSpan.FromMilliseconds(ArbitraryUtcDate.Millisecond)), "\"1901-02-03T04:05:06Z\"", "No fractional seconds"),
+            new TestCaseData(ArbitraryUtcDate, "\"1901-02-03T04:05:06.789Z\"", "3-fractional second precision"),
+            new TestCaseData(ArbitraryUtcDate.AddTicks(1234), "\"1901-02-03T04:05:06.7891234Z\"", "7-fractional second precision"),
+        };
 
-            var actual = input.ToJson();
+        [TestCaseSource(nameof(FractionalSecondsTestCases))]
+        public void DateTime_SerializesToExpectedText(DateTime dateTime, string expected, string reason)
+        {
+            var actual = dateTime.ToJson();
 
-            Assert.That(actual, Is.EqualTo(expected));
+            actual.ShouldBeEquivalentTo(expected, reason);
         }
 
         [Test]

--- a/src/Aquarius.Client/Aquarius.Client.csproj
+++ b/src/Aquarius.Client/Aquarius.Client.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
@@ -26,10 +26,10 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="NodaTime" Version="2.2.3" />
-    <PackageReference Include="ServiceStack.Client.Core" Version="1.0.44" />
-    <PackageReference Include="ServiceStack.HttpClient.Core" Version="1.0.44" />
-    <PackageReference Include="ServiceStack.Interfaces.Core" Version="1.0.44" />
-    <PackageReference Include="ServiceStack.Text.Core" Version="1.0.44" />
+    <PackageReference Include="ServiceStack.Client.Core" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.HttpClient.Core" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.Interfaces.Core" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.Text.Core" Version="5.8.0" />
   </ItemGroup>
 
   <!-- .NET 4.5 references, compilation flags and build options -->
@@ -44,10 +44,10 @@
     <Reference Include="System.Xml" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageReference Include="NodaTime" Version="1.3.0" />
-    <PackageReference Include="ServiceStack.Client" Version="4.5.12" />
-    <PackageReference Include="ServiceStack.HttpClient" Version="4.5.12" />
-    <PackageReference Include="ServiceStack.Interfaces" Version="4.5.12" />
-    <PackageReference Include="ServiceStack.Text" Version="4.5.12" />
+    <PackageReference Include="ServiceStack.Client" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.HttpClient" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.Interfaces" Version="5.8.0" />
+    <PackageReference Include="ServiceStack.Text" Version="5.8.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
.NET Framework jumps from 4.5.12 => 5.8.0
.NET Core jumps from 1.0.44 => 5.8.0

Needed to capture the ISO 8601 time-stamp optimization to omit milliseconds or fractional seconds when possible.
This keeps the JSON payload size identical to previous versions, which is helpful when appending large blocks of points.