### PR TITLE
PF-824 - Added an optional IProgressReporter interface

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,9 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
+### 20.3.2
+- Added the optional IProgressReporter interface, for Samples.LazyGet and TimeSeries.SendBatchRequests support.
+
 ### 20.3.1
 - Updated the service models for the AQUARIUS Samples 2020.05 release.
 

--- a/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
+++ b/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
@@ -53,8 +53,4 @@
     <ProjectReference Include="..\Aquarius.Client\Aquarius.Client.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="TestHelpers\" />
-  </ItemGroup>
-
 </Project>

--- a/src/Aquarius.Client.UnitTests/Samples/Client/LazyGetTests.cs
+++ b/src/Aquarius.Client.UnitTests/Samples/Client/LazyGetTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Aquarius.Client.UnitTests.TestHelpers;
+using Aquarius.Helpers;
 using Aquarius.Samples.Client;
 using Aquarius.Samples.Client.ServiceModel;
 using FluentAssertions;
@@ -143,7 +145,7 @@ namespace Aquarius.UnitTests.Samples.Client
 
         private List<Thing> EvaluateAllLazyLoadedItems()
         {
-            return _client.LazyGet<Thing, GetThings, ThingResults>(new GetThings()).DomainObjects.ToList();
+            return _client.LazyGet<Thing, GetThings, ThingResults>(new GetThings(), progressReporter: new ConsoleProgressReporter()).DomainObjects.ToList();
         }
 
         private void AssertExpectedItemsAndLazyFetches(List<Thing> items, int expectedTotalCount, int expectedFetchesCount)

--- a/src/Aquarius.Client.UnitTests/TestHelpers/ConsoleProgressReporter.cs
+++ b/src/Aquarius.Client.UnitTests/TestHelpers/ConsoleProgressReporter.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Aquarius.Helpers;
+
+namespace Aquarius.Client.UnitTests.TestHelpers
+{
+    public class ConsoleProgressReporter : IProgressReporter
+    {
+        private void WriteLine(string message)
+        {
+            Console.WriteLine($"PROGRESS: {message}");
+        }
+
+        public void Started()
+        {
+            WriteLine("Started.");
+        }
+
+        public void Progress(int currentCount, int totalCount)
+        {
+            WriteLine($"{currentCount} of {totalCount}");
+        }
+
+        public void Completed()
+        {
+            WriteLine("Completed.");
+        }
+    }
+}

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/AquariusClientTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/AquariusClientTests.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Aquarius.Client.UnitTests.TestHelpers;
+using Aquarius.Helpers;
 using Aquarius.TimeSeries.Client;
 using Aquarius.TimeSeries.Client.EndPoints;
 using Aquarius.TimeSeries.Client.ServiceModels.Provisioning;

--- a/src/Aquarius.Client/Helpers/IProgressReporter.cs
+++ b/src/Aquarius.Client/Helpers/IProgressReporter.cs
@@ -1,0 +1,9 @@
+﻿namespace Aquarius.Helpers
+{
+    public interface IProgressReporter
+    {
+        void Started();
+        void Progress(int currentCount, int totalCount);
+        void Completed();
+    }
+}

--- a/src/Aquarius.Client/Samples/Client/ISamplesClient.cs
+++ b/src/Aquarius.Client/Samples/Client/ISamplesClient.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.IO;
 using System.Net.Http;
+using System.Threading;
+using Aquarius.Helpers;
 using Aquarius.Samples.Client.ServiceModel;
 using Aquarius.TimeSeries.Client;
 using ServiceStack;
@@ -53,7 +55,7 @@ namespace Aquarius.Samples.Client
             HttpContent extraContent = null,
             string extraContentName = null);
 
-        LazyResult<TDomainObject> LazyGet<TDomainObject, TRequest, TResponse>(TRequest requestDto)
+        LazyResult<TDomainObject> LazyGet<TDomainObject, TRequest, TResponse>(TRequest requestDto, CancellationToken? cancellationToken = null, IProgressReporter progressReporter = null)
             where TRequest : IPaginatedRequest, IReturn<TResponse>
             where TResponse : IPaginatedResponse<TDomainObject>;
 

--- a/src/Aquarius.Client/TimeSeries/Client/AquariusClient.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/AquariusClient.cs
@@ -94,12 +94,17 @@ namespace Aquarius.TimeSeries.Client
                 : null;
         }
 
-        public IEnumerable<TResponse> SendBatchRequests<TRequest, TResponse>(IServiceClient client, int batchSize, IEnumerable<TRequest> requests, CancellationToken? cancellationToken = null)
+        public IEnumerable<TResponse> SendBatchRequests<TRequest, TResponse>(
+            IServiceClient client,
+            int batchSize,
+            IEnumerable<TRequest> requests,
+            CancellationToken? cancellationToken = null,
+            IProgressReporter progressReporter = null)
             where TRequest : IReturn<TResponse>
         {
             using (var batchClient = CreateBatchGetRequestClient(client))
             {
-                return batchClient.SendAll<TRequest, TResponse>(batchSize, requests, cancellationToken);
+                return batchClient.SendAll<TRequest, TResponse>(batchSize, requests, cancellationToken, progressReporter);
             }
         }
 

--- a/src/Aquarius.Client/TimeSeries/Client/IAquariusClient.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/IAquariusClient.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Threading;
+using Aquarius.Helpers;
 using ServiceStack;
 
 namespace Aquarius.TimeSeries.Client
@@ -26,7 +27,12 @@ namespace Aquarius.TimeSeries.Client
         IServiceClient CloneAuthenticatedClientWithOverrideMethod(IServiceClient client, string overrideMethod);
         string GetBaseUri(IServiceClient client);
 
-        IEnumerable<TResponse> SendBatchRequests<TRequest, TResponse>(IServiceClient client, int batchSize, IEnumerable<TRequest> requests, CancellationToken? cancellationToken = null)
+        IEnumerable<TResponse> SendBatchRequests<TRequest, TResponse>(
+            IServiceClient client,
+            int batchSize,
+            IEnumerable<TRequest> requests,
+            CancellationToken? cancellationToken = null,
+            IProgressReporter progressReporter = null)
             where TRequest : IReturn<TResponse>;
 
         [Obsolete("Sessions will now re-authenticate automatically if they expire.")]


### PR DESCRIPTION
The ISamplesClient.LazyGet() and IAquariusClient.SendBatchRequests() methods can now support optional progress reporting