### PR TITLE
AQ-28763 Updated logic for maintenance mode check

### DIFF
--- a/src/Aquarius.Client/Samples/Client/SamplesClient.cs
+++ b/src/Aquarius.Client/Samples/Client/SamplesClient.cs
@@ -76,7 +76,19 @@ namespace Aquarius.Samples.Client
 
             Client.AddHeader(AuthorizationHeaderKey, $"token {apiToken}");
 
-            ServerVersion = GetServerVersion();
+            try
+            {
+                ServerVersion = GetServerVersion();
+            }
+            catch (SamplesApiException e)
+            {
+                if (e.IsAny500())
+                {
+                    throw new SamplesMaintenanceModeException($"{e.Message}: AQUARIUS Samples is in maintenance mode", e.InnerException as WebServiceException);
+                }
+                throw;
+            }
+
             AuthenticatedUser = GetAuthenticatedUser();
 
             Log.Info($"Connected to {GetBaseUri()} ({ServerVersion}) as {AuthenticatedUser.FullName}");

--- a/src/Aquarius.Client/Samples/Client/WebServiceExceptionHandler.cs
+++ b/src/Aquarius.Client/Samples/Client/WebServiceExceptionHandler.cs
@@ -9,9 +9,6 @@ namespace Aquarius.Samples.Client
     {
         public static SamplesApiException CreateSamplesApiExceptionFromResponse(WebServiceException e)
         {
-            if (e.ResponseHeaders["server"] == "AmazonS3")
-                return new SamplesMaintenanceModeException($"{e.Message}: AQUARIUS Samples is in maintenance mode", e);
-
             var errorResponse = DeserializeErrorFromResponse(e);
             var message = ComposeMessage(e, errorResponse);
 


### PR DESCRIPTION
Samples team will be removing the current maintenance page in the next
few months. New logic: assume any 500 error from /api/v1/status endpoing
=> maintenance, and throw SamplesMaintenanceModeException().