### PR TITLE
PF-1099 - Fixed serialization of nullable Interval values

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,9 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
+### 21.1.1
+- Fixed a JSON serialization bug for nullable NodaTime Interval objects.
+
 ### 21.1.0
 - Updated the service models for the AQUARIUS Time-Series 2021.1 release.
 - Updated the service models for the AQUARIUS Samples 2021.01 release.

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceStackConfig.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceStackConfig.cs
@@ -74,6 +74,9 @@ namespace Aquarius.TimeSeries.Client
             JsConfig<Interval>.RawDeserializeFn = DeserializeInterval;
             JsConfig<Interval>.IncludeDefaultValue = true;
 
+            JsConfig<Interval?>.RawSerializeFn = SerializeInterval;
+            JsConfig<Interval?>.RawDeserializeFn = DeserializeNullableInterval;
+
             JsConfig<Duration>.RawSerializeFn = SerializeDuration;
             JsConfig<Duration>.DeSerializeFn = DeserializeDuration;
             JsConfig<Duration>.IncludeDefaultValue = true;
@@ -264,6 +267,14 @@ namespace Aquarius.TimeSeries.Client
             return DeserializeInstant(text);
         }
 
+        private static string SerializeInterval(Interval? value)
+        {
+            if (value == null)
+                return null;
+            return SerializeInterval(value.Value);
+        }
+
+
         private static string SerializeInterval(Interval value)
         {
             var dto = new IntervalDto
@@ -272,6 +283,14 @@ namespace Aquarius.TimeSeries.Client
                 End = value.End
             };
             return dto.ToJson();
+        }
+
+        private static Interval? DeserializeNullableInterval(string json)
+        {
+            if (string.IsNullOrEmpty(json))
+                return null;
+
+            return DeserializeInterval(json);
         }
 
         private static Interval DeserializeInterval(string json)


### PR DESCRIPTION
This was affecting some Acquisition API DTOs for the `POST /timeseries/{UniqueId}/metadata` operation