### PR TITLE
PF-1433 - Allow individual batch get failures to have a handler

### DIFF
--- a/src/Aquarius.Client/TimeSeries/Client/AquariusClient.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/AquariusClient.cs
@@ -114,9 +114,21 @@ namespace Aquarius.TimeSeries.Client
             IProgressReporter progressReporter = null)
             where TRequest : IReturn<TResponse>
         {
+            return SendBatchRequests<TRequest, TResponse>(client, batchSize, requests, null, cancellationToken, progressReporter);
+        }
+
+        public IEnumerable<TResponse> SendBatchRequests<TRequest, TResponse>(
+            IServiceClient client,
+            int batchSize,
+            IEnumerable<TRequest> requests,
+            Action<TRequest, ResponseStatus> failedRequestHandler,
+            CancellationToken? cancellationToken = null,
+            IProgressReporter progressReporter = null)
+            where TRequest : IReturn<TResponse>
+        {
             using (var batchClient = CreateBatchGetRequestClient(client))
             {
-                return batchClient.SendAll<TRequest, TResponse>(batchSize, requests, cancellationToken, progressReporter);
+                return batchClient.SendAll<TRequest, TResponse>(batchSize, requests, failedRequestHandler, cancellationToken, progressReporter);
             }
         }
 

--- a/src/Aquarius.Client/TimeSeries/Client/IAquariusClient.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/IAquariusClient.cs
@@ -36,6 +36,15 @@ namespace Aquarius.TimeSeries.Client
             IProgressReporter progressReporter = null)
             where TRequest : IReturn<TResponse>;
 
+        IEnumerable<TResponse> SendBatchRequests<TRequest, TResponse>(
+            IServiceClient client,
+            int batchSize,
+            IEnumerable<TRequest> requests,
+            Action<TRequest, ResponseStatus> failedRequestHandler,
+            CancellationToken? cancellationToken = null,
+            IProgressReporter progressReporter = null)
+            where TRequest : IReturn<TResponse>;
+
         [Obsolete("Sessions will now re-authenticate automatically if they expire.")]
         ScopeAction SessionKeepAlive();
     }


### PR DESCRIPTION
This will allow integrations to do something with the failed request and continue on with the successful ones.

For very-rare robustness use cases.