### PR TITLE
PF-653 - Added ClientFromExistingSession() method

### DIFF
--- a/src/Aquarius.Client/TimeSeries/ExistingSessionAuthenticator.cs
+++ b/src/Aquarius.Client/TimeSeries/ExistingSessionAuthenticator.cs
@@ -1,0 +1,28 @@
+﻿using Aquarius.TimeSeries.Client;
+
+namespace Aquarius.TimeSeries
+{
+    public class ExistingSessionAuthenticator : IAuthenticator
+    {
+        private string SessionToken { get; }
+
+        public static IAuthenticator Create(string existingSessionToken)
+        {
+            return new ExistingSessionAuthenticator(existingSessionToken);
+        }
+
+        private ExistingSessionAuthenticator(string existingSessionToken)
+        {
+            SessionToken = existingSessionToken;
+        }
+
+        public string Login(string username, string password)
+        {
+            return SessionToken;
+        }
+
+        public void Logout()
+        {
+        }
+    }
+}


### PR DESCRIPTION
This will allow an existing browser session to be reused by an externally-launched tool.

No automatic-reauthentication will be possible, and the session will not be deleted on the server when the connection is closed.