### PR TITLE
AWP-4141 .NET 6.0 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,5 @@ ipch/
 # Uncomment if necessary however generally it will be regenerated when needed
 #!**/packages/repositories.config
 .vs/
+.idea/
 TestResult.xml

--- a/src/Aquarius.Client.Legacy/Aquarius.Client.Legacy.csproj
+++ b/src/Aquarius.Client.Legacy/Aquarius.Client.Legacy.csproj
@@ -23,10 +23,10 @@
   <!-- .NET Standard 2.1 references, compilation flags and build options -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="NodaTime" Version="2.2.3" />
-    <PackageReference Include="ServiceStack.Client.Core" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.HttpClient.Core" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.Interfaces.Core" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.Text.Core" Version="5.10.4" />
+    <PackageReference Include="ServiceStack.Client.Core" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.HttpClient.Core" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.Interfaces.Core" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.Text.Core" Version="6.0.2" />
   </ItemGroup>
 
   <!-- .NET 4.7.2 references, compilation flags and build options -->
@@ -38,10 +38,10 @@
     <Reference Include="System.Xml" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageReference Include="NodaTime" Version="1.3.0" />
-    <PackageReference Include="ServiceStack.Client" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.HttpClient" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.Interfaces" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.Text" Version="5.10.4" />
+    <PackageReference Include="ServiceStack.Client" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.HttpClient" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.Interfaces" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.Text" Version="6.0.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Aquarius.Client\Aquarius.Client.csproj" />

--- a/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
+++ b/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
@@ -21,9 +21,9 @@
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-    <PackageReference Include="ServiceStack.Client.Core" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.Interfaces.Core" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.Text.Core" Version="5.10.4" />
+    <PackageReference Include="ServiceStack.Client.Core" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.Interfaces.Core" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.Text.Core" Version="6.0.2" />
   </ItemGroup>
 
   <!-- .NET 4.7.2 references, compilation flags and build options -->
@@ -38,9 +38,9 @@
     <Reference Include="System.Xml" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageReference Include="NodaTime" Version="1.3.0" />
-    <PackageReference Include="ServiceStack.Client" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.Interfaces" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.Text" Version="5.10.4" />
+    <PackageReference Include="ServiceStack.Client" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.Interfaces" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.Text" Version="6.0.2" />
     <PackageReference Include="AutoFixture" Version="3.51.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />

--- a/src/Aquarius.Client.UnitTests/Samples/Client/FileUploaderTests.cs
+++ b/src/Aquarius.Client.UnitTests/Samples/Client/FileUploaderTests.cs
@@ -20,6 +20,15 @@ using Ploeh.AutoFixture;
 namespace Aquarius.UnitTests.Samples.Client
 {
     [TestFixture]
+    [Ignore(@"
+FileUploader tests fail when targeting net6.0 due to ServiceStack dependencies.
+ServiceStack.HttpClient.Core package (6.0.0 and higher) targets net6.0 and netstandard2.0.
+In netstandard2.0:
+    JsonHttpClient [ServiceStack.HttpClient.dll]
+    -> ResultsFilterHttpResponseDelegate [ServiceStack.HttpClient.dll]
+In net6.0:
+    JsonHttpClient [ServiceStack.HttpClient.dll]
+    -> ResultsFilterHttpResponseDelegate [ServiceStack.Client.dll]")]
     public class FileUploaderTests
     {
         [OneTimeSetUp]

--- a/src/Aquarius.Client.UnitTests/Samples/Client/FileUploaderTests.cs
+++ b/src/Aquarius.Client.UnitTests/Samples/Client/FileUploaderTests.cs
@@ -20,15 +20,6 @@ using Ploeh.AutoFixture;
 namespace Aquarius.UnitTests.Samples.Client
 {
     [TestFixture]
-    [Ignore(@"
-FileUploader tests fail when targeting net6.0 due to ServiceStack dependencies.
-ServiceStack.HttpClient.Core package (6.0.0 and higher) targets net6.0 and netstandard2.0.
-In netstandard2.0:
-    JsonHttpClient [ServiceStack.HttpClient.dll]
-    -> ResultsFilterHttpResponseDelegate [ServiceStack.HttpClient.dll]
-In net6.0:
-    JsonHttpClient [ServiceStack.HttpClient.dll]
-    -> ResultsFilterHttpResponseDelegate [ServiceStack.Client.dll]")]
     public class FileUploaderTests
     {
         [OneTimeSetUp]

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/NativeTypes/ServerRequestNameResolverTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/NativeTypes/ServerRequestNameResolverTests.cs
@@ -58,18 +58,18 @@ namespace Aquarius.Client.UnitTests.TimeSeries.Client.NativeTypes
         {
             _mockEndpointClient
                 .Get(Arg.Any<GetTypesMetadata>())
-                .Returns(new MetadataTypes
+                .Returns(new Aquarius.TimeSeries.Client.NativeTypes.MetadataTypes
                 {
-                    Operations = new List<MetadataOperationType>
+                    Operations = new List<Aquarius.TimeSeries.Client.NativeTypes.MetadataOperationType>
                     {
-                        new MetadataOperationType
+                        new Aquarius.TimeSeries.Client.NativeTypes.MetadataOperationType
                         {
-                            Request = new MetadataType
+                            Request = new Aquarius.TimeSeries.Client.NativeTypes.MetadataType
                             {
                                 Name = typeof(RenamedServerGetRequest).Name,
-                                Routes = new List<MetadataRoute>
+                                Routes = new List<Aquarius.TimeSeries.Client.NativeTypes.MetadataRoute>
                                 {
-                                    new MetadataRoute
+                                    new Aquarius.TimeSeries.Client.NativeTypes.MetadataRoute
                                     {
                                         Path = KnownRoute
                                     }
@@ -84,20 +84,20 @@ namespace Aquarius.Client.UnitTests.TimeSeries.Client.NativeTypes
         {
             _mockEndpointClient
                 .Get(Arg.Any<GetTypesMetadata>())
-                .Returns(new MetadataTypes
+                .Returns(new Aquarius.TimeSeries.Client.NativeTypes.MetadataTypes
                 {
-                    Operations = new List<MetadataOperationType>
+                    Operations = new List<Aquarius.TimeSeries.Client.NativeTypes.MetadataOperationType>
                     {
-                        new MetadataOperationType
+                        new Aquarius.TimeSeries.Client.NativeTypes.MetadataOperationType
                         {
-                            Request = new MetadataType
+                            Request = new Aquarius.TimeSeries.Client.NativeTypes.MetadataType
                             {
                                 Name = typeof(RenamedServerGetRequest).Name,
                                 Routes = null,
                             },
-                            Routes = new List<MetadataRoute>
+                            Routes = new List<Aquarius.TimeSeries.Client.NativeTypes.MetadataRoute>
                             {
-                                new MetadataRoute
+                                new Aquarius.TimeSeries.Client.NativeTypes.MetadataRoute
                                 {
                                     Path = KnownRoute
                                 }

--- a/src/Aquarius.Client/Aquarius.Client.csproj
+++ b/src/Aquarius.Client/Aquarius.Client.csproj
@@ -32,10 +32,10 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
     <PackageReference Include="NodaTime" Version="2.2.3" />
-    <PackageReference Include="ServiceStack.Client.Core" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.HttpClient.Core" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.Interfaces.Core" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.Text.Core" Version="5.10.4" />
+    <PackageReference Include="ServiceStack.Client.Core" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.HttpClient.Core" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.Interfaces.Core" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.Text.Core" Version="6.0.2" />
   </ItemGroup>
 
   <!-- .NET 4.7.2 references, compilation flags and build options -->
@@ -50,10 +50,10 @@
     <Reference Include="System.Xml" />
     <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
     <PackageReference Include="NodaTime" Version="1.3.0" />
-    <PackageReference Include="ServiceStack.Client" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.HttpClient" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.Interfaces" Version="5.10.4" />
-    <PackageReference Include="ServiceStack.Text" Version="5.10.4" />
+    <PackageReference Include="ServiceStack.Client" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.HttpClient" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.Interfaces" Version="6.0.2" />
+    <PackageReference Include="ServiceStack.Text" Version="6.0.2" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />

--- a/src/Aquarius.Client/Aquarius.Client.csproj
+++ b/src/Aquarius.Client/Aquarius.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.1;net6.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Aquarius.SDK</PackageId>
     <Authors>Aquatic Informatics Inc.</Authors>
@@ -27,10 +27,10 @@
   </ItemGroup>
 
   <!-- .NET Standard 2.1 references, compilation flags and build options -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'net6.0'">
     <DefineConstants>NODATIME2</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="NodaTime" Version="2.2.3" />
     <PackageReference Include="ServiceStack.Client.Core" Version="6.0.2" />
     <PackageReference Include="ServiceStack.HttpClient.Core" Version="6.0.2" />

--- a/src/Aquarius.Client/Helpers/SdkServiceClient.cs
+++ b/src/Aquarius.Client/Helpers/SdkServiceClient.cs
@@ -33,6 +33,7 @@ namespace Aquarius.Helpers
             var components = new[]
             {
                 UserAgent,
+                System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription,
                 UserAgentBuilder.GetSdkComponent(),
                 UserAgentBuilder.GetApplicationComponent()
             };

--- a/src/Aquarius.Client/TimeSeries/Client/Helpers/ClientHelper.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/Helpers/ClientHelper.cs
@@ -70,7 +70,7 @@ namespace Aquarius.TimeSeries.Client.Helpers
 
         private static void LoadFromXmlString(RSACryptoServiceProvider rsaCrypto, string publicKeyXml)
         {
-#if NETFRAMEWORK
+#if NETFRAMEWORK || NET6_0_OR_GREATER
             rsaCrypto.FromXmlString(publicKeyXml);
 #else
             // Thanks to: https://gist.github.com/Jargon64/5b172c452827e15b21882f1d76a94be4


### PR DESCRIPTION
@KarlManning-AI @DougSchmidt-AI 
After upgrading ServiceStack to version 6, FileUploader tests fail when targeting net6.0 due to ServiceStack dependencies.
ServiceStack.HttpClient.Core package (6.0.0 and higher) targets net6.0 and netstandard2.0.
In netstandard2.0:
    JsonHttpClient [ServiceStack.HttpClient.dll]
    -> ResultsFilterHttpResponseDelegate [ServiceStack.HttpClient.dll]
In net6.0:
    JsonHttpClient [ServiceStack.HttpClient.dll]
    -> ResultsFilterHttpResponseDelegate [ServiceStack.Client.dll]

If all Aquarius.Client.* projects are switched to target net6.0 (instead of netstandard2.1), tests pass.