### PR TITLE
Auto-update Time-Series .NET SDK

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,9 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
+### 2x.x.x
+- Updated the service models for the AQUARIUS Time-Series 202x.x release.
+
 ### 25.3.0
 - Updated the service models for the AQUARIUS Time-Series 2025.3 release.
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,8 +4,8 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
-### 2x.x.x
-- Updated the service models for the AQUARIUS Time-Series 202x.x release.
+### 25.4.0
+- Updated the service models for the AQUARIUS Time-Series 2025.4 release.
 
 ### 25.3.0
 - Updated the service models for the AQUARIUS Time-Series 2025.3 release.

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2025-10-22 02:07:41
+Date: 2026-01-08 01:51:05
 Version: 6.02
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: https://develop-1.dev.aquariusdev.net/AQUARIUS/Acquisition/v2
@@ -724,6 +724,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("25.3.106.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("25.4.67.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2025-10-22 02:07:40
+Date: 2026-01-08 01:51:04
 Version: 6.02
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: https://develop-1.dev.aquariusdev.net/AQUARIUS/Provisioning/v1
@@ -39,6 +39,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         AppliesToLocations,
         AppliesToLocationTypes,
         AppliesToTimeSeries,
+        AppliesToVisits,
     }
 
     public enum TagApplicability
@@ -573,9 +574,9 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         public List<string> PickListValues { get; set; }
 
         ///<summary>
-        ///Extended attribute applicability, select one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries.
+        ///Extended attribute applicability, select one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits.
         ///</summary>
-        [ApiMember(DataType="array", Description="Extended attribute applicability, select one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries.")]
+        [ApiMember(DataType="array", Description="Extended attribute applicability, select one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits.")]
         public List<ExtendedAttributeApplicability> Applicability { get; set; }
 
         ///<summary>
@@ -624,9 +625,9 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         }
 
         ///<summary>
-        ///If set, return only extended attribute definitions with specified applicability, select from: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries
+        ///If set, return only extended attribute definitions with specified applicability, select from: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits
         ///</summary>
-        [ApiMember(AllowMultiple=true, DataType="array", Description="If set, return only extended attribute definitions with specified applicability, select from: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries")]
+        [ApiMember(AllowMultiple=true, DataType="array", Description="If set, return only extended attribute definitions with specified applicability, select from: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits")]
         public List<ExtendedAttributeApplicability> Applicability { get; set; }
     }
 
@@ -4559,9 +4560,15 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         public bool AppliesToTimeSeries { get; set; }
 
         ///<summary>
-        ///Extended attribute applicability, one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries.
+        ///DEPRECATED: Use Applicability instead. True if extended attribute is applicable to Visits
         ///</summary>
-        [ApiMember(DataType="array", Description="Extended attribute applicability, one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries.")]
+        [ApiMember(DataType="boolean", Description="DEPRECATED: Use Applicability instead. True if extended attribute is applicable to Visits")]
+        public bool AppliesToVisits { get; set; }
+
+        ///<summary>
+        ///Extended attribute applicability, one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits.
+        ///</summary>
+        [ApiMember(DataType="array", Description="Extended attribute applicability, one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits.")]
         public List<ExtendedAttributeApplicability> Applicability { get; set; }
 
         ///<summary>
@@ -6726,6 +6733,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("25.3.106.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("25.4.67.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2025-10-22 02:07:38
+Date: 2026-01-08 01:51:02
 Version: 6.02
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: https://develop-1.dev.aquariusdev.net/AQUARIUS/Publish/v2
@@ -4277,6 +4277,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///</summary>
         [ApiMember(DataType="string", Description="Last time the deleted field visit matched the given filters; set only when request includes ChangesSinceToken", Format="date-time")]
         public DateTimeOffset? LastMatchedTime { get; set; }
+
+        ///<summary>
+        ///Extended attributes
+        ///</summary>
+        [ApiMember(DataType="array", Description="Extended attributes")]
+        public IList<ExtendedAttribute> ExtendedAttributes { get; set; }
     }
 
     public class FieldVisitReading
@@ -4572,12 +4578,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///</summary>
         [ApiMember(Description="The method used for the test", Name="TestMethod")]
         public string TestMethod { get; set; }
-
-        ///<summary>
-        ///The code identifying the aquifer
-        ///</summary>
-        [ApiMember(Description="The code identifying the aquifer", Name="AquiferCode")]
-        public string AquiferCode { get; set; }
 
         ///<summary>
         ///The type of aquifer
@@ -6397,6 +6397,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
             Activities = new List<ActivityType>{};
             Parameters = new List<string>{};
             InspectionTypes = new List<InspectionType>{};
+            ExtendedFilters = new List<ExtendedAttributeFilter>{};
         }
 
         ///<summary>
@@ -6464,6 +6465,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///</summary>
         [ApiMember(Description="If set, length reading values will be converted to the specified Standard Reference Datum")]
         public string ConvertToStandardReferenceDatum { get; set; }
+
+        ///<summary>
+        ///Filter results to items matching the given extended attribute values
+        ///</summary>
+        [ApiMember(DataType="array", Description="Filter results to items matching the given extended attribute values")]
+        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; }
     }
 
     [Route("/GetFieldVisitData", "GET")]
@@ -6529,6 +6536,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class FieldVisitDescriptionListServiceRequest
         : IReturn<FieldVisitDescriptionListServiceResponse>
     {
+        public FieldVisitDescriptionListServiceRequest()
+        {
+            ExtendedFilters = new List<ExtendedAttributeFilter>{};
+        }
+
         ///<summary>
         ///Filter results to the given location
         ///</summary>
@@ -6558,6 +6570,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///</summary>
         [ApiMember(DataType="string", Description="Filter results to items modified at or after the ChangesSinceToken time", Format="date-time")]
         public DateTime? ChangesSinceToken { get; set; }
+
+        ///<summary>
+        ///Filter results to items matching the given extended attribute values
+        ///</summary>
+        [ApiMember(DataType="array", Description="Filter results to items matching the given extended attribute values")]
+        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; }
     }
 
     [Route("/GetAuthToken", "GET")]
@@ -7714,6 +7732,12 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///</summary>
         [ApiMember(DataType="WellIntegrityActivity", Description="Well integrity activity")]
         public WellIntegrityActivity WellIntegrityActivity { get; set; }
+
+        ///<summary>
+        ///Extended attributes
+        ///</summary>
+        [ApiMember(DataType="array", Description="Extended attributes")]
+        public IList<ExtendedAttribute> ExtendedAttributes { get; set; }
     }
 
     public class FieldVisitDescriptionListServiceResponse
@@ -8466,6 +8490,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("25.3.106.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("25.4.67.0");
     }
 }


### PR DESCRIPTION
Automatic PR to update the Time-Series .NET SDK. Manually push a commit to update the ReleaseNotes.md file, and update the version in AppVeyor, before merging.<br><br>Companion Java SDK update at: https://github.com/AquaticInformatics/aquarius-sdk-java/pulls/