### PR TITLE
AQ-27362 Fixes Metadata Endpoint

### DIFF
--- a/src/Aquarius.Client/TimeSeries/Client/NativeTypes/GetTypesMetadata.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/NativeTypes/GetTypesMetadata.cs
@@ -19,6 +19,7 @@ namespace Aquarius.TimeSeries.Client.NativeTypes
     {
         public List<string> Actions { get; set; }
         public MetadataType Request { get; set; }
+        public List<MetadataRoute> Routes { get; set; }
     }
 
     public class MetadataType

--- a/src/Aquarius.Client/TimeSeries/Client/NativeTypes/ServerRequestNameResolver.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/NativeTypes/ServerRequestNameResolver.cs
@@ -40,9 +40,19 @@ namespace Aquarius.TimeSeries.Client.NativeTypes
 
                     foreach (var operation in response.Operations)
                     {
-                        foreach (var route in operation.Request.Routes)
+                        if (operation.Request.Routes != null)
                         {
-                            RequestsByRoute[route.Path] = operation.Request;
+                            foreach (var route in operation.Request.Routes)
+                            {
+                                RequestsByRoute[route.Path] = operation.Request;
+                            }
+                        }
+                        else
+                        {
+                            foreach (var route in operation.Routes)
+                            {
+                                RequestsByRoute[route.Path] = operation.Request;
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
@DougSchmidt-AI The AQTS upgrade from ServiceStack 5.8.0 to 5.10.4 resulted in changes to the metadata endpoint causing this code to throw an "object reference" exception.

This code change has been tested in WebPortal and seems to work, avoiding the object reference exception.