### PR TITLE
Auto-update Time-Series .NET SDK

### DIFF
--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2025-10-22 02:07:41
+Date: 2025-11-03 04:38:42
 Version: 6.02
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: https://develop-1.dev.aquariusdev.net/AQUARIUS/Acquisition/v2
@@ -724,6 +724,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("25.3.106.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("25.4.10.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2025-10-22 02:07:40
+Date: 2025-11-03 04:38:42
 Version: 6.02
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: https://develop-1.dev.aquariusdev.net/AQUARIUS/Provisioning/v1
@@ -6726,6 +6726,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("25.3.106.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("25.4.10.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2025-10-22 02:07:38
+Date: 2025-11-03 04:38:41
 Version: 6.02
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: https://develop-1.dev.aquariusdev.net/AQUARIUS/Publish/v2
@@ -4574,12 +4574,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         public string TestMethod { get; set; }
 
         ///<summary>
-        ///The code identifying the aquifer
-        ///</summary>
-        [ApiMember(Description="The code identifying the aquifer", Name="AquiferCode")]
-        public string AquiferCode { get; set; }
-
-        ///<summary>
         ///The type of aquifer
         ///</summary>
         [ApiMember(Description="The type of aquifer", Name="AquiferType")]
@@ -8466,6 +8460,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("25.3.106.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("25.4.10.0");
     }
 }


### PR DESCRIPTION
Automatic PR to update the Time-Series .NET SDK. Manually push a commit to update the Release Notes file, and update the version in AppVeyor, before merging.<br><br>Companion Java SDK update at: https://github.com/AquaticInformatics/aquarius-sdk-java/pulls/