### PR TITLE
AQS-760 - Work around the rare non-ISO8601 complaint JSON timestamp from AQSamples

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,9 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
+### 20.4.5
+- Workaround a rare timestamp serialization bug in AQSamples JSON timestamps
+
 ### 20.4.2
 - Updated dependencies to the ServiceStack 5.10 release
 

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/JsonSerializationTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/JsonSerializationTests.cs
@@ -282,6 +282,15 @@ namespace Aquarius.UnitTests.TimeSeries.Client
             NodaTimeInstant_ParsesVariousValues(
                 "\"1901-02-03T08:05:06.789+04:00[GST]\"", // Gulf Standard Time
                 Instant.FromDateTimeUtc(ArbitraryUtcDate));
+
+            // AQS-760 workaround for goofy timestamps without a time component
+            NodaTimeInstant_ParsesVariousValues(
+                "\"2020-12-01T-08:00\"", // This occurred in on a production system
+                Instant.FromUtc(2020, 12, 01, 0, 0).Minus(Duration.FromHours(-8)));
+
+            NodaTimeInstant_ParsesVariousValues(
+                "\"2020-12-01T+10:00\"", // What if the timezone was in Australia?
+                Instant.FromUtc(2020, 12, 01, 0, 0).Minus(Duration.FromHours(10)));
         }
 
         [Test]


### PR DESCRIPTION
Just discovered a production system spitting out a timestamp like `2020-12-01T-08:00` in some rare cases. Detect that failure, assume a midnight time component, and keep on trucking!