### PR TITLE
AQ-28763 Tweaked maintenance mode detection

### DIFF
--- a/src/Aquarius.Client.UnitTests/Samples/Client/MaintenanceModeTests.cs
+++ b/src/Aquarius.Client.UnitTests/Samples/Client/MaintenanceModeTests.cs
@@ -1,0 +1,73 @@
+using System;
+using Aquarius.Samples.Client;
+using Aquarius.Samples.Client.ServiceModel;
+using NSubstitute;
+using NUnit.Framework;
+using ServiceStack;
+using FluentAssertions;
+
+#if AUTOFIXTURE4
+using AutoFixture;
+#else
+using Ploeh.AutoFixture;
+#endif
+
+namespace Aquarius.Client.UnitTests.Samples.Client
+{
+    [TestFixture]
+    public class MaintenanceModeTests
+    {
+        private IServiceClient _fakeServiceClient;
+        private IFixture _fixture;
+
+        [SetUp]
+        public void ForEachTest()
+        {
+            _fakeServiceClient = Substitute.For<IServiceClient>();
+            _fixture = new Fixture();
+        }
+
+        [Test]
+        public void ClientDetectsMaintenanceModeOnCreation()
+        {
+            _fakeServiceClient
+                .Get(Arg.Any<GetStatus>())
+                .Returns(x =>
+                {
+                    throw new WebServiceException
+                    {
+                        StatusCode = 500
+                    };
+                });
+            
+            ((Action) (() => SamplesClient.CreateTestClient(_fakeServiceClient)))
+                .ShouldThrow<SamplesMaintenanceModeException>();
+        }
+
+        [Test]
+        public void ClientDetectsMaintenanceModeAfterCreation()
+        {
+            _fakeServiceClient
+                .Get(Arg.Any<GetStatus>())
+                .Returns(new Status { ReleaseName = "0.0" });
+
+            _fakeServiceClient
+                .Get(Arg.Any<SamplesClient.GetUserTokens>())
+                .Returns(_fixture.Create<SamplesClient.UserTokensResponse>());
+            
+            _fakeServiceClient
+                .Post(Arg.Any<PostTag>())
+                .Returns(x =>
+                {
+                    throw new WebServiceException
+                    {
+                        StatusCode = 500
+                    };
+                });
+
+            var client = SamplesClient.CreateTestClient(_fakeServiceClient);
+            ((Action)(() => client.Post(new PostTag())))
+                .ShouldThrow<SamplesMaintenanceModeException>();
+        }
+    }
+}

--- a/src/Aquarius.Client/Samples/Client/SamplesClient.cs
+++ b/src/Aquarius.Client/Samples/Client/SamplesClient.cs
@@ -342,7 +342,8 @@ namespace Aquarius.Samples.Client
             }, scopeMethod);
         }
 
-        public TResponse InvokeWebServiceMethod<TResponse>(Func<TResponse> webServiceMethod, Func<JsConfigScope> scopeMethod = null)
+        public TResponse InvokeWebServiceMethod<TResponse>(Func<TResponse> webServiceMethod,
+            Func<JsConfigScope> scopeMethod = null)
         {
             try
             {
@@ -353,12 +354,25 @@ namespace Aquarius.Samples.Client
             }
             catch (WebServiceException exception)
             {
+                if (exception.IsAny500() && IsStatusRequest(webServiceMethod))
+                {
+                    throw new SamplesMaintenanceModeException($"{exception.Message}: AQUARIUS Samples is in maintenance mode", exception);
+                }
+                if (exception.IsAny500())
+                {
+                    InvokeWebServiceMethod(() => _client.Get(new GetStatus()));
+                }
                 throw WebServiceExceptionHandler.CreateSamplesApiExceptionFromResponse(exception);
             }
             catch (WebException exception)
             {
                 throw WebServiceExceptionHandler.CreateSamplesApiExceptionFromResponse(exception);
             }
+        }
+        
+        private static bool IsStatusRequest<TResponse>(Func<TResponse> webServiceMethod)
+        {
+            return webServiceMethod.Method.ReturnType == typeof(Status);
         }
     }
 }

--- a/src/Aquarius.Client/Samples/Client/SamplesClient.cs
+++ b/src/Aquarius.Client/Samples/Client/SamplesClient.cs
@@ -76,19 +76,7 @@ namespace Aquarius.Samples.Client
 
             Client.AddHeader(AuthorizationHeaderKey, $"token {apiToken}");
 
-            try
-            {
-                ServerVersion = GetServerVersion();
-            }
-            catch (SamplesApiException e)
-            {
-                if (e.IsAny500())
-                {
-                    throw new SamplesMaintenanceModeException($"{e.Message}: AQUARIUS Samples is in maintenance mode", e.InnerException as WebServiceException);
-                }
-                throw;
-            }
-
+            ServerVersion = GetServerVersion();
             AuthenticatedUser = GetAuthenticatedUser();
 
             Log.Info($"Connected to {GetBaseUri()} ({ServerVersion}) as {AuthenticatedUser.FullName}");

--- a/src/Aquarius.Client/Samples/Client/WebServiceExceptionHandler.cs
+++ b/src/Aquarius.Client/Samples/Client/WebServiceExceptionHandler.cs
@@ -9,9 +9,6 @@ namespace Aquarius.Samples.Client
     {
         public static SamplesApiException CreateSamplesApiExceptionFromResponse(WebServiceException e)
         {
-            if (e.IsAny500())
-                return new SamplesMaintenanceModeException($"{e.Message}: AQUARIUS Samples is in maintenance mode", e);
-            
             var errorResponse = DeserializeErrorFromResponse(e);
             var message = ComposeMessage(e, errorResponse);
 

--- a/src/Aquarius.Client/Samples/Client/WebServiceExceptionHandler.cs
+++ b/src/Aquarius.Client/Samples/Client/WebServiceExceptionHandler.cs
@@ -9,6 +9,9 @@ namespace Aquarius.Samples.Client
     {
         public static SamplesApiException CreateSamplesApiExceptionFromResponse(WebServiceException e)
         {
+            if (e.IsAny500())
+                return new SamplesMaintenanceModeException($"{e.Message}: AQUARIUS Samples is in maintenance mode", e);
+            
             var errorResponse = DeserializeErrorFromResponse(e);
             var message = ComposeMessage(e, errorResponse);
 


### PR DESCRIPTION
Restored Client's ability to detect maintenance mode after creation,
kept the updated logic. Added unit tests for detection both on and after creation.