### PR TITLE
PF-1215 - Fixed a bug in Samples file uploading

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,7 +4,8 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
-### 21.2.2
+### 21.2.3
+- Fixed a bug in Samples file uploading
 - Improved the DateTimeOffset and NodaTime.Instant deserializers to handle AQSamples timestamps with optional timecodes
 - Switch AQSamples service models from NodaTime.Instant to DateTimeOffset, so that clients can see the UTC offset.
 - Updated the service models for the AQUARIUS Samples 2021.05 release.

--- a/src/Aquarius.Client/Samples/Client/FileUploader.cs
+++ b/src/Aquarius.Client/Samples/Client/FileUploader.cs
@@ -40,7 +40,7 @@ namespace Aquarius.Samples.Client
             if (_restClient is JsonHttpClient jhc)
             {
                 jhc.ResultsFilterResponse = (response, o, method, uri, request) =>
-                    LocationResponseHeader = response.Headers?.Location.ToString();
+                    LocationResponseHeader = response.Headers?.Location?.ToString();
             }
         }
 


### PR DESCRIPTION
Some AQSamples file upload APIs set a Location response header, but some file upload APIs don't.

Avoid the NullReferenceException when a response does not include a Location header in the upload response.