### PR TITLE
PF-608 - Fixed some AQS file upload APIs

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,10 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
+### 20.0.5
+- Samples API: Query parameters for file uplaod requests are now properly camelCased.
+- Added ISamplesClient.LocationResponseHeader string to reflect the last received Location header response (useful for tracking file upload URL responses)
+
 ### 20.0.4
 - Updated the service models for the AQUARIUS Samples 2020.03 release.
 

--- a/src/Aquarius.Client/Aquarius.Client.csproj
+++ b/src/Aquarius.Client/Aquarius.Client.csproj
@@ -49,5 +49,8 @@
     <PackageReference Include="ServiceStack.Interfaces" Version="5.8.0" />
     <PackageReference Include="ServiceStack.Text" Version="5.8.0" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/Aquarius.Client/Samples/Client/ISamplesClient.cs
+++ b/src/Aquarius.Client/Samples/Client/ISamplesClient.cs
@@ -11,6 +11,7 @@ namespace Aquarius.Samples.Client
     {
         IServiceClient Client { get; }
         AquariusServerVersion ServerVersion { get; }
+        string LocationResponseHeader { get; }
 
         TResponse Get<TResponse>(IReturn<TResponse> requestDto);
         void Get(IReturnVoid requestDto);
@@ -24,11 +25,25 @@ namespace Aquarius.Samples.Client
         TResponse SparsePut<TResponse>(IReturn<TResponse> requestDto);
         void SparsePut(IReturnVoid requestDto);
 
+        void PostFileWithRequest<TRequest>(
+            string path,
+            TRequest requestDto,
+            HttpContent extraContent = null,
+            string extraContentName = null) where TRequest : IReturnVoid;
+
+        void PostFileWithRequest<TRequest>(
+            Stream contentToUpload,
+            string uploadedFileName,
+            TRequest requestDto,
+            HttpContent extraContent = null,
+            string extraContentName = null) where TRequest : IReturnVoid;
+
         TResponse PostFileWithRequest<TResponse>(
             string path,
             IReturn<TResponse> requestDto,
             HttpContent extraContent = null,
             string extraContentName = null);
+
         TResponse PostFileWithRequest<TResponse>(
             Stream contentToUpload,
             string uploadedFileName,


### PR DESCRIPTION
1) Use camelCase query parameter names for file upload requests

2) Add IReturnVoid variants of file upload methods

3) Add SamplesClient.LocationResponseHeader property

This property will be set whenever the response includes a Location header.

Some Samples file upload responses only include a response URL in a Location header.