### PR TITLE
PF-767 - Fixed the AQUARIUS Samples timestamp deserialization logic

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -3,6 +3,8 @@
 This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
+### 20.2.1
+- Fixed a bug in the AQUARIUS Samples timestamp deserialization logic
 
 ### 20.2.0
 - Updated the service models for the AQUARIUS Time-Series 2020.2 release.

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/JsonSerializationTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/JsonSerializationTests.cs
@@ -277,6 +277,14 @@ namespace Aquarius.UnitTests.TimeSeries.Client
         }
 
         [Test]
+        public void NodaTimeInstant_ParsesSamplesTimestampWithTimeCode()
+        {
+            NodaTimeInstant_ParsesVariousValues(
+                "\"1901-02-03T08:05:06.789+04:00[GST]\"", // Gulf Standard Time
+                Instant.FromDateTimeUtc(ArbitraryUtcDate));
+        }
+
+        [Test]
         public void NodaTimeInstant_UsingJsConfigThatOverridesDefaultIncludeNullValues_SerializesDefaultValue()
         {
             using (CreateJsConfigThatOverridesDefaultIncludeNullValuesSetting())

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceStackConfig.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceStackConfig.cs
@@ -223,6 +223,13 @@ namespace Aquarius.TimeSeries.Client
                 case "maxinstant":
                     return Instant.MaxValue;
                 default:
+                    var timeCodeIndex = text.IndexOf('[');
+
+                    if (timeCodeIndex >= 0)
+                    {
+                        text = text.Substring(0, timeCodeIndex);
+                    }
+
                     var dateTimeOffset = DateTimeSerializer.ParseDateTimeOffset(text);
                     return Instant.FromDateTimeOffset(dateTimeOffset);
             }


### PR DESCRIPTION
Any optional "[timecode]" at the end of an ISO timestamp is now ignored.