### PR TITLE
AWP-4554 Implement double-lock in ServiceStackConfig.ConfigureServiceStack()

### DIFF
--- a/src/Aquarius.Client/Samples/Client/SamplesClient.cs
+++ b/src/Aquarius.Client/Samples/Client/SamplesClient.cs
@@ -27,6 +27,9 @@ namespace Aquarius.Samples.Client
 
         private static void SetupServiceStack()
         {
+            if (_serviceStackConfigured)
+                return;
+
             lock (SyncLock)
             {
                 if (_serviceStackConfigured)

--- a/src/Aquarius.Client/TimeSeries/Client/AquariusClient.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/AquariusClient.cs
@@ -41,6 +41,9 @@ namespace Aquarius.TimeSeries.Client
 
         private static void SetupServiceStack()
         {
+            if (_serviceStackConfigured)
+                return;
+
             lock (SyncLock)
             {
                 if (_serviceStackConfigured)

--- a/src/Aquarius.Client/TimeSeries/Client/NativeTypes/ServerRequestNameResolver.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/NativeTypes/ServerRequestNameResolver.cs
@@ -27,6 +27,9 @@ namespace Aquarius.TimeSeries.Client.NativeTypes
 
         private void FetchEndpointMetadataOnce(IServiceClient client)
         {
+            if (RequestsByRoute != null)
+                return;
+
             lock (_syncLock)
             {
                 if (RequestsByRoute != null)

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceStackConfig.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceStackConfig.cs
@@ -22,6 +22,9 @@ namespace Aquarius.TimeSeries.Client
 
         public static void ConfigureServiceStack()
         {
+            if (_configured)
+                return;
+
             lock (SyncLock)
             {
                 if (_configured)


### PR DESCRIPTION
This should slightly improve performance on multi-threaded systems.