### PR TITLE
at-1052 update sdk

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,16 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
+### 24.4.0
+- Updated the service models for the AQUARIUS Time-Series 2024.4 beta release.
+
+### 24.2.1/24.2.2/24.2.3
+- Internal updates to Nuget access keys for build, no functional changes.
+
+### 24.2.0
+- Added support for .NET 8, dropped support for .NET 6.
+- Moved the ServiceStack dependencies from v6.0.2 to v8.4.0
+
 ### 24.2.0
 - Updated the service models for the AQUARIUS Time-Series 2024.2 beta release.
 

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2024-07-30 03:44:14
+Date: 2025-01-08 04:13:00
 Version: 6.02
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: https://develop-1.dev.aquariusdev.net/AQUARIUS/Acquisition/v2
@@ -695,6 +695,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("24.2.66.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("24.4.38.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2024-07-30 03:44:10
+Date: 2025-01-08 04:12:56
 Version: 6.02
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: https://develop-1.dev.aquariusdev.net/AQUARIUS/Provisioning/v1
@@ -6726,6 +6726,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("24.2.66.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("24.4.38.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2024-07-30 03:44:04
+Date: 2025-01-08 04:12:51
 Version: 6.02
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: https://develop-1.dev.aquariusdev.net/AQUARIUS/Publish/v2
@@ -8120,6 +8120,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("24.2.66.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("24.4.38.0");
     }
 }


### PR DESCRIPTION
bumps the sdk to 24.4 (appveyor version updated). there were no api changes detected.
i've added release notes for the last few prs that were missed.