### PR TITLE
at-1799 fix sdk generation

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,10 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
+### 25.4.2
+- Collections are no longer initialized by default. When creating an API object directly collections won't be initalized but appear to be done so when binding through an API request.
+- Fixes a bug where Provisioning Locations POST/PUT methods failed on the UtcOffset field
+
 ### 25.4.0
 - Updated the service models for the AQUARIUS Time-Series 2025.4 release.
 

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/OffsetSerializerTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/OffsetSerializerTests.cs
@@ -27,7 +27,8 @@ namespace Aquarius.UnitTests.TimeSeries.Client
             new TestCaseData("Negative offset", Negative8.Value, "\"-PT8H\""),
             new TestCaseData("Utc offset", UtcOffset.Value, "\"PT0S\""),
             new TestCaseData("Positive offset", Positive10.Value, "\"PT10H\""),
-            new TestCaseData("Positive offset with hours and minutes", Positive9Point5.Value, "\"PT9H30M\"")
+            new TestCaseData("Positive offset with hours and minutes", Positive9Point5.Value, "\"PT9H30M\""),
+            new TestCaseData("Null offset", null, "\"PT0S\"")
         };
 
         private static readonly IEnumerable<TestCaseData> NullableOffsetCases = new[]

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/OffsetSerializerTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/OffsetSerializerTests.cs
@@ -1,0 +1,70 @@
+﻿using Aquarius.TimeSeries.Client;
+using FluentAssertions;
+using NodaTime;
+using NUnit.Framework;
+using ServiceStack;
+using System;
+using System.Collections.Generic;
+
+namespace Aquarius.UnitTests.TimeSeries.Client
+{
+    [TestFixture]
+    public class OffsetSerializerTests
+    {
+        [SetUp]
+        public void ForEachTest()
+        {
+            ServiceStackConfig.ConfigureServiceStack();
+        }
+
+        private static readonly Offset? Negative8 = Offset.FromTicks(TimeSpan.FromHours(-8).Ticks);
+        private static readonly Offset? UtcOffset = Offset.FromTicks(0);
+        private static readonly Offset? Positive9Point5 = Offset.FromTicks(TimeSpan.FromHours(9.5).Ticks); 
+        private static readonly Offset? Positive10 = Offset.FromTicks(TimeSpan.FromHours(10).Ticks);
+        
+        private static readonly IEnumerable<TestCaseData> OffsetCases = new[]
+        {
+            new TestCaseData("Negative offset", Negative8.Value, "\"-PT8H\""),
+            new TestCaseData("Utc offset", UtcOffset.Value, "\"PT0S\""),
+            new TestCaseData("Positive offset", Positive10.Value, "\"PT10H\""),
+            new TestCaseData("Positive offset with hours and minutes", Positive9Point5.Value, "\"PT9H30M\"")
+        };
+
+        private static readonly IEnumerable<TestCaseData> NullableOffsetCases = new[]
+        {
+            new TestCaseData("Negative offset", Negative8, "\"-PT8H\""),
+            new TestCaseData("Utc offset", UtcOffset, "\"PT0S\""),
+            new TestCaseData("Positive offset", Positive10, "\"PT10H\""),
+            new TestCaseData("Positive offset with hours and minutes", Positive9Point5, "\"PT9H30M\""),
+            new TestCaseData("Null offset", null, null)
+        };
+
+        [TestCaseSource("OffsetCases")]
+        public void Offset_DeserializesFromJsonCorrectly(string reason, Offset expectedOffset, string offsetAsJson)
+        {
+            var actualOffset = offsetAsJson.FromJson<Offset>();
+            ((Offset)actualOffset).ShouldBeEquivalentTo(expectedOffset, reason);
+        }
+
+        [TestCaseSource("OffsetCases")]
+        public void Offset_SerializesToJsonCorrectly(string reason, Offset offset, string offsetAsJson)
+        {
+            var actualJson = offset.ToJson();
+            actualJson.ShouldBeEquivalentTo(offsetAsJson, reason);
+        }
+
+        [TestCaseSource("NullableOffsetCases")]
+        public void NullableOffset_DeserializesFromJsonCorrectly(string reason, Offset? expectedOffset, string offsetAsJson)
+        {
+            var actualOffset = offsetAsJson.FromJson<Offset?>();
+            ((Offset?)actualOffset).ShouldBeEquivalentTo(expectedOffset, reason);
+        }
+
+        [TestCaseSource("NullableOffsetCases")]
+        public void NullableOffset_SerializesToJsonCorrectly(string reason, Offset? offset, string offsetAsJson)
+        {
+            var actualJson = offset.ToJson();
+            actualJson.ShouldBeEquivalentTo(offsetAsJson, reason);
+        }
+    }
+}

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2026-01-29 12:26:31
+Date: 2026-01-29 13:26:44
 Version: 10.04
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: https://aqwp-opendata.aquariusdev.net/AQUARIUS/Acquisition/v2
@@ -336,7 +336,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Notes to append
         ///</summary>
         [ApiMember(DataType="array", Description="Notes to append", IsRequired=true)]
-        public List<TimeSeriesNote> Notes { get; set; } = [];
+        public List<TimeSeriesNote> Notes { get; set; }
     }
 
     [Route("/timeseries/{UniqueId}/overwriteappend", "POST")]

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
@@ -1,14 +1,15 @@
 /* Options:
-Date: 2026-01-08 01:51:05
-Version: 6.02
+Date: 2026-01-29 11:34:50
+Version: 10.04
 Tip: To override a DTO option, remove "//" prefix before updating
-BaseUrl: https://develop-1.dev.aquariusdev.net/AQUARIUS/Acquisition/v2
+BaseUrl: https://aqwp-opendata.aquariusdev.net/AQUARIUS/Acquisition/v2
 
 GlobalNamespace: Aquarius.TimeSeries.Client.ServiceModels.Acquisition
 MakePartial: False
 MakeVirtual: False
 //MakeInternal: False
 //MakeDataContractsExtensible: False
+AddNullableAnnotations: False
 //AddReturnMarker: True
 //AddDescriptionAsComments: True
 //AddDataContractAttributes: False
@@ -16,7 +17,7 @@ MakeVirtual: False
 //AddGeneratedCodeAttributes: False
 //AddResponseStatus: False
 //AddImplicitVersion: 
-//InitializeCollections: True
+InitializeCollections: True
 ExportValueTypes: True
 //IncludeTypes: 
 //ExcludeTypes: 
@@ -160,11 +161,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
     public class PostLocationAttachment
         : IReturn<PostLocationAttachmentResponse>, IFileUploadRequest
     {
-        public PostLocationAttachment()
-        {
-            Tags = new List<ApplyTagRequest>{};
-        }
-
         ///<summary>
         ///Unique ID of the location to add the attachment to
         ///</summary>
@@ -194,18 +190,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Tags to be assigned to the attachment with optional values; an empty list means the attachment will have no tags assigned to it.
         ///</summary>
         [ApiMember(DataType="array", Description="Tags to be assigned to the attachment with optional values; an empty list means the attachment will have no tags assigned to it.")]
-        public List<ApplyTagRequest> Tags { get; set; }
+        public List<ApplyTagRequest> Tags { get; set; } = [];
     }
 
     [Route("/timeseries/{UniqueId}/reflected", "POST")]
     public class PostReflectedTimeSeries
         : IReturn<AppendResponse>
     {
-        public PostReflectedTimeSeries()
-        {
-            Points = new List<TimeSeriesPoint>{};
-        }
-
         ///<summary>
         ///The unique ID (from Publish API) of the reflected time-series to receive points
         ///</summary>
@@ -216,7 +207,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Points to append (can be empty). All points must lie within the time range
         ///</summary>
         [ApiMember(DataType="array", Description="Points to append (can be empty). All points must lie within the time range")]
-        public List<TimeSeriesPoint> Points { get; set; }
+        public List<TimeSeriesPoint> Points { get; set; } = [];
 
         ///<summary>
         ///Time range to update. Any existing points in the time range will be overwritten
@@ -229,12 +220,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
     public class PostReportAttachment
         : IReturn<PostReportResponse>, IFileUploadRequest
     {
-        public PostReportAttachment()
-        {
-            SourceTimeSeriesUniqueIds = new List<Guid>{};
-            Tags = new List<ApplyTagRequest>{};
-        }
-
         ///<summary>
         ///Title of the report
         ///</summary>
@@ -263,7 +248,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Unique IDs of source time-series displayed in report
         ///</summary>
         [ApiMember(DataType="array", Description="Unique IDs of source time-series displayed in report")]
-        public List<Guid> SourceTimeSeriesUniqueIds { get; set; }
+        public List<Guid> SourceTimeSeriesUniqueIds { get; set; } = [];
 
         ///<summary>
         ///Time range of source data displayed in report
@@ -281,7 +266,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Tags to be assigned to the report with optional values; an empty list means the report will have no tags assigned to it.
         ///</summary>
         [ApiMember(DataType="array", Description="Tags to be assigned to the report with optional values; an empty list means the report will have no tags assigned to it.")]
-        public List<ApplyTagRequest> Tags { get; set; }
+        public List<ApplyTagRequest> Tags { get; set; } = [];
 
         ///<summary>
         ///File
@@ -295,11 +280,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
     public class PostTimeSeriesAppend
         : IReturn<AppendResponse>
     {
-        public PostTimeSeriesAppend()
-        {
-            Points = new List<TimeSeriesPoint>{};
-        }
-
         ///<summary>
         ///The unique ID (from Publish API) of the time-series to receive points
         ///</summary>
@@ -310,7 +290,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Points to append (can be empty)
         ///</summary>
         [ApiMember(DataType="array", Description="Points to append (can be empty)")]
-        public List<TimeSeriesPoint> Points { get; set; }
+        public List<TimeSeriesPoint> Points { get; set; } = [];
     }
 
     [Route("/timeseries/{UniqueId}/metadata/grade", "POST")]
@@ -346,11 +326,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
     public class PostTimeSeriesMetadata
         : IReturn<PostTimeSeriesMetadataResponse>
     {
-        public PostTimeSeriesMetadata()
-        {
-            Notes = new List<TimeSeriesNote>{};
-        }
-
         ///<summary>
         ///The unique ID (from Publish API) of the time-series
         ///</summary>
@@ -361,18 +336,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Notes to append
         ///</summary>
         [ApiMember(DataType="array", Description="Notes to append", IsRequired=true)]
-        public List<TimeSeriesNote> Notes { get; set; }
+        public List<TimeSeriesNote> Notes { get; set; } = [];
     }
 
     [Route("/timeseries/{UniqueId}/overwriteappend", "POST")]
     public class PostTimeSeriesOverwriteAppend
         : IReturn<AppendResponse>
     {
-        public PostTimeSeriesOverwriteAppend()
-        {
-            Points = new List<TimeSeriesPoint>{};
-        }
-
         ///<summary>
         ///The unique ID (from Publish API) of the time-series to receive points
         ///</summary>
@@ -383,7 +353,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Points to append (can be empty). All points must lie within the time range
         ///</summary>
         [ApiMember(DataType="array", Description="Points to append (can be empty). All points must lie within the time range")]
-        public List<TimeSeriesPoint> Points { get; set; }
+        public List<TimeSeriesPoint> Points { get; set; } = [];
 
         ///<summary>
         ///Time range to delete before appending points
@@ -448,11 +418,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
 
     public class TimeSeriesPoint
     {
-        public TimeSeriesPoint()
-        {
-            Qualifiers = new List<string>{};
-        }
-
         ///<summary>
         ///ISO 8601 timestamp. Must not be specified if Type is 'Gap'.
         ///</summary>
@@ -481,7 +446,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Qualifier codes
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifier codes")]
-        public List<string> Qualifiers { get; set; }
+        public List<string> Qualifiers { get; set; } = [];
     }
 
     public class AppendResponse
@@ -540,11 +505,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
 
     public class PostLocationAttachmentResponse
     {
-        public PostLocationAttachmentResponse()
-        {
-            Tags = new List<AppliedTag>{};
-        }
-
         ///<summary>
         ///Attachment URL
         ///</summary>
@@ -586,7 +546,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Tags applied to this attachment
         ///</summary>
         [ApiMember(DataType="array", Description="Tags applied to this attachment")]
-        public List<AppliedTag> Tags { get; set; }
+        public List<AppliedTag> Tags { get; set; } = [];
     }
 
     public class PostReportResponse
@@ -609,23 +569,17 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
 
     public class PostVisitFileResponse
     {
-        public PostVisitFileResponse()
-        {
-            VisitUris = new List<string>{};
-            VisitIdentifiers = new List<string>{};
-        }
-
         ///<summary>
         ///Relative URIs of created or modified visits
         ///</summary>
         [ApiMember(DataType="array", Description="Relative URIs of created or modified visits")]
-        public List<string> VisitUris { get; set; }
+        public List<string> VisitUris { get; set; } = [];
 
         ///<summary>
         ///Identifiers of created or modified visits
         ///</summary>
         [ApiMember(DataType="array", Description="Identifiers of created or modified visits")]
-        public List<string> VisitIdentifiers { get; set; }
+        public List<string> VisitIdentifiers { get; set; } = [];
 
         ///<summary>
         ///Registered field data plug-in that processed the file
@@ -724,6 +678,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("25.4.67.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("26.1.8.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2026-01-29 11:34:50
+Date: 2026-01-29 12:26:31
 Version: 10.04
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: https://aqwp-opendata.aquariusdev.net/AQUARIUS/Acquisition/v2
@@ -17,7 +17,7 @@ AddNullableAnnotations: False
 //AddGeneratedCodeAttributes: False
 //AddResponseStatus: False
 //AddImplicitVersion: 
-InitializeCollections: True
+InitializeCollections: False
 ExportValueTypes: True
 //IncludeTypes: 
 //ExcludeTypes: 
@@ -190,7 +190,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Tags to be assigned to the attachment with optional values; an empty list means the attachment will have no tags assigned to it.
         ///</summary>
         [ApiMember(DataType="array", Description="Tags to be assigned to the attachment with optional values; an empty list means the attachment will have no tags assigned to it.")]
-        public List<ApplyTagRequest> Tags { get; set; } = [];
+        public List<ApplyTagRequest> Tags { get; set; }
     }
 
     [Route("/timeseries/{UniqueId}/reflected", "POST")]
@@ -207,7 +207,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Points to append (can be empty). All points must lie within the time range
         ///</summary>
         [ApiMember(DataType="array", Description="Points to append (can be empty). All points must lie within the time range")]
-        public List<TimeSeriesPoint> Points { get; set; } = [];
+        public List<TimeSeriesPoint> Points { get; set; }
 
         ///<summary>
         ///Time range to update. Any existing points in the time range will be overwritten
@@ -248,7 +248,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Unique IDs of source time-series displayed in report
         ///</summary>
         [ApiMember(DataType="array", Description="Unique IDs of source time-series displayed in report")]
-        public List<Guid> SourceTimeSeriesUniqueIds { get; set; } = [];
+        public List<Guid> SourceTimeSeriesUniqueIds { get; set; }
 
         ///<summary>
         ///Time range of source data displayed in report
@@ -266,7 +266,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Tags to be assigned to the report with optional values; an empty list means the report will have no tags assigned to it.
         ///</summary>
         [ApiMember(DataType="array", Description="Tags to be assigned to the report with optional values; an empty list means the report will have no tags assigned to it.")]
-        public List<ApplyTagRequest> Tags { get; set; } = [];
+        public List<ApplyTagRequest> Tags { get; set; }
 
         ///<summary>
         ///File
@@ -290,7 +290,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Points to append (can be empty)
         ///</summary>
         [ApiMember(DataType="array", Description="Points to append (can be empty)")]
-        public List<TimeSeriesPoint> Points { get; set; } = [];
+        public List<TimeSeriesPoint> Points { get; set; }
     }
 
     [Route("/timeseries/{UniqueId}/metadata/grade", "POST")]
@@ -353,7 +353,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Points to append (can be empty). All points must lie within the time range
         ///</summary>
         [ApiMember(DataType="array", Description="Points to append (can be empty). All points must lie within the time range")]
-        public List<TimeSeriesPoint> Points { get; set; } = [];
+        public List<TimeSeriesPoint> Points { get; set; }
 
         ///<summary>
         ///Time range to delete before appending points
@@ -446,7 +446,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Qualifier codes
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifier codes")]
-        public List<string> Qualifiers { get; set; } = [];
+        public List<string> Qualifiers { get; set; }
     }
 
     public class AppendResponse
@@ -546,7 +546,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Tags applied to this attachment
         ///</summary>
         [ApiMember(DataType="array", Description="Tags applied to this attachment")]
-        public List<AppliedTag> Tags { get; set; } = [];
+        public List<AppliedTag> Tags { get; set; }
     }
 
     public class PostReportResponse
@@ -573,13 +573,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
         ///Relative URIs of created or modified visits
         ///</summary>
         [ApiMember(DataType="array", Description="Relative URIs of created or modified visits")]
-        public List<string> VisitUris { get; set; } = [];
+        public List<string> VisitUris { get; set; }
 
         ///<summary>
         ///Identifiers of created or modified visits
         ///</summary>
         [ApiMember(DataType="array", Description="Identifiers of created or modified visits")]
-        public List<string> VisitIdentifiers { get; set; } = [];
+        public List<string> VisitIdentifiers { get; set; }
 
         ///<summary>
         ///Registered field data plug-in that processed the file

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
@@ -1,14 +1,15 @@
 /* Options:
-Date: 2026-01-08 01:51:04
-Version: 6.02
+Date: 2026-01-29 11:34:46
+Version: 10.04
 Tip: To override a DTO option, remove "//" prefix before updating
-BaseUrl: https://develop-1.dev.aquariusdev.net/AQUARIUS/Provisioning/v1
+BaseUrl: https://aqwp-opendata.aquariusdev.net/AQUARIUS/Provisioning/v1
 
 GlobalNamespace: Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 MakePartial: False
 MakeVirtual: False
 //MakeInternal: False
 //MakeDataContractsExtensible: False
+AddNullableAnnotations: False
 //AddReturnMarker: True
 //AddDescriptionAsComments: True
 //AddDataContractAttributes: False
@@ -16,7 +17,7 @@ MakeVirtual: False
 //AddGeneratedCodeAttributes: False
 //AddResponseStatus: False
 //AddImplicitVersion: 
-//InitializeCollections: True
+InitializeCollections: True
 ExportValueTypes: True
 //IncludeTypes: 
 //ExcludeTypes: 
@@ -549,12 +550,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class EditableExtendedAttribute
     {
-        public EditableExtendedAttribute()
-        {
-            PickListValues = new List<string>{};
-            Applicability = new List<ExtendedAttributeApplicability>{};
-        }
-
         ///<summary>
         ///Unique extended attribute key
         ///</summary>
@@ -571,13 +566,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Set of pick-list values. Required if ValueType is PickList. Values must be distinct.
         ///</summary>
         [ApiMember(DataType="array", Description="Set of pick-list values. Required if ValueType is PickList. Values must be distinct.")]
-        public List<string> PickListValues { get; set; }
+        public List<string> PickListValues { get; set; } = [];
 
         ///<summary>
         ///Extended attribute applicability, select one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits.
         ///</summary>
         [ApiMember(DataType="array", Description="Extended attribute applicability, select one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits.")]
-        public List<ExtendedAttributeApplicability> Applicability { get; set; }
+        public List<ExtendedAttributeApplicability> Applicability { get; set; } = [];
 
         ///<summary>
         ///Flag which defines if extended attribute is VisibleInDatasetList
@@ -619,16 +614,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
     public class GetExtendedAttributes
         : IReturn<ExtendedAttributesResponse>
     {
-        public GetExtendedAttributes()
-        {
-            Applicability = new List<ExtendedAttributeApplicability>{};
-        }
-
         ///<summary>
         ///If set, return only extended attribute definitions with specified applicability, select from: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits
         ///</summary>
         [ApiMember(AllowMultiple=true, DataType="array", Description="If set, return only extended attribute definitions with specified applicability, select from: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits")]
-        public List<ExtendedAttributeApplicability> Applicability { get; set; }
+        public List<ExtendedAttributeApplicability> Applicability { get; set; } = [];
     }
 
     [Route("/extendedattributes", "POST")]
@@ -1039,11 +1029,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class LocationTypeBase
     {
-        public LocationTypeBase()
-        {
-            ExtendedAttributeDefinitionIds = new List<Guid>{};
-        }
-
         ///<summary>
         ///Type name
         ///</summary>
@@ -1066,7 +1051,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Unique IDs of Extended Attribute definitions associated with this location type
         ///</summary>
         [ApiMember(DataType="array", Description="Unique IDs of Extended Attribute definitions associated with this location type")]
-        public List<Guid> ExtendedAttributeDefinitionIds { get; set; }
+        public List<Guid> ExtendedAttributeDefinitionIds { get; set; } = [];
     }
 
     [Route("/locations", "POST")]
@@ -1101,16 +1086,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
     public class PostReferencePoint
         : ReferencePointBase, IReturn<ReferencePoint>
     {
-        public PostReferencePoint()
-        {
-            ReferencePointPeriods = new List<PostReferencePointPeriod>{};
-        }
-
         ///<summary>
         ///Periods of applicablity for this reference point. Must have at least one period
         ///</summary>
         [ApiMember(DataType="array", Description="Periods of applicablity for this reference point. Must have at least one period", IsRequired=true)]
-        public List<PostReferencePointPeriod> ReferencePointPeriods { get; set; }
+        public List<PostReferencePointPeriod> ReferencePointPeriods { get; set; } = [];
     }
 
     public class PostReferencePointPeriod
@@ -1172,12 +1152,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
     public class PutLocationTags
         : IReturn<Location>
     {
-        public PutLocationTags()
-        {
-            TagUniqueIds = new List<Guid>{};
-            Tags = new List<ApplyTagRequest>{};
-        }
-
         ///<summary>
         ///Unique ID of the location
         ///</summary>
@@ -1188,13 +1162,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///DEPRECATED: use Tags instead
         ///</summary>
         [ApiMember(DataType="array", Description="DEPRECATED: use Tags instead")]
-        public List<Guid> TagUniqueIds { get; set; }
+        public List<Guid> TagUniqueIds { get; set; } = [];
 
         ///<summary>
         ///Tags to be assigned to the location with optional values; an empty list means the location will have no tags assigned to it.
         ///</summary>
         [ApiMember(DataType="array", Description="Tags to be assigned to the location with optional values; an empty list means the location will have no tags assigned to it.")]
-        public List<ApplyTagRequest> Tags { get; set; }
+        public List<ApplyTagRequest> Tags { get; set; } = [];
     }
 
     [Route("/locationtypes/{UniqueId}", "PUT")]
@@ -1223,11 +1197,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
     public class PutReferencePoint
         : ReferencePointBase, IReturn<ReferencePoint>
     {
-        public PutReferencePoint()
-        {
-            ReferencePointPeriods = new List<PutReferencePointPeriod>{};
-        }
-
         ///<summary>
         ///Unique ID of the Reference Point
         ///</summary>
@@ -1238,7 +1207,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Periods of applicablity for this reference point. Must have at least one period
         ///</summary>
         [ApiMember(DataType="array", Description="Periods of applicablity for this reference point. Must have at least one period", IsRequired=true)]
-        public List<PutReferencePointPeriod> ReferencePointPeriods { get; set; }
+        public List<PutReferencePointPeriod> ReferencePointPeriods { get; set; } = [];
     }
 
     public class PutReferencePointPeriod
@@ -1633,11 +1602,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
     public class PutQualifier
         : IReturn<QualifierResponse>
     {
-        public PutQualifier()
-        {
-            GroupIdentifiers = new List<string>{};
-        }
-
         ///<summary>
         ///Unique ID of the qualifier 
         ///</summary>
@@ -1660,18 +1624,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Qualifier group identifiers - if no groups (an empty list is []) are specified, the qualifier will be removed from all groups and re-assigned to the 'Default' qualifier group
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifier group identifiers - if no groups (an empty list is []) are specified, the qualifier will be removed from all groups and re-assigned to the 'Default' qualifier group", IsRequired=true)]
-        public List<string> GroupIdentifiers { get; set; }
+        public List<string> GroupIdentifiers { get; set; } = [];
     }
 
     [Route("/qualifiergroups/{UniqueId}", "PUT")]
     public class PutQualifierGroup
         : IReturn<QualifierGroupResponse>
     {
-        public PutQualifierGroup()
-        {
-            QualifierCodeList = new List<string>{};
-        }
-
         ///<summary>
         ///Unique ID of the qualifier group
         ///</summary>
@@ -1688,16 +1647,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Qualifier codes contained in this group 
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifier codes contained in this group ", IsRequired=true)]
-        public List<string> QualifierCodeList { get; set; }
+        public List<string> QualifierCodeList { get; set; } = [];
     }
 
     public class QualifierBase
     {
-        public QualifierBase()
-        {
-            GroupIdentifiers = new List<string>{};
-        }
-
         ///<summary>
         ///Public identifier
         ///</summary>
@@ -1720,7 +1674,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Qualifier group identifiers - if no groups are specified, the qualifier will be assigned to the 'Default' qualifier group
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifier group identifiers - if no groups are specified, the qualifier will be assigned to the 'Default' qualifier group")]
-        public List<string> GroupIdentifiers { get; set; }
+        public List<string> GroupIdentifiers { get; set; } = [];
     }
 
     [Route("/grades/{GradeCode}", "DELETE")]
@@ -2016,11 +1970,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class RoleBase
     {
-        public RoleBase()
-        {
-            RoleApprovalTransitions = new List<RoleApprovalTransition>{};
-        }
-
         ///<summary>
         ///Name
         ///</summary>
@@ -2031,7 +1980,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///List of approval transitions this role grants permission to perform.
         ///</summary>
         [ApiMember(DataType="array", Description="List of approval transitions this role grants permission to perform.")]
-        public List<RoleApprovalTransition> RoleApprovalTransitions { get; set; }
+        public List<RoleApprovalTransition> RoleApprovalTransitions { get; set; } = [];
 
         ///<summary>
         ///True if role grants permission to: Read data and generate reports.
@@ -2096,11 +2045,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class RoleFlattenedBase
     {
-        public RoleFlattenedBase()
-        {
-            RoleApprovalTransitions = new List<string>{};
-        }
-
         ///<summary>
         ///Name
         ///</summary>
@@ -2111,7 +2055,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///List of approval transitions this role grants permission to perform. Format: '&lt;FromLevel&gt; &lt;ToLevel&gt;'. Example: '900 1200'
         ///</summary>
         [ApiMember(DataType="array", Description="List of approval transitions this role grants permission to perform. Format: '&lt;FromLevel&gt; &lt;ToLevel&gt;'. Example: '900 1200'")]
-        public List<string> RoleApprovalTransitions { get; set; }
+        public List<string> RoleApprovalTransitions { get; set; } = [];
 
         ///<summary>
         ///True if role grants permission to: Read data and generate reports.
@@ -2215,11 +2159,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class SensorBase
     {
-        public SensorBase()
-        {
-            Tags = new List<ApplyTagRequest>{};
-        }
-
         ///<summary>
         ///Location Unique ID
         ///</summary>
@@ -2284,7 +2223,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Tags to be assigned to the sensor with optional values
         ///</summary>
         [ApiMember(DataType="array", Description="Tags to be assigned to the sensor with optional values")]
-        public List<ApplyTagRequest> Tags { get; set; }
+        public List<ApplyTagRequest> Tags { get; set; } = [];
     }
 
     [Route("/settings/{Group}/{Key}", "DELETE")]
@@ -2777,12 +2716,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class TagRequestBase
     {
-        public TagRequestBase()
-        {
-            PickListValues = new List<string>{};
-            Applicability = new List<TagApplicability>{};
-        }
-
         ///<summary>
         ///Unique tag key
         ///</summary>
@@ -2799,13 +2732,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Set of pick-list values. Required if ValueType is PickList. Values must be distinct.
         ///</summary>
         [ApiMember(DataType="array", Description="Set of pick-list values. Required if ValueType is PickList. Values must be distinct.")]
-        public List<string> PickListValues { get; set; }
+        public List<string> PickListValues { get; set; } = [];
 
         ///<summary>
         ///If set, create tag with specified applicability, selected from one or more: AppliesToAttachments, AppliesToLocations, AppliesToLocationNotes, AppliesToReports and AppliesToSensorsGauges.  When omitted, the tag is applicable to all.
         ///</summary>
         [ApiMember(DataType="array", Description="If set, create tag with specified applicability, selected from one or more: AppliesToAttachments, AppliesToLocations, AppliesToLocationNotes, AppliesToReports and AppliesToSensorsGauges.  When omitted, the tag is applicable to all.")]
-        public List<TagApplicability> Applicability { get; set; }
+        public List<TagApplicability> Applicability { get; set; } = [];
     }
 
     public class DeleteNameTagBase
@@ -3151,11 +3084,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
     public class PostCalculatedDerivedTimeSeries
         : IReturn<TimeSeries>, IPostTimeSeriesRequest
     {
-        public PostCalculatedDerivedTimeSeries()
-        {
-            TimeSeriesUniqueIds = new List<Guid>{};
-        }
-
         ///<summary>
         ///Unique ID of the location for which a time series is to be created
         ///</summary>
@@ -3250,7 +3178,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///List of time series unique IDs of which the order translates to x1, x2… xN with x1 being the Master
         ///</summary>
         [ApiMember(DataType="array", Description="List of time series unique IDs of which the order translates to x1, x2… xN with x1 being the Master", IsRequired=true)]
-        public List<Guid> TimeSeriesUniqueIds { get; set; }
+        public List<Guid> TimeSeriesUniqueIds { get; set; } = [];
 
         ///<summary>
         ///Formula
@@ -4313,16 +4241,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class ApprovalLevelsResponse
     {
-        public ApprovalLevelsResponse()
-        {
-            Results = new List<ApprovalLevel>{};
-        }
-
         ///<summary>
         ///The list of approval levels
         ///</summary>
         [ApiMember(DataType="array", Description="The list of approval levels")]
-        public List<ApprovalLevel> Results { get; set; }
+        public List<ApprovalLevel> Results { get; set; } = [];
     }
 
     public class AttributeVariance
@@ -4348,11 +4271,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class Audit
     {
-        public Audit()
-        {
-            AttributeChanges = new List<AttributeVariance>{};
-        }
-
         ///<summary>
         ///The recorded audit event
         ///</summary>
@@ -4363,7 +4281,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Summary of attribute changes
         ///</summary>
         [ApiMember(DataType="array", Description="Summary of attribute changes")]
-        public List<AttributeVariance> AttributeChanges { get; set; }
+        public List<AttributeVariance> AttributeChanges { get; set; } = [];
     }
 
     public class AuditEvent
@@ -4401,16 +4319,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class AuditsResponse
     {
-        public AuditsResponse()
-        {
-            Results = new List<Audit>{};
-        }
-
         ///<summary>
         ///The list of audits
         ///</summary>
         [ApiMember(DataType="array", Description="The list of audits")]
-        public List<Audit> Results { get; set; }
+        public List<Audit> Results { get; set; } = [];
     }
 
     public class Channel
@@ -4430,30 +4343,20 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class ChannelsResponse
     {
-        public ChannelsResponse()
-        {
-            Results = new List<Channel>{};
-        }
-
         ///<summary>
         ///The list of channels
         ///</summary>
         [ApiMember(DataType="array", Description="The list of channels")]
-        public List<Channel> Results { get; set; }
+        public List<Channel> Results { get; set; } = [];
     }
 
     public class CodeTableResponse
     {
-        public CodeTableResponse()
-        {
-            Results = new List<CodeTable>{};
-        }
-
         ///<summary>
         ///The list of codes
         ///</summary>
         [ApiMember(DataType="array", Description="The list of codes")]
-        public List<CodeTable> Results { get; set; }
+        public List<CodeTable> Results { get; set; } = [];
     }
 
     public class ConfigurableDropDownListItem
@@ -4468,16 +4371,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class ConfigurableDropDownListItemsResponse
     {
-        public ConfigurableDropDownListItemsResponse()
-        {
-            Results = new List<ConfigurableDropDownListItem>{};
-        }
-
         ///<summary>
         ///The list of configurable drop-down list items
         ///</summary>
         [ApiMember(DataType="array", Description="The list of configurable drop-down list items")]
-        public List<ConfigurableDropDownListItem> Results { get; set; }
+        public List<ConfigurableDropDownListItem> Results { get; set; } = [];
     }
 
     public class DropDownList
@@ -4497,26 +4395,15 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class DropDownListResponse
     {
-        public DropDownListResponse()
-        {
-            Results = new List<DropDownList>{};
-        }
-
         ///<summary>
         ///The list of drop-down lists
         ///</summary>
         [ApiMember(DataType="array", Description="The list of drop-down lists")]
-        public List<DropDownList> Results { get; set; }
+        public List<DropDownList> Results { get; set; } = [];
     }
 
     public class ExtendedAttribute
     {
-        public ExtendedAttribute()
-        {
-            PickListValues = new List<string>{};
-            Applicability = new List<ExtendedAttributeApplicability>{};
-        }
-
         ///<summary>
         ///Unique ID of the extended attribute
         ///</summary>
@@ -4539,7 +4426,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Set of pick-list values if ValueType is PickList
         ///</summary>
         [ApiMember(DataType="array", Description="Set of pick-list values if ValueType is PickList")]
-        public List<string> PickListValues { get; set; }
+        public List<string> PickListValues { get; set; } = [];
 
         ///<summary>
         ///DEPRECATED: Use Applicability instead. True if extended attribute is applicable to Locations
@@ -4569,7 +4456,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Extended attribute applicability, one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits.
         ///</summary>
         [ApiMember(DataType="array", Description="Extended attribute applicability, one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits.")]
-        public List<ExtendedAttributeApplicability> Applicability { get; set; }
+        public List<ExtendedAttributeApplicability> Applicability { get; set; } = [];
 
         ///<summary>
         ///True if extended attribute is VisibleInDatasetList
@@ -4685,16 +4572,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class ExtendedAttributesResponse
     {
-        public ExtendedAttributesResponse()
-        {
-            Results = new List<ExtendedAttribute>{};
-        }
-
         ///<summary>
         ///The list of extended attributes
         ///</summary>
         [ApiMember(DataType="array", Description="The list of extended attributes")]
-        public List<ExtendedAttribute> Results { get; set; }
+        public List<ExtendedAttribute> Results { get; set; } = [];
     }
 
     public class ExtendedAttributeValue
@@ -4759,16 +4641,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class FieldDataPluginsResponse
     {
-        public FieldDataPluginsResponse()
-        {
-            Results = new List<FieldDataPlugin>{};
-        }
-
         ///<summary>
         ///The list of registered field data plug-ins
         ///</summary>
         [ApiMember(DataType="array", Description="The list of registered field data plug-ins")]
-        public List<FieldDataPlugin> Results { get; set; }
+        public List<FieldDataPlugin> Results { get; set; } = [];
     }
 
     public class FixedDropDownListItem
@@ -4800,16 +4677,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class FixedDropDownListItemsResponse
     {
-        public FixedDropDownListItemsResponse()
-        {
-            Results = new List<FixedDropDownListItem>{};
-        }
-
         ///<summary>
         ///The list of fixed drop-down list items
         ///</summary>
         [ApiMember(DataType="array", Description="The list of fixed drop-down list items")]
-        public List<FixedDropDownListItem> Results { get; set; }
+        public List<FixedDropDownListItem> Results { get; set; } = [];
     }
 
     public class Grade
@@ -4847,16 +4719,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class GradesResponse
     {
-        public GradesResponse()
-        {
-            Results = new List<Grade>{};
-        }
-
         ///<summary>
         ///The list of grades
         ///</summary>
         [ApiMember(DataType="array", Description="The list of grades")]
-        public List<Grade> Results { get; set; }
+        public List<Grade> Results { get; set; } = [];
     }
 
     public class InterpolationTypeEntry
@@ -4882,25 +4749,15 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class InterpolationTypesResponse
     {
-        public InterpolationTypesResponse()
-        {
-            Results = new List<InterpolationTypeEntry>{};
-        }
-
         ///<summary>
         ///The list of interpolation types
         ///</summary>
         [ApiMember(DataType="array", Description="The list of interpolation types")]
-        public List<InterpolationTypeEntry> Results { get; set; }
+        public List<InterpolationTypeEntry> Results { get; set; } = [];
     }
 
     public class Location
     {
-        public Location()
-        {
-            Tags = new List<AppliedTag>{};
-        }
-
         ///<summary>
         ///Unique ID of the location
         ///</summary>
@@ -4989,7 +4846,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Tags applied to this location
         ///</summary>
         [ApiMember(DataType="array", Description="Tags applied to this location")]
-        public List<AppliedTag> Tags { get; set; }
+        public List<AppliedTag> Tags { get; set; } = [];
 
         ///<summary>
         ///Extended attribute values
@@ -5067,16 +4924,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class LocationDatumResponse
     {
-        public LocationDatumResponse()
-        {
-            Results = new List<LocationDatumPeriod>{};
-        }
-
         ///<summary>
         ///The list of assumed local datums for the location
         ///</summary>
         [ApiMember(DataType="array", Description="The list of assumed local datums for the location")]
-        public List<LocationDatumPeriod> Results { get; set; }
+        public List<LocationDatumPeriod> Results { get; set; } = [];
     }
 
     public class LocationFolder
@@ -5120,16 +4972,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class LocationFoldersResponse
     {
-        public LocationFoldersResponse()
-        {
-            Results = new List<LocationFolder>{};
-        }
-
         ///<summary>
         ///The list of location folders
         ///</summary>
         [ApiMember(DataType="array", Description="The list of location folders")]
-        public List<LocationFolder> Results { get; set; }
+        public List<LocationFolder> Results { get; set; } = [];
     }
 
     public class LocationFolderUserRole
@@ -5179,11 +5026,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class LocationFolderUserRoles
     {
-        public LocationFolderUserRoles()
-        {
-            Roles = new List<LocationFolderUserRole>{};
-        }
-
         ///<summary>
         ///Unique Id of the location folder
         ///</summary>
@@ -5194,7 +5036,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///List of user roles applicable to this location folder
         ///</summary>
         [ApiMember(DataType="array", Description="List of user roles applicable to this location folder")]
-        public List<LocationFolderUserRole> Roles { get; set; }
+        public List<LocationFolderUserRole> Roles { get; set; } = [];
     }
 
     public class LocationType
@@ -5238,16 +5080,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class LocationTypesResponse
     {
-        public LocationTypesResponse()
-        {
-            Results = new List<LocationType>{};
-        }
-
         ///<summary>
         ///The list of location types
         ///</summary>
         [ApiMember(DataType="array", Description="The list of location types")]
-        public List<LocationType> Results { get; set; }
+        public List<LocationType> Results { get; set; } = [];
     }
 
     public class LocationUserRole
@@ -5262,11 +5099,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class LocationUserRoles
     {
-        public LocationUserRoles()
-        {
-            Roles = new List<LocationUserRole>{};
-        }
-
         ///<summary>
         ///Unique Id of the location
         ///</summary>
@@ -5277,7 +5109,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///List of user roles applicable to this location
         ///</summary>
         [ApiMember(DataType="array", Description="List of user roles applicable to this location")]
-        public List<LocationUserRole> Roles { get; set; }
+        public List<LocationUserRole> Roles { get; set; } = [];
     }
 
     public class MonitoringMethod
@@ -5333,16 +5165,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class MonitoringMethodsResponse
     {
-        public MonitoringMethodsResponse()
-        {
-            Results = new List<MonitoringMethod>{};
-        }
-
         ///<summary>
         ///The list of monitoring methods
         ///</summary>
         [ApiMember(DataType="array", Description="The list of monitoring methods")]
-        public List<MonitoringMethod> Results { get; set; }
+        public List<MonitoringMethod> Results { get; set; } = [];
     }
 
     public class NameTag
@@ -5362,44 +5189,29 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class NameTagsResponse
     {
-        public NameTagsResponse()
-        {
-            Results = new List<NameTag>{};
-        }
-
         ///<summary>
         ///The list of tags
         ///</summary>
         [ApiMember(DataType="array", Description="The list of tags")]
-        public List<NameTag> Results { get; set; }
+        public List<NameTag> Results { get; set; } = [];
     }
 
     public class OnePlatformLocationsResponse
     {
-        public OnePlatformLocationsResponse()
-        {
-            Results = new List<Location>{};
-        }
-
         ///<summary>
         ///The list of One Platform locations
         ///</summary>
         [ApiMember(DataType="array", Description="The list of One Platform locations")]
-        public List<Location> Results { get; set; }
+        public List<Location> Results { get; set; } = [];
     }
 
     public class OnePlatformTimeSeriesResponse
     {
-        public OnePlatformTimeSeriesResponse()
-        {
-            Results = new List<TimeSeries>{};
-        }
-
         ///<summary>
         ///The list of One Platform time-series
         ///</summary>
         [ApiMember(DataType="array", Description="The list of One Platform time-series")]
-        public List<TimeSeries> Results { get; set; }
+        public List<TimeSeries> Results { get; set; } = [];
     }
 
     public class OpenIdConnectRelyingPartyConfiguration
@@ -5540,16 +5352,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class ParametersResponse
     {
-        public ParametersResponse()
-        {
-            Results = new List<Parameter>{};
-        }
-
         ///<summary>
         ///The list of parameters
         ///</summary>
         [ApiMember(DataType="array", Description="The list of parameters")]
-        public List<Parameter> Results { get; set; }
+        public List<Parameter> Results { get; set; } = [];
     }
 
     public class PopulatedUnitGroup
@@ -5564,25 +5371,15 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class PopulatedUnitGroupsResponse
     {
-        public PopulatedUnitGroupsResponse()
-        {
-            Results = new List<PopulatedUnitGroup>{};
-        }
-
         ///<summary>
         ///The list of unit groups
         ///</summary>
         [ApiMember(DataType="array", Description="The list of unit groups")]
-        public List<PopulatedUnitGroup> Results { get; set; }
+        public List<PopulatedUnitGroup> Results { get; set; } = [];
     }
 
     public class QualifierGroupResponse
     {
-        public QualifierGroupResponse()
-        {
-            QualifierCodeList = new List<string>{};
-        }
-
         ///<summary>
         ///Unique ID of the qualifier group
         ///</summary>
@@ -5599,21 +5396,16 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Qualifier codes in group
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifier codes in group")]
-        public List<string> QualifierCodeList { get; set; }
+        public List<string> QualifierCodeList { get; set; } = [];
     }
 
     public class QualifierGroupsResponse
     {
-        public QualifierGroupsResponse()
-        {
-            Results = new List<QualifierGroupResponse>{};
-        }
-
         ///<summary>
         ///The list of qualifier groups
         ///</summary>
         [ApiMember(DataType="array", Description="The list of qualifier groups")]
-        public List<QualifierGroupResponse> Results { get; set; }
+        public List<QualifierGroupResponse> Results { get; set; } = [];
     }
 
     public class QualifierResponse
@@ -5634,16 +5426,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class QualifiersResponse
     {
-        public QualifiersResponse()
-        {
-            Results = new List<QualifierResponse>{};
-        }
-
         ///<summary>
         ///The list of qualifiers
         ///</summary>
         [ApiMember(DataType="array", Description="The list of qualifiers")]
-        public List<QualifierResponse> Results { get; set; }
+        public List<QualifierResponse> Results { get; set; } = [];
     }
 
     public class RecurringReport
@@ -5681,26 +5468,16 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class RecurringReportResponse
     {
-        public RecurringReportResponse()
-        {
-            Results = new List<RecurringReport>{};
-        }
-
         ///<summary>
         ///The list of recurring reports
         ///</summary>
         [ApiMember(DataType="array", Description="The list of recurring reports")]
-        public List<RecurringReport> Results { get; set; }
+        public List<RecurringReport> Results { get; set; } = [];
     }
 
     public class ReferencePoint
         : ReferencePointBase
     {
-        public ReferencePoint()
-        {
-            ReferencePointPeriods = new List<ReferencePointPeriod>{};
-        }
-
         ///<summary>
         ///Unique ID of the reference point
         ///</summary>
@@ -5711,7 +5488,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Periods of applicablity for this reference point
         ///</summary>
         [ApiMember(DataType="array", Description="Periods of applicablity for this reference point")]
-        public List<ReferencePointPeriod> ReferencePointPeriods { get; set; }
+        public List<ReferencePointPeriod> ReferencePointPeriods { get; set; } = [];
     }
 
     public class ReferencePointPeriod
@@ -5789,16 +5566,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class ReferencePointResponse
     {
-        public ReferencePointResponse()
-        {
-            Results = new List<ReferencePoint>{};
-        }
-
         ///<summary>
         ///The list of reference points
         ///</summary>
         [ApiMember(DataType="array", Description="The list of reference points")]
-        public List<ReferencePoint> Results { get; set; }
+        public List<ReferencePoint> Results { get; set; } = [];
     }
 
     public class ReportPlugin
@@ -5836,25 +5608,15 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class ReportPluginResponse
     {
-        public ReportPluginResponse()
-        {
-            Results = new List<ReportPlugin>{};
-        }
-
         ///<summary>
         ///The list of registered reports
         ///</summary>
         [ApiMember(DataType="array", Description="The list of registered reports")]
-        public List<ReportPlugin> Results { get; set; }
+        public List<ReportPlugin> Results { get; set; } = [];
     }
 
     public class Role
     {
-        public Role()
-        {
-            RoleApprovalTransitions = new List<RoleApprovalTransition>{};
-        }
-
         ///<summary>
         ///Unique Id of the role
         ///</summary>
@@ -5871,7 +5633,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///List of approval transitions this role grants permission to perform.
         ///</summary>
         [ApiMember(DataType="array", Description="List of approval transitions this role grants permission to perform.")]
-        public List<RoleApprovalTransition> RoleApprovalTransitions { get; set; }
+        public List<RoleApprovalTransition> RoleApprovalTransitions { get; set; } = [];
 
         ///<summary>
         ///True if role grants permission to: Read data and generate reports.
@@ -5961,25 +5723,15 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class RolesResponse
     {
-        public RolesResponse()
-        {
-            Results = new List<Role>{};
-        }
-
         ///<summary>
         ///The list of roles
         ///</summary>
         [ApiMember(DataType="array", Description="The list of roles")]
-        public List<Role> Results { get; set; }
+        public List<Role> Results { get; set; } = [];
     }
 
     public class Sensor
     {
-        public Sensor()
-        {
-            Tags = new List<AppliedTag>{};
-        }
-
         ///<summary>
         ///Unique ID
         ///</summary>
@@ -6056,7 +5808,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Tags
         ///</summary>
         [ApiMember(DataType="array", Description="Tags")]
-        public List<AppliedTag> Tags { get; set; }
+        public List<AppliedTag> Tags { get; set; } = [];
     }
 
     public class Setting
@@ -6100,16 +5852,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class SettingsResponse
     {
-        public SettingsResponse()
-        {
-            Results = new List<Setting>{};
-        }
-
         ///<summary>
         ///The list of settings
         ///</summary>
         [ApiMember(DataType="array", Description="The list of settings")]
-        public List<Setting> Results { get; set; }
+        public List<Setting> Results { get; set; } = [];
     }
 
     public class StandardDatum
@@ -6123,16 +5870,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class StandardDatumsResponse
     {
-        public StandardDatumsResponse()
-        {
-            Results = new List<StandardDatum>{};
-        }
-
         ///<summary>
         ///The list of standard datums
         ///</summary>
         [ApiMember(DataType="array", Description="The list of standard datums")]
-        public List<StandardDatum> Results { get; set; }
+        public List<StandardDatum> Results { get; set; } = [];
     }
 
     public class StandardReferenceDatum
@@ -6182,16 +5924,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class StandardReferenceDatumsResponse
     {
-        public StandardReferenceDatumsResponse()
-        {
-            Results = new List<StandardReferenceDatum>{};
-        }
-
         ///<summary>
         ///The list of Standard Reference Datums
         ///</summary>
         [ApiMember(DataType="array", Description="The list of Standard Reference Datums")]
-        public List<StandardReferenceDatum> Results { get; set; }
+        public List<StandardReferenceDatum> Results { get; set; } = [];
     }
 
     public class SubLocation
@@ -6217,26 +5954,15 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class SubLocationsResponse
     {
-        public SubLocationsResponse()
-        {
-            Results = new List<SubLocation>{};
-        }
-
         ///<summary>
         ///The list of sublocations
         ///</summary>
         [ApiMember(DataType="array", Description="The list of sublocations")]
-        public List<SubLocation> Results { get; set; }
+        public List<SubLocation> Results { get; set; } = [];
     }
 
     public class Tag
     {
-        public Tag()
-        {
-            PickListValues = new List<string>{};
-            Applicability = new List<TagApplicability>{};
-        }
-
         ///<summary>
         ///Unique ID of the tag
         ///</summary>
@@ -6259,7 +5985,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Set of pick-list values if ValueType is PickList
         ///</summary>
         [ApiMember(DataType="array", Description="Set of pick-list values if ValueType is PickList")]
-        public List<string> PickListValues { get; set; }
+        public List<string> PickListValues { get; set; } = [];
 
         ///<summary>
         ///DEPRECATED: Use Applicability instead. True if tag is applicable to Attachments
@@ -6295,21 +6021,16 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Tag applicability, any of: AppliesToAttachments, AppliesToLocations, AppliesToLocationNotes, AppliesToReports and AppliesToSensorsGauges.
         ///</summary>
         [ApiMember(DataType="array", Description="Tag applicability, any of: AppliesToAttachments, AppliesToLocations, AppliesToLocationNotes, AppliesToReports and AppliesToSensorsGauges.")]
-        public List<TagApplicability> Applicability { get; set; }
+        public List<TagApplicability> Applicability { get; set; } = [];
     }
 
     public class TagsResponse
     {
-        public TagsResponse()
-        {
-            Results = new List<Tag>{};
-        }
-
         ///<summary>
         ///The list of tags
         ///</summary>
         [ApiMember(DataType="array", Description="The list of tags")]
-        public List<Tag> Results { get; set; }
+        public List<Tag> Results { get; set; } = [];
     }
 
     public class ThresholdType
@@ -6347,16 +6068,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class ThresholdTypesResponse
     {
-        public ThresholdTypesResponse()
-        {
-            Results = new List<ThresholdType>{};
-        }
-
         ///<summary>
         ///The list of threshold types
         ///</summary>
         [ApiMember(DataType="array", Description="The list of threshold types")]
-        public List<ThresholdType> Results { get; set; }
+        public List<ThresholdType> Results { get; set; } = [];
     }
 
     public class TimeSeries
@@ -6478,16 +6194,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class TimeSeriesResponse
     {
-        public TimeSeriesResponse()
-        {
-            Results = new List<TimeSeries>{};
-        }
-
         ///<summary>
         ///The list of time series
         ///</summary>
         [ApiMember(DataType="array", Description="The list of time series")]
-        public List<TimeSeries> Results { get; set; }
+        public List<TimeSeries> Results { get; set; } = [];
     }
 
     public class Unit
@@ -6624,30 +6335,20 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class UnitGroupsResponse
     {
-        public UnitGroupsResponse()
-        {
-            Results = new List<UnitGroup>{};
-        }
-
         ///<summary>
         ///The list of unit groups
         ///</summary>
         [ApiMember(DataType="array", Description="The list of unit groups")]
-        public List<UnitGroup> Results { get; set; }
+        public List<UnitGroup> Results { get; set; } = [];
     }
 
     public class UnitsResponse
     {
-        public UnitsResponse()
-        {
-            Results = new List<Unit>{};
-        }
-
         ///<summary>
         ///The list of units
         ///</summary>
         [ApiMember(DataType="array", Description="The list of units")]
-        public List<Unit> Results { get; set; }
+        public List<Unit> Results { get; set; } = [];
     }
 
     public class User
@@ -6715,16 +6416,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 
     public class UsersResponse
     {
-        public UsersResponse()
-        {
-            Results = new List<User>{};
-        }
-
         ///<summary>
         ///The list of users
         ///</summary>
         [ApiMember(DataType="array", Description="The list of users")]
-        public List<User> Results { get; set; }
+        public List<User> Results { get; set; } = [];
     }
 
 }
@@ -6733,6 +6429,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("25.4.67.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("26.1.8.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2026-01-29 11:34:46
+Date: 2026-01-29 12:26:27
 Version: 10.04
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: https://aqwp-opendata.aquariusdev.net/AQUARIUS/Provisioning/v1
@@ -17,7 +17,7 @@ AddNullableAnnotations: False
 //AddGeneratedCodeAttributes: False
 //AddResponseStatus: False
 //AddImplicitVersion: 
-InitializeCollections: True
+InitializeCollections: False
 ExportValueTypes: True
 //IncludeTypes: 
 //ExcludeTypes: 
@@ -566,13 +566,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Set of pick-list values. Required if ValueType is PickList. Values must be distinct.
         ///</summary>
         [ApiMember(DataType="array", Description="Set of pick-list values. Required if ValueType is PickList. Values must be distinct.")]
-        public List<string> PickListValues { get; set; } = [];
+        public List<string> PickListValues { get; set; }
 
         ///<summary>
         ///Extended attribute applicability, select one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits.
         ///</summary>
         [ApiMember(DataType="array", Description="Extended attribute applicability, select one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits.")]
-        public List<ExtendedAttributeApplicability> Applicability { get; set; } = [];
+        public List<ExtendedAttributeApplicability> Applicability { get; set; }
 
         ///<summary>
         ///Flag which defines if extended attribute is VisibleInDatasetList
@@ -618,7 +618,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///If set, return only extended attribute definitions with specified applicability, select from: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits
         ///</summary>
         [ApiMember(AllowMultiple=true, DataType="array", Description="If set, return only extended attribute definitions with specified applicability, select from: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits")]
-        public List<ExtendedAttributeApplicability> Applicability { get; set; } = [];
+        public List<ExtendedAttributeApplicability> Applicability { get; set; }
     }
 
     [Route("/extendedattributes", "POST")]
@@ -1051,7 +1051,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Unique IDs of Extended Attribute definitions associated with this location type
         ///</summary>
         [ApiMember(DataType="array", Description="Unique IDs of Extended Attribute definitions associated with this location type")]
-        public List<Guid> ExtendedAttributeDefinitionIds { get; set; } = [];
+        public List<Guid> ExtendedAttributeDefinitionIds { get; set; }
     }
 
     [Route("/locations", "POST")]
@@ -1162,13 +1162,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///DEPRECATED: use Tags instead
         ///</summary>
         [ApiMember(DataType="array", Description="DEPRECATED: use Tags instead")]
-        public List<Guid> TagUniqueIds { get; set; } = [];
+        public List<Guid> TagUniqueIds { get; set; }
 
         ///<summary>
         ///Tags to be assigned to the location with optional values; an empty list means the location will have no tags assigned to it.
         ///</summary>
         [ApiMember(DataType="array", Description="Tags to be assigned to the location with optional values; an empty list means the location will have no tags assigned to it.")]
-        public List<ApplyTagRequest> Tags { get; set; } = [];
+        public List<ApplyTagRequest> Tags { get; set; }
     }
 
     [Route("/locationtypes/{UniqueId}", "PUT")]
@@ -1674,7 +1674,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Qualifier group identifiers - if no groups are specified, the qualifier will be assigned to the 'Default' qualifier group
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifier group identifiers - if no groups are specified, the qualifier will be assigned to the 'Default' qualifier group")]
-        public List<string> GroupIdentifiers { get; set; } = [];
+        public List<string> GroupIdentifiers { get; set; }
     }
 
     [Route("/grades/{GradeCode}", "DELETE")]
@@ -1980,7 +1980,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///List of approval transitions this role grants permission to perform.
         ///</summary>
         [ApiMember(DataType="array", Description="List of approval transitions this role grants permission to perform.")]
-        public List<RoleApprovalTransition> RoleApprovalTransitions { get; set; } = [];
+        public List<RoleApprovalTransition> RoleApprovalTransitions { get; set; }
 
         ///<summary>
         ///True if role grants permission to: Read data and generate reports.
@@ -2055,7 +2055,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///List of approval transitions this role grants permission to perform. Format: '&lt;FromLevel&gt; &lt;ToLevel&gt;'. Example: '900 1200'
         ///</summary>
         [ApiMember(DataType="array", Description="List of approval transitions this role grants permission to perform. Format: '&lt;FromLevel&gt; &lt;ToLevel&gt;'. Example: '900 1200'")]
-        public List<string> RoleApprovalTransitions { get; set; } = [];
+        public List<string> RoleApprovalTransitions { get; set; }
 
         ///<summary>
         ///True if role grants permission to: Read data and generate reports.
@@ -2223,7 +2223,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Tags to be assigned to the sensor with optional values
         ///</summary>
         [ApiMember(DataType="array", Description="Tags to be assigned to the sensor with optional values")]
-        public List<ApplyTagRequest> Tags { get; set; } = [];
+        public List<ApplyTagRequest> Tags { get; set; }
     }
 
     [Route("/settings/{Group}/{Key}", "DELETE")]
@@ -2732,13 +2732,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Set of pick-list values. Required if ValueType is PickList. Values must be distinct.
         ///</summary>
         [ApiMember(DataType="array", Description="Set of pick-list values. Required if ValueType is PickList. Values must be distinct.")]
-        public List<string> PickListValues { get; set; } = [];
+        public List<string> PickListValues { get; set; }
 
         ///<summary>
         ///If set, create tag with specified applicability, selected from one or more: AppliesToAttachments, AppliesToLocations, AppliesToLocationNotes, AppliesToReports and AppliesToSensorsGauges.  When omitted, the tag is applicable to all.
         ///</summary>
         [ApiMember(DataType="array", Description="If set, create tag with specified applicability, selected from one or more: AppliesToAttachments, AppliesToLocations, AppliesToLocationNotes, AppliesToReports and AppliesToSensorsGauges.  When omitted, the tag is applicable to all.")]
-        public List<TagApplicability> Applicability { get; set; } = [];
+        public List<TagApplicability> Applicability { get; set; }
     }
 
     public class DeleteNameTagBase
@@ -4245,7 +4245,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of approval levels
         ///</summary>
         [ApiMember(DataType="array", Description="The list of approval levels")]
-        public List<ApprovalLevel> Results { get; set; } = [];
+        public List<ApprovalLevel> Results { get; set; }
     }
 
     public class AttributeVariance
@@ -4281,7 +4281,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Summary of attribute changes
         ///</summary>
         [ApiMember(DataType="array", Description="Summary of attribute changes")]
-        public List<AttributeVariance> AttributeChanges { get; set; } = [];
+        public List<AttributeVariance> AttributeChanges { get; set; }
     }
 
     public class AuditEvent
@@ -4323,7 +4323,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of audits
         ///</summary>
         [ApiMember(DataType="array", Description="The list of audits")]
-        public List<Audit> Results { get; set; } = [];
+        public List<Audit> Results { get; set; }
     }
 
     public class Channel
@@ -4347,7 +4347,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of channels
         ///</summary>
         [ApiMember(DataType="array", Description="The list of channels")]
-        public List<Channel> Results { get; set; } = [];
+        public List<Channel> Results { get; set; }
     }
 
     public class CodeTableResponse
@@ -4356,7 +4356,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of codes
         ///</summary>
         [ApiMember(DataType="array", Description="The list of codes")]
-        public List<CodeTable> Results { get; set; } = [];
+        public List<CodeTable> Results { get; set; }
     }
 
     public class ConfigurableDropDownListItem
@@ -4375,7 +4375,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of configurable drop-down list items
         ///</summary>
         [ApiMember(DataType="array", Description="The list of configurable drop-down list items")]
-        public List<ConfigurableDropDownListItem> Results { get; set; } = [];
+        public List<ConfigurableDropDownListItem> Results { get; set; }
     }
 
     public class DropDownList
@@ -4399,7 +4399,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of drop-down lists
         ///</summary>
         [ApiMember(DataType="array", Description="The list of drop-down lists")]
-        public List<DropDownList> Results { get; set; } = [];
+        public List<DropDownList> Results { get; set; }
     }
 
     public class ExtendedAttribute
@@ -4426,7 +4426,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Set of pick-list values if ValueType is PickList
         ///</summary>
         [ApiMember(DataType="array", Description="Set of pick-list values if ValueType is PickList")]
-        public List<string> PickListValues { get; set; } = [];
+        public List<string> PickListValues { get; set; }
 
         ///<summary>
         ///DEPRECATED: Use Applicability instead. True if extended attribute is applicable to Locations
@@ -4456,7 +4456,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Extended attribute applicability, one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits.
         ///</summary>
         [ApiMember(DataType="array", Description="Extended attribute applicability, one of: AppliesToLocations, AppliesToLocationTypes, AppliesToTimeSeries, AppliesToVisits.")]
-        public List<ExtendedAttributeApplicability> Applicability { get; set; } = [];
+        public List<ExtendedAttributeApplicability> Applicability { get; set; }
 
         ///<summary>
         ///True if extended attribute is VisibleInDatasetList
@@ -4576,7 +4576,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of extended attributes
         ///</summary>
         [ApiMember(DataType="array", Description="The list of extended attributes")]
-        public List<ExtendedAttribute> Results { get; set; } = [];
+        public List<ExtendedAttribute> Results { get; set; }
     }
 
     public class ExtendedAttributeValue
@@ -4645,7 +4645,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of registered field data plug-ins
         ///</summary>
         [ApiMember(DataType="array", Description="The list of registered field data plug-ins")]
-        public List<FieldDataPlugin> Results { get; set; } = [];
+        public List<FieldDataPlugin> Results { get; set; }
     }
 
     public class FixedDropDownListItem
@@ -4681,7 +4681,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of fixed drop-down list items
         ///</summary>
         [ApiMember(DataType="array", Description="The list of fixed drop-down list items")]
-        public List<FixedDropDownListItem> Results { get; set; } = [];
+        public List<FixedDropDownListItem> Results { get; set; }
     }
 
     public class Grade
@@ -4723,7 +4723,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of grades
         ///</summary>
         [ApiMember(DataType="array", Description="The list of grades")]
-        public List<Grade> Results { get; set; } = [];
+        public List<Grade> Results { get; set; }
     }
 
     public class InterpolationTypeEntry
@@ -4753,7 +4753,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of interpolation types
         ///</summary>
         [ApiMember(DataType="array", Description="The list of interpolation types")]
-        public List<InterpolationTypeEntry> Results { get; set; } = [];
+        public List<InterpolationTypeEntry> Results { get; set; }
     }
 
     public class Location
@@ -4846,7 +4846,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Tags applied to this location
         ///</summary>
         [ApiMember(DataType="array", Description="Tags applied to this location")]
-        public List<AppliedTag> Tags { get; set; } = [];
+        public List<AppliedTag> Tags { get; set; }
 
         ///<summary>
         ///Extended attribute values
@@ -4928,7 +4928,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of assumed local datums for the location
         ///</summary>
         [ApiMember(DataType="array", Description="The list of assumed local datums for the location")]
-        public List<LocationDatumPeriod> Results { get; set; } = [];
+        public List<LocationDatumPeriod> Results { get; set; }
     }
 
     public class LocationFolder
@@ -4976,7 +4976,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of location folders
         ///</summary>
         [ApiMember(DataType="array", Description="The list of location folders")]
-        public List<LocationFolder> Results { get; set; } = [];
+        public List<LocationFolder> Results { get; set; }
     }
 
     public class LocationFolderUserRole
@@ -5036,7 +5036,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///List of user roles applicable to this location folder
         ///</summary>
         [ApiMember(DataType="array", Description="List of user roles applicable to this location folder")]
-        public List<LocationFolderUserRole> Roles { get; set; } = [];
+        public List<LocationFolderUserRole> Roles { get; set; }
     }
 
     public class LocationType
@@ -5084,7 +5084,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of location types
         ///</summary>
         [ApiMember(DataType="array", Description="The list of location types")]
-        public List<LocationType> Results { get; set; } = [];
+        public List<LocationType> Results { get; set; }
     }
 
     public class LocationUserRole
@@ -5109,7 +5109,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///List of user roles applicable to this location
         ///</summary>
         [ApiMember(DataType="array", Description="List of user roles applicable to this location")]
-        public List<LocationUserRole> Roles { get; set; } = [];
+        public List<LocationUserRole> Roles { get; set; }
     }
 
     public class MonitoringMethod
@@ -5169,7 +5169,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of monitoring methods
         ///</summary>
         [ApiMember(DataType="array", Description="The list of monitoring methods")]
-        public List<MonitoringMethod> Results { get; set; } = [];
+        public List<MonitoringMethod> Results { get; set; }
     }
 
     public class NameTag
@@ -5193,7 +5193,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of tags
         ///</summary>
         [ApiMember(DataType="array", Description="The list of tags")]
-        public List<NameTag> Results { get; set; } = [];
+        public List<NameTag> Results { get; set; }
     }
 
     public class OnePlatformLocationsResponse
@@ -5202,7 +5202,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of One Platform locations
         ///</summary>
         [ApiMember(DataType="array", Description="The list of One Platform locations")]
-        public List<Location> Results { get; set; } = [];
+        public List<Location> Results { get; set; }
     }
 
     public class OnePlatformTimeSeriesResponse
@@ -5211,7 +5211,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of One Platform time-series
         ///</summary>
         [ApiMember(DataType="array", Description="The list of One Platform time-series")]
-        public List<TimeSeries> Results { get; set; } = [];
+        public List<TimeSeries> Results { get; set; }
     }
 
     public class OpenIdConnectRelyingPartyConfiguration
@@ -5356,7 +5356,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of parameters
         ///</summary>
         [ApiMember(DataType="array", Description="The list of parameters")]
-        public List<Parameter> Results { get; set; } = [];
+        public List<Parameter> Results { get; set; }
     }
 
     public class PopulatedUnitGroup
@@ -5375,7 +5375,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of unit groups
         ///</summary>
         [ApiMember(DataType="array", Description="The list of unit groups")]
-        public List<PopulatedUnitGroup> Results { get; set; } = [];
+        public List<PopulatedUnitGroup> Results { get; set; }
     }
 
     public class QualifierGroupResponse
@@ -5396,7 +5396,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Qualifier codes in group
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifier codes in group")]
-        public List<string> QualifierCodeList { get; set; } = [];
+        public List<string> QualifierCodeList { get; set; }
     }
 
     public class QualifierGroupsResponse
@@ -5405,7 +5405,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of qualifier groups
         ///</summary>
         [ApiMember(DataType="array", Description="The list of qualifier groups")]
-        public List<QualifierGroupResponse> Results { get; set; } = [];
+        public List<QualifierGroupResponse> Results { get; set; }
     }
 
     public class QualifierResponse
@@ -5430,7 +5430,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of qualifiers
         ///</summary>
         [ApiMember(DataType="array", Description="The list of qualifiers")]
-        public List<QualifierResponse> Results { get; set; } = [];
+        public List<QualifierResponse> Results { get; set; }
     }
 
     public class RecurringReport
@@ -5472,7 +5472,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of recurring reports
         ///</summary>
         [ApiMember(DataType="array", Description="The list of recurring reports")]
-        public List<RecurringReport> Results { get; set; } = [];
+        public List<RecurringReport> Results { get; set; }
     }
 
     public class ReferencePoint
@@ -5488,7 +5488,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Periods of applicablity for this reference point
         ///</summary>
         [ApiMember(DataType="array", Description="Periods of applicablity for this reference point")]
-        public List<ReferencePointPeriod> ReferencePointPeriods { get; set; } = [];
+        public List<ReferencePointPeriod> ReferencePointPeriods { get; set; }
     }
 
     public class ReferencePointPeriod
@@ -5570,7 +5570,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of reference points
         ///</summary>
         [ApiMember(DataType="array", Description="The list of reference points")]
-        public List<ReferencePoint> Results { get; set; } = [];
+        public List<ReferencePoint> Results { get; set; }
     }
 
     public class ReportPlugin
@@ -5612,7 +5612,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of registered reports
         ///</summary>
         [ApiMember(DataType="array", Description="The list of registered reports")]
-        public List<ReportPlugin> Results { get; set; } = [];
+        public List<ReportPlugin> Results { get; set; }
     }
 
     public class Role
@@ -5633,7 +5633,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///List of approval transitions this role grants permission to perform.
         ///</summary>
         [ApiMember(DataType="array", Description="List of approval transitions this role grants permission to perform.")]
-        public List<RoleApprovalTransition> RoleApprovalTransitions { get; set; } = [];
+        public List<RoleApprovalTransition> RoleApprovalTransitions { get; set; }
 
         ///<summary>
         ///True if role grants permission to: Read data and generate reports.
@@ -5727,7 +5727,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of roles
         ///</summary>
         [ApiMember(DataType="array", Description="The list of roles")]
-        public List<Role> Results { get; set; } = [];
+        public List<Role> Results { get; set; }
     }
 
     public class Sensor
@@ -5808,7 +5808,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Tags
         ///</summary>
         [ApiMember(DataType="array", Description="Tags")]
-        public List<AppliedTag> Tags { get; set; } = [];
+        public List<AppliedTag> Tags { get; set; }
     }
 
     public class Setting
@@ -5856,7 +5856,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of settings
         ///</summary>
         [ApiMember(DataType="array", Description="The list of settings")]
-        public List<Setting> Results { get; set; } = [];
+        public List<Setting> Results { get; set; }
     }
 
     public class StandardDatum
@@ -5874,7 +5874,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of standard datums
         ///</summary>
         [ApiMember(DataType="array", Description="The list of standard datums")]
-        public List<StandardDatum> Results { get; set; } = [];
+        public List<StandardDatum> Results { get; set; }
     }
 
     public class StandardReferenceDatum
@@ -5928,7 +5928,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of Standard Reference Datums
         ///</summary>
         [ApiMember(DataType="array", Description="The list of Standard Reference Datums")]
-        public List<StandardReferenceDatum> Results { get; set; } = [];
+        public List<StandardReferenceDatum> Results { get; set; }
     }
 
     public class SubLocation
@@ -5958,7 +5958,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of sublocations
         ///</summary>
         [ApiMember(DataType="array", Description="The list of sublocations")]
-        public List<SubLocation> Results { get; set; } = [];
+        public List<SubLocation> Results { get; set; }
     }
 
     public class Tag
@@ -5985,7 +5985,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Set of pick-list values if ValueType is PickList
         ///</summary>
         [ApiMember(DataType="array", Description="Set of pick-list values if ValueType is PickList")]
-        public List<string> PickListValues { get; set; } = [];
+        public List<string> PickListValues { get; set; }
 
         ///<summary>
         ///DEPRECATED: Use Applicability instead. True if tag is applicable to Attachments
@@ -6021,7 +6021,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Tag applicability, any of: AppliesToAttachments, AppliesToLocations, AppliesToLocationNotes, AppliesToReports and AppliesToSensorsGauges.
         ///</summary>
         [ApiMember(DataType="array", Description="Tag applicability, any of: AppliesToAttachments, AppliesToLocations, AppliesToLocationNotes, AppliesToReports and AppliesToSensorsGauges.")]
-        public List<TagApplicability> Applicability { get; set; } = [];
+        public List<TagApplicability> Applicability { get; set; }
     }
 
     public class TagsResponse
@@ -6030,7 +6030,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of tags
         ///</summary>
         [ApiMember(DataType="array", Description="The list of tags")]
-        public List<Tag> Results { get; set; } = [];
+        public List<Tag> Results { get; set; }
     }
 
     public class ThresholdType
@@ -6072,7 +6072,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of threshold types
         ///</summary>
         [ApiMember(DataType="array", Description="The list of threshold types")]
-        public List<ThresholdType> Results { get; set; } = [];
+        public List<ThresholdType> Results { get; set; }
     }
 
     public class TimeSeries
@@ -6198,7 +6198,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of time series
         ///</summary>
         [ApiMember(DataType="array", Description="The list of time series")]
-        public List<TimeSeries> Results { get; set; } = [];
+        public List<TimeSeries> Results { get; set; }
     }
 
     public class Unit
@@ -6339,7 +6339,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of unit groups
         ///</summary>
         [ApiMember(DataType="array", Description="The list of unit groups")]
-        public List<UnitGroup> Results { get; set; } = [];
+        public List<UnitGroup> Results { get; set; }
     }
 
     public class UnitsResponse
@@ -6348,7 +6348,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of units
         ///</summary>
         [ApiMember(DataType="array", Description="The list of units")]
-        public List<Unit> Results { get; set; } = [];
+        public List<Unit> Results { get; set; }
     }
 
     public class User
@@ -6420,7 +6420,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///The list of users
         ///</summary>
         [ApiMember(DataType="array", Description="The list of users")]
-        public List<User> Results { get; set; } = [];
+        public List<User> Results { get; set; }
     }
 
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2026-01-29 12:26:27
+Date: 2026-01-29 13:26:38
 Version: 10.04
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: https://aqwp-opendata.aquariusdev.net/AQUARIUS/Provisioning/v1
@@ -1090,7 +1090,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Periods of applicablity for this reference point. Must have at least one period
         ///</summary>
         [ApiMember(DataType="array", Description="Periods of applicablity for this reference point. Must have at least one period", IsRequired=true)]
-        public List<PostReferencePointPeriod> ReferencePointPeriods { get; set; } = [];
+        public List<PostReferencePointPeriod> ReferencePointPeriods { get; set; }
     }
 
     public class PostReferencePointPeriod
@@ -1207,7 +1207,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Periods of applicablity for this reference point. Must have at least one period
         ///</summary>
         [ApiMember(DataType="array", Description="Periods of applicablity for this reference point. Must have at least one period", IsRequired=true)]
-        public List<PutReferencePointPeriod> ReferencePointPeriods { get; set; } = [];
+        public List<PutReferencePointPeriod> ReferencePointPeriods { get; set; }
     }
 
     public class PutReferencePointPeriod
@@ -1624,7 +1624,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Qualifier group identifiers - if no groups (an empty list is []) are specified, the qualifier will be removed from all groups and re-assigned to the 'Default' qualifier group
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifier group identifiers - if no groups (an empty list is []) are specified, the qualifier will be removed from all groups and re-assigned to the 'Default' qualifier group", IsRequired=true)]
-        public List<string> GroupIdentifiers { get; set; } = [];
+        public List<string> GroupIdentifiers { get; set; }
     }
 
     [Route("/qualifiergroups/{UniqueId}", "PUT")]
@@ -1647,7 +1647,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///Qualifier codes contained in this group 
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifier codes contained in this group ", IsRequired=true)]
-        public List<string> QualifierCodeList { get; set; } = [];
+        public List<string> QualifierCodeList { get; set; }
     }
 
     public class QualifierBase
@@ -3178,7 +3178,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
         ///List of time series unique IDs of which the order translates to x1, x2… xN with x1 being the Master
         ///</summary>
         [ApiMember(DataType="array", Description="List of time series unique IDs of which the order translates to x1, x2… xN with x1 being the Master", IsRequired=true)]
-        public List<Guid> TimeSeriesUniqueIds { get; set; } = [];
+        public List<Guid> TimeSeriesUniqueIds { get; set; }
 
         ///<summary>
         ///Formula

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
@@ -1,14 +1,15 @@
 /* Options:
-Date: 2026-01-08 01:51:02
-Version: 6.02
+Date: 2026-01-29 11:34:42
+Version: 10.04
 Tip: To override a DTO option, remove "//" prefix before updating
-BaseUrl: https://develop-1.dev.aquariusdev.net/AQUARIUS/Publish/v2
+BaseUrl: https://aqwp-opendata.aquariusdev.net/AQUARIUS/Publish/v2
 
 GlobalNamespace: Aquarius.TimeSeries.Client.ServiceModels.Publish
 MakePartial: False
 MakeVirtual: False
 //MakeInternal: False
 //MakeDataContractsExtensible: False
+AddNullableAnnotations: False
 //AddReturnMarker: True
 //AddDescriptionAsComments: True
 //AddDataContractAttributes: False
@@ -16,7 +17,7 @@ MakeVirtual: False
 //AddGeneratedCodeAttributes: False
 //AddResponseStatus: False
 //AddImplicitVersion: 
-//InitializeCollections: True
+InitializeCollections: True
 ExportValueTypes: True
 //IncludeTypes: 
 //ExcludeTypes: 
@@ -317,15 +318,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class ExpandedRatingCurve
     {
-        public ExpandedRatingCurve()
-        {
-            PeriodsOfApplicability = new List<PeriodOfApplicability>{};
-            Shifts = new List<RatingShift>{};
-            Offsets = new List<OffsetPoint>{};
-            BaseRatingTable = new List<RatingPoint>{};
-            AdjustedRatingTable = new List<RatingPoint>{};
-        }
-
         ///<summary>
         ///Id
         ///</summary>
@@ -360,19 +352,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Periods of applicability
         ///</summary>
         [ApiMember(DataType="array", Description="Periods of applicability")]
-        public List<PeriodOfApplicability> PeriodsOfApplicability { get; set; }
+        public List<PeriodOfApplicability> PeriodsOfApplicability { get; set; } = [];
 
         ///<summary>
         ///Shifts
         ///</summary>
         [ApiMember(DataType="array", Description="Shifts")]
-        public List<RatingShift> Shifts { get; set; }
+        public List<RatingShift> Shifts { get; set; } = [];
 
         ///<summary>
         ///Offsets
         ///</summary>
         [ApiMember(DataType="array", Description="Offsets")]
-        public List<OffsetPoint> Offsets { get; set; }
+        public List<OffsetPoint> Offsets { get; set; } = [];
 
         ///<summary>
         ///Is blended
@@ -384,13 +376,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Base rating table
         ///</summary>
         [ApiMember(DataType="array", Description="Base rating table")]
-        public List<RatingPoint> BaseRatingTable { get; set; }
+        public List<RatingPoint> BaseRatingTable { get; set; } = [];
 
         ///<summary>
         ///Adjusted rating table
         ///</summary>
         [ApiMember(DataType="array", Description="Adjusted rating table")]
-        public List<RatingPoint> AdjustedRatingTable { get; set; }
+        public List<RatingPoint> AdjustedRatingTable { get; set; } = [];
     }
 
     public class ExtendedAttribute
@@ -610,11 +602,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class LocationDatum
     {
-        public LocationDatum()
-        {
-            DatumPeriods = new List<LocationDatumPeriod>{};
-        }
-
         ///<summary>
         ///Reference standard
         ///</summary>
@@ -625,7 +612,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Datum periods
         ///</summary>
         [ApiMember(DataType="array", Description="Datum periods")]
-        public List<LocationDatumPeriod> DatumPeriods { get; set; }
+        public List<LocationDatumPeriod> DatumPeriods { get; set; } = [];
     }
 
     public class LocationDatumPeriod
@@ -693,12 +680,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class LocationDescription
     {
-        public LocationDescription()
-        {
-            SecondaryFolders = new List<string>{};
-            Tags = new List<TagMetadata>{};
-        }
-
         ///<summary>
         ///Name
         ///</summary>
@@ -733,7 +714,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Secondary folders
         ///</summary>
         [ApiMember(DataType="array", Description="Secondary folders")]
-        public List<string> SecondaryFolders { get; set; }
+        public List<string> SecondaryFolders { get; set; } = [];
 
         ///<summary>
         ///Last modified
@@ -751,7 +732,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Tags
         ///</summary>
         [ApiMember(DataType="array", Description="Tags")]
-        public List<TagMetadata> Tags { get; set; }
+        public List<TagMetadata> Tags { get; set; } = [];
 
         ///<summary>
         ///Utc offset
@@ -762,11 +743,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class LocationMonitoringMethod
     {
-        public LocationMonitoringMethod()
-        {
-            Tags = new List<TagMetadata>{};
-        }
-
         ///<summary>
         ///UniqueId
         ///</summary>
@@ -867,16 +843,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Tags
         ///</summary>
         [ApiMember(DataType="array", Description="Tags")]
-        public List<TagMetadata> Tags { get; set; }
+        public List<TagMetadata> Tags { get; set; } = [];
     }
 
     public class LocationNote
     {
-        public LocationNote()
-        {
-            Tags = new List<TagMetadata>{};
-        }
-
         ///<summary>
         ///UniqueId
         ///</summary>
@@ -923,7 +894,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Location note tags
         ///</summary>
         [ApiMember(DataType="array", Description="Location note tags")]
-        public List<TagMetadata> Tags { get; set; }
+        public List<TagMetadata> Tags { get; set; } = [];
 
         ///<summary>
         ///User who last modified this note
@@ -940,11 +911,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class LocationReferenceStandard
     {
-        public LocationReferenceStandard()
-        {
-            ReferenceStandardOffsets = new List<ReferenceStandardOffset>{};
-        }
-
         ///<summary>
         ///Reference standard
         ///</summary>
@@ -955,7 +921,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Reference standard offsets
         ///</summary>
         [ApiMember(DataType="array", Description="Reference standard offsets")]
-        public List<ReferenceStandardOffset> ReferenceStandardOffsets { get; set; }
+        public List<ReferenceStandardOffset> ReferenceStandardOffsets { get; set; } = [];
 
         ///<summary>
         ///Comments
@@ -1298,12 +1264,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class Processor
     {
-        public Processor()
-        {
-            InputTimeSeriesUniqueIds = new List<Guid>{};
-            Settings = new Dictionary<string, string>{};
-        }
-
         ///<summary>
         ///Processor type
         ///</summary>
@@ -1314,7 +1274,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Input time series unique ids
         ///</summary>
         [ApiMember(DataType="array", Description="Input time series unique ids")]
-        public List<Guid> InputTimeSeriesUniqueIds { get; set; }
+        public List<Guid> InputTimeSeriesUniqueIds { get; set; } = [];
 
         ///<summary>
         ///Output time series unique id
@@ -1340,7 +1300,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         [ApiMember(Description="Input rating model identifier")]
         public string InputRatingModelIdentifier { get; set; }
 
-        public Dictionary<string, string> Settings { get; set; }
+        public Dictionary<string, string> Settings { get; set; } = new();
     }
 
     public class Qualifier
@@ -1416,15 +1376,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class RatingCurve
     {
-        public RatingCurve()
-        {
-            PeriodsOfApplicability = new List<PeriodOfApplicability>{};
-            Shifts = new List<RatingShift>{};
-            BaseRatingTable = new List<RatingPoint>{};
-            Offsets = new List<OffsetPoint>{};
-            GradeRanges = new List<RatingGrade>{};
-        }
-
         ///<summary>
         ///Id
         ///</summary>
@@ -1465,31 +1416,31 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Periods of applicability
         ///</summary>
         [ApiMember(DataType="array", Description="Periods of applicability")]
-        public List<PeriodOfApplicability> PeriodsOfApplicability { get; set; }
+        public List<PeriodOfApplicability> PeriodsOfApplicability { get; set; } = [];
 
         ///<summary>
         ///Shifts
         ///</summary>
         [ApiMember(DataType="array", Description="Shifts")]
-        public List<RatingShift> Shifts { get; set; }
+        public List<RatingShift> Shifts { get; set; } = [];
 
         ///<summary>
         ///Base rating table
         ///</summary>
         [ApiMember(DataType="array", Description="Base rating table")]
-        public List<RatingPoint> BaseRatingTable { get; set; }
+        public List<RatingPoint> BaseRatingTable { get; set; } = [];
 
         ///<summary>
         ///Offsets
         ///</summary>
         [ApiMember(DataType="array", Description="Offsets")]
-        public List<OffsetPoint> Offsets { get; set; }
+        public List<OffsetPoint> Offsets { get; set; } = [];
 
         ///<summary>
         ///Grade Ranges
         ///</summary>
         [ApiMember(DataType="array", Description="Grade Ranges")]
-        public List<RatingGrade> GradeRanges { get; set; }
+        public List<RatingGrade> GradeRanges { get; set; } = [];
     }
 
     public enum RatingCurveType
@@ -1609,11 +1560,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class RatingShift
     {
-        public RatingShift()
-        {
-            ShiftPoints = new List<RatingShiftPoint>{};
-        }
-
         ///<summary>
         ///Period of applicability
         ///</summary>
@@ -1624,7 +1570,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Shift points
         ///</summary>
         [ApiMember(DataType="array", Description="Shift points")]
-        public List<RatingShiftPoint> ShiftPoints { get; set; }
+        public List<RatingShiftPoint> ShiftPoints { get; set; } = [];
     }
 
     public class RatingShiftPoint
@@ -1644,11 +1590,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class ReferencePoint
     {
-        public ReferencePoint()
-        {
-            ReferencePointPeriods = new List<ReferencePointPeriod>{};
-        }
-
         ///<summary>
         ///Unique ID of the reference point
         ///</summary>
@@ -1701,7 +1642,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Periods of applicability
         ///</summary>
         [ApiMember(DataType="array", Description="Periods of applicability")]
-        public List<ReferencePointPeriod> ReferencePointPeriods { get; set; }
+        public List<ReferencePointPeriod> ReferencePointPeriods { get; set; } = [];
     }
 
     public class ReferencePointPeriod
@@ -1808,12 +1749,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class Report
     {
-        public Report()
-        {
-            SourceTimeSeriesUniqueIds = new List<Guid>{};
-            Tags = new List<TagMetadata>{};
-        }
-
         ///<summary>
         ///ReportUniqueId
         ///</summary>
@@ -1860,7 +1795,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Source time-series unique IDs
         ///</summary>
         [ApiMember(DataType="array", Description="Source time-series unique IDs")]
-        public List<Guid> SourceTimeSeriesUniqueIds { get; set; }
+        public List<Guid> SourceTimeSeriesUniqueIds { get; set; } = [];
 
         ///<summary>
         ///Location unique ID
@@ -1872,7 +1807,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Tags
         ///</summary>
         [ApiMember(DataType="array", Description="Tags")]
-        public List<TagMetadata> Tags { get; set; }
+        public List<TagMetadata> Tags { get; set; } = [];
 
         ///<summary>
         ///Report creator's user unique ID
@@ -1946,11 +1881,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class TagDefinition
     {
-        public TagDefinition()
-        {
-            PickListValues = new List<string>{};
-        }
-
         ///<summary>
         ///Key of the tag
         ///</summary>
@@ -1973,7 +1903,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Set of pick-list values if ValueType is PickList
         ///</summary>
         [ApiMember(DataType="array", Description="Set of pick-list values if ValueType is PickList")]
-        public List<string> PickListValues { get; set; }
+        public List<string> PickListValues { get; set; } = [];
 
         ///<summary>
         ///True if tag is applicable to Attachments
@@ -2758,11 +2688,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class TimeSeriesThreshold
     {
-        public TimeSeriesThreshold()
-        {
-            Periods = new List<TimeSeriesThresholdPeriod>{};
-        }
-
         ///<summary>
         ///Name
         ///</summary>
@@ -2809,7 +2734,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Periods
         ///</summary>
         [ApiMember(DataType="array", Description="Periods")]
-        public List<TimeSeriesThresholdPeriod> Periods { get; set; }
+        public List<TimeSeriesThresholdPeriod> Periods { get; set; } = [];
     }
 
     public class TimeSeriesThresholdPeriod
@@ -3209,11 +3134,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class Attachment
     {
-        public Attachment()
-        {
-            Tags = new List<TagMetadata>{};
-        }
-
         ///<summary>
         ///Attachment type
         ///</summary>
@@ -3290,7 +3210,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Tags
         ///</summary>
         [ApiMember(DataType="array", Description="Tags")]
-        public List<TagMetadata> Tags { get; set; }
+        public List<TagMetadata> Tags { get; set; } = [];
     }
 
     public class Calibration
@@ -3604,11 +3524,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class CrossSectionSurveyActivity
     {
-        public CrossSectionSurveyActivity()
-        {
-            CrossSectionPoints = new List<CrossSectionPoint>{};
-        }
-
         ///<summary>
         ///Start time
         ///</summary>
@@ -3661,7 +3576,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Cross-section points
         ///</summary>
         [ApiMember(DataType="array", Description="Cross-section points")]
-        public List<CrossSectionPoint> CrossSectionPoints { get; set; }
+        public List<CrossSectionPoint> CrossSectionPoints { get; set; } = [];
     }
 
     public class CurrentMeter
@@ -3718,15 +3633,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class DischargeActivity
     {
-        public DischargeActivity()
-        {
-            VolumetricDischargeActivities = new List<VolumetricDischargeActivity>{};
-            EngineeredStructureDischargeActivities = new List<EngineeredStructureDischargeActivity>{};
-            PointVelocityDischargeActivities = new List<PointVelocityDischargeActivity>{};
-            OtherMethodDischargeActivities = new List<OtherMethodDischargeActivity>{};
-            AdcpDischargeActivities = new List<AdcpDischargeActivity>{};
-        }
-
         ///<summary>
         ///Discharge summary
         ///</summary>
@@ -3737,31 +3643,31 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Volumetric discharge activities
         ///</summary>
         [ApiMember(DataType="array", Description="Volumetric discharge activities")]
-        public List<VolumetricDischargeActivity> VolumetricDischargeActivities { get; set; }
+        public List<VolumetricDischargeActivity> VolumetricDischargeActivities { get; set; } = [];
 
         ///<summary>
         ///Engineered structure discharge activities
         ///</summary>
         [ApiMember(DataType="array", Description="Engineered structure discharge activities")]
-        public List<EngineeredStructureDischargeActivity> EngineeredStructureDischargeActivities { get; set; }
+        public List<EngineeredStructureDischargeActivity> EngineeredStructureDischargeActivities { get; set; } = [];
 
         ///<summary>
         ///Point velocity discharge activities
         ///</summary>
         [ApiMember(DataType="array", Description="Point velocity discharge activities")]
-        public List<PointVelocityDischargeActivity> PointVelocityDischargeActivities { get; set; }
+        public List<PointVelocityDischargeActivity> PointVelocityDischargeActivities { get; set; } = [];
 
         ///<summary>
         ///Other method discharge activities
         ///</summary>
         [ApiMember(DataType="array", Description="Other method discharge activities")]
-        public List<OtherMethodDischargeActivity> OtherMethodDischargeActivities { get; set; }
+        public List<OtherMethodDischargeActivity> OtherMethodDischargeActivities { get; set; } = [];
 
         ///<summary>
         ///Adcp discharge activities
         ///</summary>
         [ApiMember(DataType="array", Description="Adcp discharge activities")]
-        public List<AdcpDischargeActivity> AdcpDischargeActivities { get; set; }
+        public List<AdcpDischargeActivity> AdcpDischargeActivities { get; set; } = [];
     }
 
     public class DischargeChannelMeasurement
@@ -3877,11 +3783,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class DischargeSummary
     {
-        public DischargeSummary()
-        {
-            GageHeightReadings = new List<GageHeightReading>{};
-        }
-
         ///<summary>
         ///Measurement start time
         ///</summary>
@@ -4000,7 +3901,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Gage height readings
         ///</summary>
         [ApiMember(DataType="array", Description="Gage height readings")]
-        public List<GageHeightReading> GageHeightReadings { get; set; }
+        public List<GageHeightReading> GageHeightReadings { get; set; } = [];
 
         ///<summary>
         ///Difference during visit
@@ -4120,25 +4021,17 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class FieldVisit
         : FieldVisitDescription, IFieldVisitData
     {
-        public FieldVisit()
-        {
-            Attachments = new List<Attachment>{};
-            DischargeActivities = new List<DischargeActivity>{};
-            CrossSectionSurveyActivity = new List<CrossSectionSurveyActivity>{};
-            HydraulicTestActivities = new List<HydraulicTestActivity>{};
-        }
-
         ///<summary>
         ///Attachments
         ///</summary>
         [ApiMember(DataType="array", Description="Attachments")]
-        public List<Attachment> Attachments { get; set; }
+        public List<Attachment> Attachments { get; set; } = [];
 
         ///<summary>
         ///Discharge activities
         ///</summary>
         [ApiMember(DataType="array", Description="Discharge activities")]
-        public List<DischargeActivity> DischargeActivities { get; set; }
+        public List<DischargeActivity> DischargeActivities { get; set; } = [];
 
         ///<summary>
         ///Gage height at zero flow activity
@@ -4162,7 +4055,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Cross-section survey activity
         ///</summary>
         [ApiMember(DataType="array", Description="Cross-section survey activity")]
-        public List<CrossSectionSurveyActivity> CrossSectionSurveyActivity { get; set; }
+        public List<CrossSectionSurveyActivity> CrossSectionSurveyActivity { get; set; } = [];
 
         ///<summary>
         ///Level survey activity
@@ -4186,7 +4079,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Hydraulic Test Activities
         ///</summary>
         [ApiMember(DataType="array", Description="Hydraulic Test Activities")]
-        public List<HydraulicTestActivity> HydraulicTestActivities { get; set; }
+        public List<HydraulicTestActivity> HydraulicTestActivities { get; set; } = [];
 
         ///<summary>
         ///Well integrity activity
@@ -4287,12 +4180,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class FieldVisitReading
     {
-        public FieldVisitReading()
-        {
-            DatumConvertedValues = new List<DatumConvertedQuantityWithDisplay>{};
-            Qualifiers = new List<string>{};
-        }
-
         ///<summary>
         ///Approval
         ///</summary>
@@ -4333,7 +4220,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Datum converted values where applicable.
         ///</summary>
         [ApiMember(DataType="array", Description="Datum converted values where applicable.")]
-        public List<DatumConvertedQuantityWithDisplay> DatumConvertedValues { get; set; }
+        public List<DatumConvertedQuantityWithDisplay> DatumConvertedValues { get; set; } = [];
 
         ///<summary>
         ///Parameter Name
@@ -4405,7 +4292,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Qualifiers
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifiers")]
-        public List<string> Qualifiers { get; set; }
+        public List<string> Qualifiers { get; set; } = [];
 
         ///<summary>
         ///Field visit reading type
@@ -4554,13 +4441,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class HydraulicTestActivity
     {
-        public HydraulicTestActivity()
-        {
-            RelatedTimeSeriesUniqueIds = new List<Guid>{};
-            RelatedFieldVisitIdentifiers = new List<Guid>{};
-            Results = new List<HydraulicTestResult>{};
-        }
-
         ///<summary>
         ///The name of the test
         ///</summary>
@@ -4607,19 +4487,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///List of related time series unique ids
         ///</summary>
         [ApiMember(DataType="array", Description="List of related time series unique ids", Name="RelatedTimeSeriesUniqueIds")]
-        public List<Guid> RelatedTimeSeriesUniqueIds { get; set; }
+        public List<Guid> RelatedTimeSeriesUniqueIds { get; set; } = [];
 
         ///<summary>
         ///List of related field visit identifiers
         ///</summary>
         [ApiMember(DataType="array", Description="List of related field visit identifiers", Name="RelatedFieldVisitIdentifiers")]
-        public List<Guid> RelatedFieldVisitIdentifiers { get; set; }
+        public List<Guid> RelatedFieldVisitIdentifiers { get; set; } = [];
 
         ///<summary>
         ///List of hydraulic test results
         ///</summary>
         [ApiMember(DataType="array", Description="List of hydraulic test results", Name="Results")]
-        public List<HydraulicTestResult> Results { get; set; }
+        public List<HydraulicTestResult> Results { get; set; } = [];
 
         ///<summary>
         ///Additional comments or notes
@@ -4715,16 +4595,16 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public interface IFieldVisitData
     {
         string Identifier { get; set; }
-        List<Attachment> Attachments { get; set; }
-        List<DischargeActivity> DischargeActivities { get; set; }
+        List<Attachment> Attachments { get; set; } = [];
+        List<DischargeActivity> DischargeActivities { get; set; } = [];
         GageHeightAtZeroFlowActivity GageHeightAtZeroFlowActivity { get; set; }
         ControlConditionActivity ControlConditionActivity { get; set; }
         InspectionActivity InspectionActivity { get; set; }
-        List<CrossSectionSurveyActivity> CrossSectionSurveyActivity { get; set; }
+        List<CrossSectionSurveyActivity> CrossSectionSurveyActivity { get; set; } = [];
         LevelSurveyActivity LevelSurveyActivity { get; set; }
         FieldVisitApproval Approval { get; set; }
         DatumConversionResult DatumConversionResult { get; set; }
-        List<HydraulicTestActivity> HydraulicTestActivities { get; set; }
+        List<HydraulicTestActivity> HydraulicTestActivities { get; set; } = [];
         WellIntegrityActivity WellIntegrityActivity { get; set; }
     }
 
@@ -4775,13 +4655,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class InspectionActivity
     {
-        public InspectionActivity()
-        {
-            Readings = new List<Reading>{};
-            CalibrationChecks = new List<CalibrationCheck>{};
-            Inspections = new List<Inspection>{};
-        }
-
         ///<summary>
         ///Party
         ///</summary>
@@ -4792,7 +4665,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Readings
         ///</summary>
         [ApiMember(DataType="array", Description="Readings")]
-        public List<Reading> Readings { get; set; }
+        public List<Reading> Readings { get; set; } = [];
 
         ///<summary>
         ///Number of readings which could not be converted to the target datum
@@ -4804,13 +4677,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Calibration checks
         ///</summary>
         [ApiMember(DataType="array", Description="Calibration checks")]
-        public List<CalibrationCheck> CalibrationChecks { get; set; }
+        public List<CalibrationCheck> CalibrationChecks { get; set; } = [];
 
         ///<summary>
         ///Inspections
         ///</summary>
         [ApiMember(DataType="array", Description="Inspections")]
-        public List<Inspection> Inspections { get; set; }
+        public List<Inspection> Inspections { get; set; } = [];
 
         ///<summary>
         ///Is valid
@@ -4821,11 +4694,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class LevelSurveyActivity
     {
-        public LevelSurveyActivity()
-        {
-            LevelMeasurements = new List<LevelSurveyMeasurement>{};
-        }
-
         ///<summary>
         ///Party
         ///</summary>
@@ -4854,7 +4722,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Level survey measurements
         ///</summary>
         [ApiMember(DataType="array", Description="Level survey measurements")]
-        public List<LevelSurveyMeasurement> LevelMeasurements { get; set; }
+        public List<LevelSurveyMeasurement> LevelMeasurements { get; set; } = [];
     }
 
     public class LevelSurveyMeasurement
@@ -4946,11 +4814,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class PointVelocityDischargeActivity
     {
-        public PointVelocityDischargeActivity()
-        {
-            Verticals = new List<Vertical>{};
-        }
-
         ///<summary>
         ///Discharge channel measurement
         ///</summary>
@@ -5099,7 +4962,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Verticals
         ///</summary>
         [ApiMember(DataType="array", Description="Verticals")]
-        public List<Vertical> Verticals { get; set; }
+        public List<Vertical> Verticals { get; set; } = [];
     }
 
     public class QuantityWithDisplay
@@ -5114,11 +4977,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class Reading
     {
-        public Reading()
-        {
-            ReadingQualifiers = new List<string>{};
-        }
-
         ///<summary>
         ///Parameter Name
         ///</summary>
@@ -5243,7 +5101,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Reading Qualifiers
         ///</summary>
         [ApiMember(DataType="array", Description="Reading Qualifiers")]
-        public List<string> ReadingQualifiers { get; set; }
+        public List<string> ReadingQualifiers { get; set; } = [];
 
         ///<summary>
         ///Groundwater measurements
@@ -5374,11 +5232,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class Vertical
     {
-        public Vertical()
-        {
-            Calibrations = new List<Calibration>{};
-        }
-
         ///<summary>
         ///Vertical number
         ///</summary>
@@ -5521,16 +5374,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Calibration
         ///</summary>
         [ApiMember(DataType="array", Description="Calibration")]
-        public List<Calibration> Calibrations { get; set; }
+        public List<Calibration> Calibrations { get; set; } = [];
     }
 
     public class VolumetricDischargeActivity
     {
-        public VolumetricDischargeActivity()
-        {
-            VolumetricDischargeReadings = new List<VolumetricDischargeReading>{};
-        }
-
         ///<summary>
         ///Discharge channel measurement
         ///</summary>
@@ -5541,7 +5389,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Volumetric discharge readings
         ///</summary>
         [ApiMember(DataType="array", Description="Volumetric discharge readings")]
-        public List<VolumetricDischargeReading> VolumetricDischargeReadings { get; set; }
+        public List<VolumetricDischargeReading> VolumetricDischargeReadings { get; set; } = [];
 
         ///<summary>
         ///Measurement container volume
@@ -5687,37 +5535,29 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class WellIntegrityActivity
     {
-        public WellIntegrityActivity()
-        {
-            WellAquiferConnections = new List<WellAquiferConnection>{};
-            WellInspections = new List<WellInspection>{};
-            WellRedevelopments = new List<WellRedevelopment>{};
-            WellRepairs = new List<WellRepair>{};
-        }
-
         ///<summary>
         ///List of aquifer connections associated with the well
         ///</summary>
         [ApiMember(DataType="array", Description="List of aquifer connections associated with the well", Name="WellAquiferConnections")]
-        public List<WellAquiferConnection> WellAquiferConnections { get; set; }
+        public List<WellAquiferConnection> WellAquiferConnections { get; set; } = [];
 
         ///<summary>
         ///List of inspections performed on the well
         ///</summary>
         [ApiMember(DataType="array", Description="List of inspections performed on the well", Name="WellInspections")]
-        public List<WellInspection> WellInspections { get; set; }
+        public List<WellInspection> WellInspections { get; set; } = [];
 
         ///<summary>
         ///List of redevelopment activities for the well
         ///</summary>
         [ApiMember(DataType="array", Description="List of redevelopment activities for the well", Name="WellRedevelopments")]
-        public List<WellRedevelopment> WellRedevelopments { get; set; }
+        public List<WellRedevelopment> WellRedevelopments { get; set; } = [];
 
         ///<summary>
         ///List of repair activities performed on the well
         ///</summary>
         [ApiMember(DataType="array", Description="List of repair activities performed on the well", Name="WellRepairs")]
-        public List<WellRepair> WellRepairs { get; set; }
+        public List<WellRepair> WellRepairs { get; set; } = [];
     }
 
     public class WellRedevelopment
@@ -5782,11 +5622,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class ActiveMeterCalibration
     {
-        public ActiveMeterCalibration()
-        {
-            Equations = new List<ActiveMeterCalibrationEquation>{};
-        }
-
         ///<summary>
         ///Visit date
         ///</summary>
@@ -5797,7 +5632,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Equations
         ///</summary>
         [ApiMember(DataType="array", Description="Equations")]
-        public List<ActiveMeterCalibrationEquation> Equations { get; set; }
+        public List<ActiveMeterCalibrationEquation> Equations { get; set; } = [];
     }
 
     public class ActiveMeterCalibrationEquation
@@ -5808,11 +5643,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class ActiveMeterDetails
         : CurrentMeter
     {
-        public ActiveMeterDetails()
-        {
-            MeterCalibrations = new List<ActiveMeterCalibration>{};
-        }
-
         ///<summary>
         ///Meter type
         ///</summary>
@@ -5841,7 +5671,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Meter calibrations
         ///</summary>
         [ApiMember(DataType="array", Description="Meter calibrations")]
-        public List<ActiveMeterCalibration> MeterCalibrations { get; set; }
+        public List<ActiveMeterCalibration> MeterCalibrations { get; set; } = [];
     }
 
     public enum ActivityType
@@ -6392,14 +6222,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class FieldVisitDataByLocationServiceRequest
         : IReturn<FieldVisitDataByLocationServiceResponse>, IFieldVisitDataRequest
     {
-        public FieldVisitDataByLocationServiceRequest()
-        {
-            Activities = new List<ActivityType>{};
-            Parameters = new List<string>{};
-            InspectionTypes = new List<InspectionType>{};
-            ExtendedFilters = new List<ExtendedAttributeFilter>{};
-        }
-
         ///<summary>
         ///Location identifier
         ///</summary>
@@ -6410,19 +6232,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///If set, only return specified activity types, selected from: Reading, Inspection, CalibrationCheck, DischargeSummary, DischargePointVelocity, DischargeVolumetric, DischargeEngineeredStructure, DischargeAdcp, DischargeOtherMethod, GageHeightAtZeroFlow, ControlCondition, CrossSectionSurvey, LevelSurvey, Attachment, HydraulicTest or WellIntegrity
         ///</summary>
         [ApiMember(AllowMultiple=true, DataType="array", Description="If set, only return specified activity types, selected from: Reading, Inspection, CalibrationCheck, DischargeSummary, DischargePointVelocity, DischargeVolumetric, DischargeEngineeredStructure, DischargeAdcp, DischargeOtherMethod, GageHeightAtZeroFlow, ControlCondition, CrossSectionSurvey, LevelSurvey, Attachment, HydraulicTest or WellIntegrity")]
-        public List<ActivityType> Activities { get; set; }
+        public List<ActivityType> Activities { get; set; } = [];
 
         ///<summary>
         ///If set, only return readings and calibrations of the specified parameters
         ///</summary>
         [ApiMember(DataType="array", Description="If set, only return readings and calibrations of the specified parameters")]
-        public List<string> Parameters { get; set; }
+        public List<string> Parameters { get; set; } = [];
 
         ///<summary>
         ///If set, only return inspections of the specified types, selected from: BubbleGage, CrestStageGage, WireWeightGage, MaximumMinimumGage, WaterQuality, FieldMeter, Other
         ///</summary>
         [ApiMember(AllowMultiple=true, DataType="array", Description="If set, only return inspections of the specified types, selected from: BubbleGage, CrestStageGage, WireWeightGage, MaximumMinimumGage, WaterQuality, FieldMeter, Other")]
-        public List<InspectionType> InspectionTypes { get; set; }
+        public List<InspectionType> InspectionTypes { get; set; } = [];
 
         ///<summary>
         ///True if node details (raw JSON of each specific activity) should be included
@@ -6470,7 +6292,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to items matching the given extended attribute values
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to items matching the given extended attribute values")]
-        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; }
+        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; } = [];
     }
 
     [Route("/GetFieldVisitData", "GET")]
@@ -6536,11 +6358,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class FieldVisitDescriptionListServiceRequest
         : IReturn<FieldVisitDescriptionListServiceResponse>
     {
-        public FieldVisitDescriptionListServiceRequest()
-        {
-            ExtendedFilters = new List<ExtendedAttributeFilter>{};
-        }
-
         ///<summary>
         ///Filter results to the given location
         ///</summary>
@@ -6575,7 +6392,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to items matching the given extended attribute values
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to items matching the given extended attribute values")]
-        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; }
+        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; } = [];
     }
 
     [Route("/GetAuthToken", "GET")]
@@ -6605,11 +6422,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class GetFieldVisitReadingsByLocationServiceRequest
         : IReturn<FieldVisitReadingsByLocationServiceResponse>
     {
-        public GetFieldVisitReadingsByLocationServiceRequest()
-        {
-            Parameters = new List<string>{};
-        }
-
         ///<summary>
         ///Location identifier. Must be empty when LocationUniqueId is set.
         ///</summary>
@@ -6626,7 +6438,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///If set, only return readings of the specified parameters
         ///</summary>
         [ApiMember(DataType="array", Description="If set, only return readings of the specified parameters")]
-        public List<string> Parameters { get; set; }
+        public List<string> Parameters { get; set; } = [];
 
         ///<summary>
         ///Filter results to items matching the Publish value
@@ -6691,14 +6503,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class LocationDescriptionListServiceRequest
         : IReturn<LocationDescriptionListServiceResponse>
     {
-        public LocationDescriptionListServiceRequest()
-        {
-            TagNames = new List<string>{};
-            TagKeys = new List<string>{};
-            TagValues = new List<string>{};
-            ExtendedFilters = new List<ExtendedAttributeFilter>{};
-        }
-
         ///<summary>
         ///Filter results to the given location name (supports *partialname* pattern*)
         ///</summary>
@@ -6721,25 +6525,25 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///DEPRECATED: renamed to TagKeys
         ///</summary>
         [ApiMember(DataType="array", Description="DEPRECATED: renamed to TagKeys")]
-        public List<string> TagNames { get; set; }
+        public List<string> TagNames { get; set; } = [];
 
         ///<summary>
         ///Filter results to locations matching all tags by key (supports *partialname* pattern)
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to locations matching all tags by key (supports *partialname* pattern)")]
-        public List<string> TagKeys { get; set; }
+        public List<string> TagKeys { get; set; } = [];
 
         ///<summary>
         ///Filter results to locations matching all tags by value (supports *partialname* pattern)
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to locations matching all tags by value (supports *partialname* pattern)")]
-        public List<string> TagValues { get; set; }
+        public List<string> TagValues { get; set; } = [];
 
         ///<summary>
         ///Filter results to items matching the given extended attribute values
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to items matching the given extended attribute values")]
-        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; }
+        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; } = [];
 
         ///<summary>
         ///Filter results to items matching the Publish value
@@ -6886,11 +6690,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class RatingModelEffectiveShiftsByStageValuesServiceRequest
         : IReturn<RatingModelEffectiveShiftsByStageValuesServiceResponse>
     {
-        public RatingModelEffectiveShiftsByStageValuesServiceRequest()
-        {
-            StageValues = new List<double>{};
-        }
-
         ///<summary>
         ///Rating model identifier
         ///</summary>
@@ -6907,7 +6706,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///The input stage values to which the shift is to be applied
         ///</summary>
         [ApiMember(DataType="array", Description="The input stage values to which the shift is to be applied", IsRequired=true)]
-        public List<double> StageValues { get; set; }
+        public List<double> StageValues { get; set; } = [];
     }
 
     [Route("/GetRatingModelEffectiveShifts", "GET")]
@@ -6943,11 +6742,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class RatingModelInputValuesServiceRequest
         : IReturn<RatingModelInputValuesServiceResponse>
     {
-        public RatingModelInputValuesServiceRequest()
-        {
-            OutputValues = new List<double>{};
-        }
-
         ///<summary>
         ///Rating model identifier
         ///</summary>
@@ -6958,7 +6752,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Output values
         ///</summary>
         [ApiMember(DataType="array", Description="Output values", IsRequired=true)]
-        public List<double> OutputValues { get; set; }
+        public List<double> OutputValues { get; set; } = [];
 
         ///<summary>
         ///Effective time of the calculation. Defaults to the current time if not specified
@@ -6971,11 +6765,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class RatingModelOutputValuesServiceRequest
         : IReturn<RatingModelOutputValuesServiceResponse>
     {
-        public RatingModelOutputValuesServiceRequest()
-        {
-            InputValues = new List<double>{};
-        }
-
         ///<summary>
         ///Rating model identifier
         ///</summary>
@@ -6986,7 +6775,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Input values
         ///</summary>
         [ApiMember(DataType="array", Description="Input values", IsRequired=true)]
-        public List<double> InputValues { get; set; }
+        public List<double> InputValues { get; set; } = [];
 
         ///<summary>
         ///Effective time of the calculation. Defaults to the current time if not specified
@@ -7005,14 +6794,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class ReportListServiceRequest
         : IReturn<ReportListServiceResponse>
     {
-        public ReportListServiceRequest()
-        {
-            TimeSeriesUniqueIds = new List<Guid>{};
-            ReportUniqueIds = new List<Guid>{};
-            TagKeys = new List<string>{};
-            TagValues = new List<string>{};
-        }
-
         ///<summary>
         ///Filter results to given location unique ID
         ///</summary>
@@ -7023,7 +6804,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to given source time series unique IDs
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to given source time series unique IDs")]
-        public List<Guid> TimeSeriesUniqueIds { get; set; }
+        public List<Guid> TimeSeriesUniqueIds { get; set; } = [];
 
         ///<summary>
         ///Filter results to the given user unique ID
@@ -7041,7 +6822,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to given report unique IDs
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to given report unique IDs")]
-        public List<Guid> ReportUniqueIds { get; set; }
+        public List<Guid> ReportUniqueIds { get; set; } = [];
 
         ///<summary>
         ///Filter results to items created at or after the CreatedFrom time
@@ -7053,13 +6834,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to items matching all tags by key (supports *partialname* pattern)
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to items matching all tags by key (supports *partialname* pattern)")]
-        public List<string> TagKeys { get; set; }
+        public List<string> TagKeys { get; set; } = [];
 
         ///<summary>
         ///Filter results to items matching all tags by value (supports *partialname* pattern)
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to items matching all tags by value (supports *partialname* pattern)")]
-        public List<string> TagValues { get; set; }
+        public List<string> TagValues { get; set; } = [];
 
         ///<summary>
         ///Limit the number of results items, after all filtering and ordering
@@ -7072,11 +6853,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class RoundServiceRequest
         : IReturn<RoundServiceResponse>
     {
-        public RoundServiceRequest()
-        {
-            Data = new List<double>{};
-        }
-
         ///<summary>
         ///The data is for this parameter
         ///</summary>
@@ -7105,18 +6881,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///A list of data values to be rounded and returned as strings
         ///</summary>
         [ApiMember(DataType="array", Description="A list of data values to be rounded and returned as strings", IsRequired=true)]
-        public List<double> Data { get; set; }
+        public List<double> Data { get; set; } = [];
     }
 
     [Route("/Round/ToSpec", "PUT")]
     public class RoundServiceSpecRequest
         : IReturn<RoundServiceResponse>
     {
-        public RoundServiceSpecRequest()
-        {
-            Data = new List<double>{};
-        }
-
         ///<summary>
         ///Use this rounding specification to round the data
         ///</summary>
@@ -7133,20 +6904,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///A list of data values to be rounded and returned as strings
         ///</summary>
         [ApiMember(DataType="array", Description="A list of data values to be rounded and returned as strings", IsRequired=true)]
-        public List<double> Data { get; set; }
+        public List<double> Data { get; set; } = [];
     }
 
     [Route("/GetSensorsAndGauges", "GET,POST")]
     public class SensorsAndGaugesServiceRequest
         : IReturn<SensorsAndGaugesServiceResponse>
     {
-        public SensorsAndGaugesServiceRequest()
-        {
-            LocationUniqueIds = new List<Guid>{};
-            TagKeys = new List<string>{};
-            TagValues = new List<string>{};
-        }
-
         ///<summary>
         ///Filter results to sensors and gauges for this location
         ///</summary>
@@ -7157,58 +6921,47 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to sensors and gauges for these locations. Limited to roughly 60 items for a GET request; use POST to avoid this limit.
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to sensors and gauges for these locations. Limited to roughly 60 items for a GET request; use POST to avoid this limit.")]
-        public List<Guid> LocationUniqueIds { get; set; }
+        public List<Guid> LocationUniqueIds { get; set; } = [];
 
         ///<summary>
         ///Filter results to sensors and gauges matching all tags by key (supports *partialname* pattern)
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to sensors and gauges matching all tags by key (supports *partialname* pattern)")]
-        public List<string> TagKeys { get; set; }
+        public List<string> TagKeys { get; set; } = [];
 
         ///<summary>
         ///Filter results to sensors and gauges matching all tags by value (supports *partialname* pattern)
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to sensors and gauges matching all tags by value (supports *partialname* pattern)")]
-        public List<string> TagValues { get; set; }
+        public List<string> TagValues { get; set; } = [];
     }
 
     [Route("/GetTagList", "GET")]
     public class TagListServiceRequest
         : IReturn<TagListServiceResponse>
     {
-        public TagListServiceRequest()
-        {
-            Applicability = new List<TagApplicability>{};
-        }
-
         ///<summary>
         ///If set, return only tags with specified applicability, selected from: AppliesToLocations, AppliesToLocationNotes, AppliesToSensorsGauges, AppliesToAttachments, AppliesToReports
         ///</summary>
         [ApiMember(AllowMultiple=true, DataType="array", Description="If set, return only tags with specified applicability, selected from: AppliesToLocations, AppliesToLocationNotes, AppliesToSensorsGauges, AppliesToAttachments, AppliesToReports")]
-        public List<TagApplicability> Applicability { get; set; }
+        public List<TagApplicability> Applicability { get; set; } = [];
     }
 
     [Route("/GetTimeSeriesData", "GET")]
     public class TimeAlignedDataServiceRequest
         : IReturn<TimeAlignedDataServiceResponse>
     {
-        public TimeAlignedDataServiceRequest()
-        {
-            TimeSeriesUniqueIds = new List<Guid>{};
-            TimeSeriesOutputUnitIds = new List<string>{};
-        }
-
         ///<summary>
         ///The unique IDs of the time-series to retrieve
         ///</summary>
         [ApiMember(DataType="array", Description="The unique IDs of the time-series to retrieve", IsRequired=true)]
-        public List<Guid> TimeSeriesUniqueIds { get; set; }
+        public List<Guid> TimeSeriesUniqueIds { get; set; } = [];
 
         ///<summary>
         ///The unit identifiers for points. Defaults to the time-series unit
         ///</summary>
         [ApiMember(DataType="array", Description="The unit identifiers for points. Defaults to the time-series unit")]
-        public List<string> TimeSeriesOutputUnitIds { get; set; }
+        public List<string> TimeSeriesOutputUnitIds { get; set; } = [];
 
         ///<summary>
         ///Filter results to items at or after the QueryFrom time
@@ -7374,27 +7127,17 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class TimeSeriesDescriptionListByUniqueIdServiceRequest
         : IReturn<TimeSeriesDescriptionListByUniqueIdServiceResponse>
     {
-        public TimeSeriesDescriptionListByUniqueIdServiceRequest()
-        {
-            TimeSeriesUniqueIds = new List<Guid>{};
-        }
-
         ///<summary>
         ///A collection of time series unique IDs to query. Limited to roughly 60 items for a GET request; use POST to avoid this limit.
         ///</summary>
         [ApiMember(DataType="array", Description="A collection of time series unique IDs to query. Limited to roughly 60 items for a GET request; use POST to avoid this limit.")]
-        public List<Guid> TimeSeriesUniqueIds { get; set; }
+        public List<Guid> TimeSeriesUniqueIds { get; set; } = [];
     }
 
     [Route("/GetTimeSeriesDescriptionList", "GET")]
     public class TimeSeriesDescriptionServiceRequest
         : IReturn<TimeSeriesDescriptionListServiceResponse>
     {
-        public TimeSeriesDescriptionServiceRequest()
-        {
-            ExtendedFilters = new List<ExtendedAttributeFilter>{};
-        }
-
         ///<summary>
         ///Filter results to the given location
         ///</summary>
@@ -7429,18 +7172,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to items matching the given extended attribute values
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to items matching the given extended attribute values")]
-        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; }
+        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; } = [];
     }
 
     [Route("/GetTimeSeriesUniqueIdList", "GET")]
     public class TimeSeriesUniqueIdListServiceRequest
         : IReturn<TimeSeriesUniqueIdListServiceResponse>
     {
-        public TimeSeriesUniqueIdListServiceRequest()
-        {
-            ExtendedFilters = new List<ExtendedAttributeFilter>{};
-        }
-
         ///<summary>
         ///Filter results to items modified at or after the ChangesSinceToken time
         ///</summary>
@@ -7487,18 +7225,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to items matching the given extended attribute values
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to items matching the given extended attribute values")]
-        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; }
+        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; } = [];
     }
 
     [Route("/GetTrendLineAnalysis", "POST")]
     public class TrendLineAnalysisServiceRequest
         : IReturn<TrendLineAnalysisServiceResponse>
     {
-        public TrendLineAnalysisServiceRequest()
-        {
-            Points = new List<TimeSeriesPoint>{};
-        }
-
         ///<summary>
         ///Type of regression analysis
         ///</summary>
@@ -7521,7 +7254,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///List of data points to perform analysis on. Requires a minimum of three points, and points sorted by timestamp in ascending order. Must not contain any duplicate times.
         ///</summary>
         [ApiMember(DataType="array", Description="List of data points to perform analysis on. Requires a minimum of three points, and points sorted by timestamp in ascending order. Must not contain any duplicate times.", IsRequired=true)]
-        public List<TimeSeriesPoint> Points { get; set; }
+        public List<TimeSeriesPoint> Points { get; set; } = [];
     }
 
     [Route("/GetUnitList", "GET")]
@@ -7561,46 +7294,31 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class ActiveMetersAndCalibrationsServiceResponse
         : PublishServiceResponse
     {
-        public ActiveMetersAndCalibrationsServiceResponse()
-        {
-            ActiveMeterDetails = new List<ActiveMeterDetails>{};
-        }
-
         ///<summary>
         ///Current meter details
         ///</summary>
         [ApiMember(DataType="array", Description="Current meter details")]
-        public List<ActiveMeterDetails> ActiveMeterDetails { get; set; }
+        public List<ActiveMeterDetails> ActiveMeterDetails { get; set; } = [];
     }
 
     public class ApprovalListServiceResponse
         : PublishServiceResponse
     {
-        public ApprovalListServiceResponse()
-        {
-            Approvals = new List<ApprovalMetadata>{};
-        }
-
         ///<summary>
         ///Approvals
         ///</summary>
         [ApiMember(DataType="array", Description="Approvals")]
-        public List<ApprovalMetadata> Approvals { get; set; }
+        public List<ApprovalMetadata> Approvals { get; set; } = [];
     }
 
     public class CorrectionListServiceResponse
         : PublishServiceResponse
     {
-        public CorrectionListServiceResponse()
-        {
-            Corrections = new List<Correction>{};
-        }
-
         ///<summary>
         ///Corrections
         ///</summary>
         [ApiMember(DataType="array", Description="Corrections")]
-        public List<Correction> Corrections { get; set; }
+        public List<Correction> Corrections { get; set; } = [];
     }
 
     public class EffectiveRatingCurveServiceResponse
@@ -7616,51 +7334,32 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class ExpandedStageTableServiceResponse
         : PublishServiceResponse
     {
-        public ExpandedStageTableServiceResponse()
-        {
-            ExpandedStageTable = new List<StagePoint>{};
-            Corrections = new List<Correction>{};
-        }
-
         ///<summary>
         ///Expanded stage table
         ///</summary>
         [ApiMember(DataType="array", Description="Expanded stage table")]
-        public List<StagePoint> ExpandedStageTable { get; set; }
+        public List<StagePoint> ExpandedStageTable { get; set; } = [];
 
         ///<summary>
         ///Corrections
         ///</summary>
         [ApiMember(DataType="array", Description="Corrections")]
-        public List<Correction> Corrections { get; set; }
+        public List<Correction> Corrections { get; set; } = [];
     }
 
     public class FieldVisitDataByLocationServiceResponse
         : PublishServiceResponse
     {
-        public FieldVisitDataByLocationServiceResponse()
-        {
-            FieldVisitData = new List<FieldVisit>{};
-        }
-
         ///<summary>
         ///Field visit descriptions and data
         ///</summary>
         [ApiMember(DataType="array", Description="Field visit descriptions and data")]
-        public List<FieldVisit> FieldVisitData { get; set; }
+        public List<FieldVisit> FieldVisitData { get; set; } = [];
     }
 
     public class FieldVisitDataServiceResponse
         : PublishServiceResponse, IFieldVisitData
     {
-        public FieldVisitDataServiceResponse()
-        {
-            Attachments = new List<Attachment>{};
-            DischargeActivities = new List<DischargeActivity>{};
-            CrossSectionSurveyActivity = new List<CrossSectionSurveyActivity>{};
-            HydraulicTestActivities = new List<HydraulicTestActivity>{};
-        }
-
         ///<summary>
         ///Field visit identifier
         ///</summary>
@@ -7671,13 +7370,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Attachments
         ///</summary>
         [ApiMember(DataType="array", Description="Attachments")]
-        public List<Attachment> Attachments { get; set; }
+        public List<Attachment> Attachments { get; set; } = [];
 
         ///<summary>
         ///Discharge activities
         ///</summary>
         [ApiMember(DataType="array", Description="Discharge activities")]
-        public List<DischargeActivity> DischargeActivities { get; set; }
+        public List<DischargeActivity> DischargeActivities { get; set; } = [];
 
         ///<summary>
         ///Gage height at zero flow activity
@@ -7701,7 +7400,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Cross-section survey activity
         ///</summary>
         [ApiMember(DataType="array", Description="Cross-section survey activity")]
-        public List<CrossSectionSurveyActivity> CrossSectionSurveyActivity { get; set; }
+        public List<CrossSectionSurveyActivity> CrossSectionSurveyActivity { get; set; } = [];
 
         ///<summary>
         ///Level survey activity
@@ -7725,7 +7424,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Hydraulic Test Activities
         ///</summary>
         [ApiMember(DataType="array", Description="Hydraulic Test Activities")]
-        public List<HydraulicTestActivity> HydraulicTestActivities { get; set; }
+        public List<HydraulicTestActivity> HydraulicTestActivities { get; set; } = [];
 
         ///<summary>
         ///Well integrity activity
@@ -7743,23 +7442,17 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class FieldVisitDescriptionListServiceResponse
         : PublishServiceResponse
     {
-        public FieldVisitDescriptionListServiceResponse()
-        {
-            FieldVisitDescriptions = new List<FieldVisitDescription>{};
-            DeletedFieldVisitDescriptions = new List<FieldVisitDescription>{};
-        }
-
         ///<summary>
         ///Field visit descriptions
         ///</summary>
         [ApiMember(DataType="array", Description="Field visit descriptions")]
-        public List<FieldVisitDescription> FieldVisitDescriptions { get; set; }
+        public List<FieldVisitDescription> FieldVisitDescriptions { get; set; } = [];
 
         ///<summary>
         ///Field visits that have been deleted since the requested ChangesSinceToken
         ///</summary>
         [ApiMember(DataType="array", Description="Field visits that have been deleted since the requested ChangesSinceToken")]
-        public List<FieldVisitDescription> DeletedFieldVisitDescriptions { get; set; }
+        public List<FieldVisitDescription> DeletedFieldVisitDescriptions { get; set; } = [];
 
         ///<summary>
         ///Next token
@@ -7771,46 +7464,26 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class FieldVisitReadingsByLocationServiceResponse
         : PublishServiceResponse
     {
-        public FieldVisitReadingsByLocationServiceResponse()
-        {
-            FieldVisitReadings = new List<FieldVisitReading>{};
-        }
-
         ///<summary>
         ///Field visit readings
         ///</summary>
         [ApiMember(DataType="array", Description="Field visit readings")]
-        public List<FieldVisitReading> FieldVisitReadings { get; set; }
+        public List<FieldVisitReading> FieldVisitReadings { get; set; } = [];
     }
 
     public class GradeListServiceResponse
         : PublishServiceResponse
     {
-        public GradeListServiceResponse()
-        {
-            Grades = new List<GradeMetadata>{};
-        }
-
         ///<summary>
         ///Grades
         ///</summary>
         [ApiMember(DataType="array", Description="Grades")]
-        public List<GradeMetadata> Grades { get; set; }
+        public List<GradeMetadata> Grades { get; set; } = [];
     }
 
     public class LocationDataServiceResponse
         : PublishServiceResponse
     {
-        public LocationDataServiceResponse()
-        {
-            Tags = new List<TagMetadata>{};
-            ExtendedAttributes = new List<ExtendedAttribute>{};
-            LocationRemarks = new List<LocationRemark>{};
-            LocationNotes = new List<LocationNote>{};
-            Attachments = new List<Attachment>{};
-            ReferencePoints = new List<ReferencePoint>{};
-        }
-
         ///<summary>
         ///Location name
         ///</summary>
@@ -7887,31 +7560,31 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Tags
         ///</summary>
         [ApiMember(DataType="array", Description="Tags")]
-        public List<TagMetadata> Tags { get; set; }
+        public List<TagMetadata> Tags { get; set; } = [];
 
         ///<summary>
         ///Extended attributes
         ///</summary>
         [ApiMember(DataType="array", Description="Extended attributes")]
-        public List<ExtendedAttribute> ExtendedAttributes { get; set; }
+        public List<ExtendedAttribute> ExtendedAttributes { get; set; } = [];
 
         ///<summary>
         ///Location remarks
         ///</summary>
         [ApiMember(DataType="array", Description="Location remarks")]
-        public List<LocationRemark> LocationRemarks { get; set; }
+        public List<LocationRemark> LocationRemarks { get; set; } = [];
 
         ///<summary>
         ///Location notes
         ///</summary>
         [ApiMember(DataType="array", Description="Location notes")]
-        public List<LocationNote> LocationNotes { get; set; }
+        public List<LocationNote> LocationNotes { get; set; } = [];
 
         ///<summary>
         ///Attachments
         ///</summary>
         [ApiMember(DataType="array", Description="Attachments")]
-        public List<Attachment> Attachments { get; set; }
+        public List<Attachment> Attachments { get; set; } = [];
 
         ///<summary>
         ///Location datum
@@ -7923,7 +7596,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Reference points
         ///</summary>
         [ApiMember(DataType="array", Description="Reference points")]
-        public List<ReferencePoint> ReferencePoints { get; set; }
+        public List<ReferencePoint> ReferencePoints { get; set; } = [];
 
         ///<summary>
         ///Property Bag
@@ -7935,16 +7608,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class LocationDescriptionListServiceResponse
         : PublishServiceResponse
     {
-        public LocationDescriptionListServiceResponse()
-        {
-            LocationDescriptions = new List<LocationDescription>{};
-        }
-
         ///<summary>
         ///Location descriptions
         ///</summary>
         [ApiMember(DataType="array", Description="Location descriptions")]
-        public List<LocationDescription> LocationDescriptions { get; set; }
+        public List<LocationDescription> LocationDescriptions { get; set; } = [];
 
         ///<summary>
         ///Next token
@@ -7956,11 +7624,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class LocationNotesServiceResponse
         : PublishServiceResponse
     {
-        public LocationNotesServiceResponse()
-        {
-            LocationNotes = new List<LocationNote>{};
-        }
-
         ///<summary>
         ///Location name
         ///</summary>
@@ -7983,7 +7646,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Location notes
         ///</summary>
         [ApiMember(DataType="array", Description="Location notes")]
-        public List<LocationNote> LocationNotes { get; set; }
+        public List<LocationNote> LocationNotes { get; set; } = [];
     }
 
     public class MetadataChangeTransactionListServiceResponse
@@ -7998,11 +7661,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 
     public class MonitoringMethodListServiceResponse
     {
-        public MonitoringMethodListServiceResponse()
-        {
-            MonitoringMethods = new List<MonitoringMethod>{};
-        }
-
         ///<summary>
         ///Response version
         ///</summary>
@@ -8025,37 +7683,27 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Monitoring methods
         ///</summary>
         [ApiMember(DataType="array", Description="Monitoring methods")]
-        public List<MonitoringMethod> MonitoringMethods { get; set; }
+        public List<MonitoringMethod> MonitoringMethods { get; set; } = [];
     }
 
     public class ParameterListServiceResponse
         : PublishServiceResponse
     {
-        public ParameterListServiceResponse()
-        {
-            Parameters = new List<ParameterMetadata>{};
-        }
-
         ///<summary>
         ///Parameters
         ///</summary>
         [ApiMember(DataType="array", Description="Parameters")]
-        public List<ParameterMetadata> Parameters { get; set; }
+        public List<ParameterMetadata> Parameters { get; set; } = [];
     }
 
     public class ProcessorListServiceResponse
         : PublishServiceResponse
     {
-        public ProcessorListServiceResponse()
-        {
-            Processors = new List<Processor>{};
-        }
-
         ///<summary>
         ///Processors
         ///</summary>
         [ApiMember(DataType="array", Description="Processors")]
-        public List<Processor> Processors { get; set; }
+        public List<Processor> Processors { get; set; } = [];
     }
 
     public class PublishServiceResponse
@@ -8082,16 +7730,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class QualifierListServiceResponse
         : PublishServiceResponse
     {
-        public QualifierListServiceResponse()
-        {
-            Qualifiers = new List<QualifierMetadata>{};
-        }
-
         ///<summary>
         ///Qualifiers
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifiers")]
-        public List<QualifierMetadata> Qualifiers { get; set; }
+        public List<QualifierMetadata> Qualifiers { get; set; } = [];
     }
 
     public class RatingCurveListServiceResponse
@@ -8129,11 +7772,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class RatingModelEffectiveShiftsByStageValuesServiceResponse
         : PublishServiceResponse
     {
-        public RatingModelEffectiveShiftsByStageValuesServiceResponse()
-        {
-            EffectiveShiftValues = new List<Nullable<Double>>{};
-        }
-
         ///<summary>
         ///Timestamp
         ///</summary>
@@ -8144,128 +7782,87 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Effective shift values
         ///</summary>
         [ApiMember(DataType="array", Description="Effective shift values")]
-        public List<Nullable<Double>> EffectiveShiftValues { get; set; }
+        public List<Nullable<Double>> EffectiveShiftValues { get; set; } = [];
     }
 
     public class RatingModelEffectiveShiftsServiceResponse
         : PublishServiceResponse
     {
-        public RatingModelEffectiveShiftsServiceResponse()
-        {
-            EffectiveShifts = new List<EffectiveShift>{};
-        }
-
         ///<summary>
         ///Effective shifts
         ///</summary>
         [ApiMember(DataType="array", Description="Effective shifts")]
-        public List<EffectiveShift> EffectiveShifts { get; set; }
+        public List<EffectiveShift> EffectiveShifts { get; set; } = [];
     }
 
     public class RatingModelInputValuesServiceResponse
         : PublishServiceResponse
     {
-        public RatingModelInputValuesServiceResponse()
-        {
-            InputValues = new List<Nullable<Double>>{};
-        }
-
         ///<summary>
         ///Input values
         ///</summary>
         [ApiMember(DataType="array", Description="Input values")]
-        public List<Nullable<Double>> InputValues { get; set; }
+        public List<Nullable<Double>> InputValues { get; set; } = [];
     }
 
     public class RatingModelOutputValuesServiceResponse
         : PublishServiceResponse
     {
-        public RatingModelOutputValuesServiceResponse()
-        {
-            OutputValues = new List<Nullable<Double>>{};
-        }
-
         ///<summary>
         ///Output values
         ///</summary>
         [ApiMember(DataType="array", Description="Output values")]
-        public List<Nullable<Double>> OutputValues { get; set; }
+        public List<Nullable<Double>> OutputValues { get; set; } = [];
     }
 
     public class ReportListServiceResponse
         : PublishServiceResponse
     {
-        public ReportListServiceResponse()
-        {
-            Reports = new List<Report>{};
-        }
-
         ///<summary>
         ///Reports
         ///</summary>
         [ApiMember(DataType="array", Description="Reports")]
-        public List<Report> Reports { get; set; }
+        public List<Report> Reports { get; set; } = [];
     }
 
     public class RoundServiceResponse
         : PublishServiceResponse
     {
-        public RoundServiceResponse()
-        {
-            Data = new List<string>{};
-        }
-
         ///<summary>
         ///Values rounded as requested
         ///</summary>
         [ApiMember(DataType="array", Description="Values rounded as requested")]
-        public List<string> Data { get; set; }
+        public List<string> Data { get; set; } = [];
     }
 
     public class SensorsAndGaugesServiceResponse
         : PublishServiceResponse
     {
-        public SensorsAndGaugesServiceResponse()
-        {
-            MonitoringMethods = new List<LocationMonitoringMethod>{};
-        }
-
         ///<summary>
         ///Monitoring methods
         ///</summary>
         [ApiMember(DataType="array", Description="Monitoring methods")]
-        public List<LocationMonitoringMethod> MonitoringMethods { get; set; }
+        public List<LocationMonitoringMethod> MonitoringMethods { get; set; } = [];
     }
 
     public class TagListServiceResponse
         : PublishServiceResponse
     {
-        public TagListServiceResponse()
-        {
-            Tags = new List<TagDefinition>{};
-        }
-
         ///<summary>
         ///Tags
         ///</summary>
         [ApiMember(DataType="array", Description="Tags")]
-        public List<TagDefinition> Tags { get; set; }
+        public List<TagDefinition> Tags { get; set; } = [];
     }
 
     public class TimeAlignedDataServiceResponse
         : PublishServiceResponse
     {
-        public TimeAlignedDataServiceResponse()
-        {
-            TimeSeries = new List<TimeAlignedTimeSeriesInfo>{};
-            Points = new List<TimeAlignedPoint>{};
-        }
-
         ///<summary>
         ///Summary info of the retrieved time-series
         ///</summary>
         [ApiMember(DataType="array", Description="Summary info of the retrieved time-series")]
-        public List<TimeAlignedTimeSeriesInfo> TimeSeries { get; set; }
+        public List<TimeAlignedTimeSeriesInfo> TimeSeries { get; set; } = [];
 
         ///<summary>
         ///Time range
@@ -8283,7 +7880,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Points
         ///</summary>
         [ApiMember(DataType="array", Description="Points")]
-        public List<TimeAlignedPoint> Points { get; set; }
+        public List<TimeAlignedPoint> Points { get; set; } = [];
     }
 
     public class TimeSeriesApprovalsTransactionListServiceResponse
@@ -8299,18 +7896,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class TimeSeriesDataServiceResponse
         : PublishServiceResponse
     {
-        public TimeSeriesDataServiceResponse()
-        {
-            Approvals = new List<Approval>{};
-            Qualifiers = new List<Qualifier>{};
-            Methods = new List<Method>{};
-            Grades = new List<Grade>{};
-            GapTolerances = new List<GapTolerance>{};
-            InterpolationTypes = new List<InterpolationType>{};
-            Notes = new List<Note>{};
-            Points = new List<TimeSeriesPoint>{};
-        }
-
         ///<summary>
         ///Unique id
         ///</summary>
@@ -8351,43 +7936,43 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Approvals
         ///</summary>
         [ApiMember(DataType="array", Description="Approvals")]
-        public List<Approval> Approvals { get; set; }
+        public List<Approval> Approvals { get; set; } = [];
 
         ///<summary>
         ///Qualifiers
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifiers")]
-        public List<Qualifier> Qualifiers { get; set; }
+        public List<Qualifier> Qualifiers { get; set; } = [];
 
         ///<summary>
         ///Methods
         ///</summary>
         [ApiMember(DataType="array", Description="Methods")]
-        public List<Method> Methods { get; set; }
+        public List<Method> Methods { get; set; } = [];
 
         ///<summary>
         ///Grades
         ///</summary>
         [ApiMember(DataType="array", Description="Grades")]
-        public List<Grade> Grades { get; set; }
+        public List<Grade> Grades { get; set; } = [];
 
         ///<summary>
         ///Gap tolerances
         ///</summary>
         [ApiMember(DataType="array", Description="Gap tolerances")]
-        public List<GapTolerance> GapTolerances { get; set; }
+        public List<GapTolerance> GapTolerances { get; set; } = [];
 
         ///<summary>
         ///Interpolation types
         ///</summary>
         [ApiMember(DataType="array", Description="Interpolation types")]
-        public List<InterpolationType> InterpolationTypes { get; set; }
+        public List<InterpolationType> InterpolationTypes { get; set; } = [];
 
         ///<summary>
         ///Notes
         ///</summary>
         [ApiMember(DataType="array", Description="Notes")]
-        public List<Note> Notes { get; set; }
+        public List<Note> Notes { get; set; } = [];
 
         ///<summary>
         ///Time range
@@ -8399,47 +7984,32 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Points
         ///</summary>
         [ApiMember(DataType="array", Description="Points")]
-        public List<TimeSeriesPoint> Points { get; set; }
+        public List<TimeSeriesPoint> Points { get; set; } = [];
     }
 
     public class TimeSeriesDescriptionListByUniqueIdServiceResponse
         : PublishServiceResponse
     {
-        public TimeSeriesDescriptionListByUniqueIdServiceResponse()
-        {
-            TimeSeriesDescriptions = new List<TimeSeriesDescription>{};
-        }
-
         ///<summary>
         ///Time series descriptions
         ///</summary>
         [ApiMember(DataType="array", Description="Time series descriptions")]
-        public List<TimeSeriesDescription> TimeSeriesDescriptions { get; set; }
+        public List<TimeSeriesDescription> TimeSeriesDescriptions { get; set; } = [];
     }
 
     public class TimeSeriesDescriptionListServiceResponse
         : PublishServiceResponse
     {
-        public TimeSeriesDescriptionListServiceResponse()
-        {
-            TimeSeriesDescriptions = new List<TimeSeriesDescription>{};
-        }
-
         ///<summary>
         ///Time series descriptions
         ///</summary>
         [ApiMember(DataType="array", Description="Time series descriptions")]
-        public List<TimeSeriesDescription> TimeSeriesDescriptions { get; set; }
+        public List<TimeSeriesDescription> TimeSeriesDescriptions { get; set; } = [];
     }
 
     public class TimeSeriesUniqueIdListServiceResponse
         : PublishServiceResponse
     {
-        public TimeSeriesUniqueIdListServiceResponse()
-        {
-            TimeSeriesUniqueIds = new List<TimeSeriesUniqueIds>{};
-        }
-
         ///<summary>
         ///Token expired
         ///</summary>
@@ -8456,7 +8026,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Time series unique ids
         ///</summary>
         [ApiMember(DataType="array", Description="Time series unique ids")]
-        public List<TimeSeriesUniqueIds> TimeSeriesUniqueIds { get; set; }
+        public List<TimeSeriesUniqueIds> TimeSeriesUniqueIds { get; set; } = [];
     }
 
     public class TrendLineAnalysisServiceResponse
@@ -8472,16 +8042,11 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public class UnitListServiceResponse
         : PublishServiceResponse
     {
-        public UnitListServiceResponse()
-        {
-            Units = new List<UnitMetadata>{};
-        }
-
         ///<summary>
         ///Units
         ///</summary>
         [ApiMember(DataType="array", Description="Units")]
-        public List<UnitMetadata> Units { get; set; }
+        public List<UnitMetadata> Units { get; set; } = [];
     }
 
 }
@@ -8490,6 +8055,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("25.4.67.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("26.1.8.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2026-01-29 11:34:42
+Date: 2026-01-29 12:26:22
 Version: 10.04
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: https://aqwp-opendata.aquariusdev.net/AQUARIUS/Publish/v2
@@ -17,7 +17,7 @@ AddNullableAnnotations: False
 //AddGeneratedCodeAttributes: False
 //AddResponseStatus: False
 //AddImplicitVersion: 
-InitializeCollections: True
+InitializeCollections: False
 ExportValueTypes: True
 //IncludeTypes: 
 //ExcludeTypes: 
@@ -352,19 +352,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Periods of applicability
         ///</summary>
         [ApiMember(DataType="array", Description="Periods of applicability")]
-        public List<PeriodOfApplicability> PeriodsOfApplicability { get; set; } = [];
+        public List<PeriodOfApplicability> PeriodsOfApplicability { get; set; }
 
         ///<summary>
         ///Shifts
         ///</summary>
         [ApiMember(DataType="array", Description="Shifts")]
-        public List<RatingShift> Shifts { get; set; } = [];
+        public List<RatingShift> Shifts { get; set; }
 
         ///<summary>
         ///Offsets
         ///</summary>
         [ApiMember(DataType="array", Description="Offsets")]
-        public List<OffsetPoint> Offsets { get; set; } = [];
+        public List<OffsetPoint> Offsets { get; set; }
 
         ///<summary>
         ///Is blended
@@ -376,13 +376,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Base rating table
         ///</summary>
         [ApiMember(DataType="array", Description="Base rating table")]
-        public List<RatingPoint> BaseRatingTable { get; set; } = [];
+        public List<RatingPoint> BaseRatingTable { get; set; }
 
         ///<summary>
         ///Adjusted rating table
         ///</summary>
         [ApiMember(DataType="array", Description="Adjusted rating table")]
-        public List<RatingPoint> AdjustedRatingTable { get; set; } = [];
+        public List<RatingPoint> AdjustedRatingTable { get; set; }
     }
 
     public class ExtendedAttribute
@@ -612,7 +612,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Datum periods
         ///</summary>
         [ApiMember(DataType="array", Description="Datum periods")]
-        public List<LocationDatumPeriod> DatumPeriods { get; set; } = [];
+        public List<LocationDatumPeriod> DatumPeriods { get; set; }
     }
 
     public class LocationDatumPeriod
@@ -714,7 +714,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Secondary folders
         ///</summary>
         [ApiMember(DataType="array", Description="Secondary folders")]
-        public List<string> SecondaryFolders { get; set; } = [];
+        public List<string> SecondaryFolders { get; set; }
 
         ///<summary>
         ///Last modified
@@ -732,7 +732,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Tags
         ///</summary>
         [ApiMember(DataType="array", Description="Tags")]
-        public List<TagMetadata> Tags { get; set; } = [];
+        public List<TagMetadata> Tags { get; set; }
 
         ///<summary>
         ///Utc offset
@@ -843,7 +843,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Tags
         ///</summary>
         [ApiMember(DataType="array", Description="Tags")]
-        public List<TagMetadata> Tags { get; set; } = [];
+        public List<TagMetadata> Tags { get; set; }
     }
 
     public class LocationNote
@@ -894,7 +894,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Location note tags
         ///</summary>
         [ApiMember(DataType="array", Description="Location note tags")]
-        public List<TagMetadata> Tags { get; set; } = [];
+        public List<TagMetadata> Tags { get; set; }
 
         ///<summary>
         ///User who last modified this note
@@ -921,7 +921,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Reference standard offsets
         ///</summary>
         [ApiMember(DataType="array", Description="Reference standard offsets")]
-        public List<ReferenceStandardOffset> ReferenceStandardOffsets { get; set; } = [];
+        public List<ReferenceStandardOffset> ReferenceStandardOffsets { get; set; }
 
         ///<summary>
         ///Comments
@@ -1274,7 +1274,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Input time series unique ids
         ///</summary>
         [ApiMember(DataType="array", Description="Input time series unique ids")]
-        public List<Guid> InputTimeSeriesUniqueIds { get; set; } = [];
+        public List<Guid> InputTimeSeriesUniqueIds { get; set; }
 
         ///<summary>
         ///Output time series unique id
@@ -1300,7 +1300,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         [ApiMember(Description="Input rating model identifier")]
         public string InputRatingModelIdentifier { get; set; }
 
-        public Dictionary<string, string> Settings { get; set; } = new();
+        public Dictionary<string, string> Settings { get; set; }
     }
 
     public class Qualifier
@@ -1416,31 +1416,31 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Periods of applicability
         ///</summary>
         [ApiMember(DataType="array", Description="Periods of applicability")]
-        public List<PeriodOfApplicability> PeriodsOfApplicability { get; set; } = [];
+        public List<PeriodOfApplicability> PeriodsOfApplicability { get; set; }
 
         ///<summary>
         ///Shifts
         ///</summary>
         [ApiMember(DataType="array", Description="Shifts")]
-        public List<RatingShift> Shifts { get; set; } = [];
+        public List<RatingShift> Shifts { get; set; }
 
         ///<summary>
         ///Base rating table
         ///</summary>
         [ApiMember(DataType="array", Description="Base rating table")]
-        public List<RatingPoint> BaseRatingTable { get; set; } = [];
+        public List<RatingPoint> BaseRatingTable { get; set; }
 
         ///<summary>
         ///Offsets
         ///</summary>
         [ApiMember(DataType="array", Description="Offsets")]
-        public List<OffsetPoint> Offsets { get; set; } = [];
+        public List<OffsetPoint> Offsets { get; set; }
 
         ///<summary>
         ///Grade Ranges
         ///</summary>
         [ApiMember(DataType="array", Description="Grade Ranges")]
-        public List<RatingGrade> GradeRanges { get; set; } = [];
+        public List<RatingGrade> GradeRanges { get; set; }
     }
 
     public enum RatingCurveType
@@ -1570,7 +1570,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Shift points
         ///</summary>
         [ApiMember(DataType="array", Description="Shift points")]
-        public List<RatingShiftPoint> ShiftPoints { get; set; } = [];
+        public List<RatingShiftPoint> ShiftPoints { get; set; }
     }
 
     public class RatingShiftPoint
@@ -1642,7 +1642,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Periods of applicability
         ///</summary>
         [ApiMember(DataType="array", Description="Periods of applicability")]
-        public List<ReferencePointPeriod> ReferencePointPeriods { get; set; } = [];
+        public List<ReferencePointPeriod> ReferencePointPeriods { get; set; }
     }
 
     public class ReferencePointPeriod
@@ -1795,7 +1795,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Source time-series unique IDs
         ///</summary>
         [ApiMember(DataType="array", Description="Source time-series unique IDs")]
-        public List<Guid> SourceTimeSeriesUniqueIds { get; set; } = [];
+        public List<Guid> SourceTimeSeriesUniqueIds { get; set; }
 
         ///<summary>
         ///Location unique ID
@@ -1807,7 +1807,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Tags
         ///</summary>
         [ApiMember(DataType="array", Description="Tags")]
-        public List<TagMetadata> Tags { get; set; } = [];
+        public List<TagMetadata> Tags { get; set; }
 
         ///<summary>
         ///Report creator's user unique ID
@@ -1903,7 +1903,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Set of pick-list values if ValueType is PickList
         ///</summary>
         [ApiMember(DataType="array", Description="Set of pick-list values if ValueType is PickList")]
-        public List<string> PickListValues { get; set; } = [];
+        public List<string> PickListValues { get; set; }
 
         ///<summary>
         ///True if tag is applicable to Attachments
@@ -2734,7 +2734,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Periods
         ///</summary>
         [ApiMember(DataType="array", Description="Periods")]
-        public List<TimeSeriesThresholdPeriod> Periods { get; set; } = [];
+        public List<TimeSeriesThresholdPeriod> Periods { get; set; }
     }
 
     public class TimeSeriesThresholdPeriod
@@ -3210,7 +3210,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Tags
         ///</summary>
         [ApiMember(DataType="array", Description="Tags")]
-        public List<TagMetadata> Tags { get; set; } = [];
+        public List<TagMetadata> Tags { get; set; }
     }
 
     public class Calibration
@@ -3576,7 +3576,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Cross-section points
         ///</summary>
         [ApiMember(DataType="array", Description="Cross-section points")]
-        public List<CrossSectionPoint> CrossSectionPoints { get; set; } = [];
+        public List<CrossSectionPoint> CrossSectionPoints { get; set; }
     }
 
     public class CurrentMeter
@@ -3643,31 +3643,31 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Volumetric discharge activities
         ///</summary>
         [ApiMember(DataType="array", Description="Volumetric discharge activities")]
-        public List<VolumetricDischargeActivity> VolumetricDischargeActivities { get; set; } = [];
+        public List<VolumetricDischargeActivity> VolumetricDischargeActivities { get; set; }
 
         ///<summary>
         ///Engineered structure discharge activities
         ///</summary>
         [ApiMember(DataType="array", Description="Engineered structure discharge activities")]
-        public List<EngineeredStructureDischargeActivity> EngineeredStructureDischargeActivities { get; set; } = [];
+        public List<EngineeredStructureDischargeActivity> EngineeredStructureDischargeActivities { get; set; }
 
         ///<summary>
         ///Point velocity discharge activities
         ///</summary>
         [ApiMember(DataType="array", Description="Point velocity discharge activities")]
-        public List<PointVelocityDischargeActivity> PointVelocityDischargeActivities { get; set; } = [];
+        public List<PointVelocityDischargeActivity> PointVelocityDischargeActivities { get; set; }
 
         ///<summary>
         ///Other method discharge activities
         ///</summary>
         [ApiMember(DataType="array", Description="Other method discharge activities")]
-        public List<OtherMethodDischargeActivity> OtherMethodDischargeActivities { get; set; } = [];
+        public List<OtherMethodDischargeActivity> OtherMethodDischargeActivities { get; set; }
 
         ///<summary>
         ///Adcp discharge activities
         ///</summary>
         [ApiMember(DataType="array", Description="Adcp discharge activities")]
-        public List<AdcpDischargeActivity> AdcpDischargeActivities { get; set; } = [];
+        public List<AdcpDischargeActivity> AdcpDischargeActivities { get; set; }
     }
 
     public class DischargeChannelMeasurement
@@ -3901,7 +3901,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Gage height readings
         ///</summary>
         [ApiMember(DataType="array", Description="Gage height readings")]
-        public List<GageHeightReading> GageHeightReadings { get; set; } = [];
+        public List<GageHeightReading> GageHeightReadings { get; set; }
 
         ///<summary>
         ///Difference during visit
@@ -4025,13 +4025,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Attachments
         ///</summary>
         [ApiMember(DataType="array", Description="Attachments")]
-        public List<Attachment> Attachments { get; set; } = [];
+        public List<Attachment> Attachments { get; set; }
 
         ///<summary>
         ///Discharge activities
         ///</summary>
         [ApiMember(DataType="array", Description="Discharge activities")]
-        public List<DischargeActivity> DischargeActivities { get; set; } = [];
+        public List<DischargeActivity> DischargeActivities { get; set; }
 
         ///<summary>
         ///Gage height at zero flow activity
@@ -4055,7 +4055,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Cross-section survey activity
         ///</summary>
         [ApiMember(DataType="array", Description="Cross-section survey activity")]
-        public List<CrossSectionSurveyActivity> CrossSectionSurveyActivity { get; set; } = [];
+        public List<CrossSectionSurveyActivity> CrossSectionSurveyActivity { get; set; }
 
         ///<summary>
         ///Level survey activity
@@ -4079,7 +4079,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Hydraulic Test Activities
         ///</summary>
         [ApiMember(DataType="array", Description="Hydraulic Test Activities")]
-        public List<HydraulicTestActivity> HydraulicTestActivities { get; set; } = [];
+        public List<HydraulicTestActivity> HydraulicTestActivities { get; set; }
 
         ///<summary>
         ///Well integrity activity
@@ -4220,7 +4220,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Datum converted values where applicable.
         ///</summary>
         [ApiMember(DataType="array", Description="Datum converted values where applicable.")]
-        public List<DatumConvertedQuantityWithDisplay> DatumConvertedValues { get; set; } = [];
+        public List<DatumConvertedQuantityWithDisplay> DatumConvertedValues { get; set; }
 
         ///<summary>
         ///Parameter Name
@@ -4292,7 +4292,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Qualifiers
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifiers")]
-        public List<string> Qualifiers { get; set; } = [];
+        public List<string> Qualifiers { get; set; }
 
         ///<summary>
         ///Field visit reading type
@@ -4487,19 +4487,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///List of related time series unique ids
         ///</summary>
         [ApiMember(DataType="array", Description="List of related time series unique ids", Name="RelatedTimeSeriesUniqueIds")]
-        public List<Guid> RelatedTimeSeriesUniqueIds { get; set; } = [];
+        public List<Guid> RelatedTimeSeriesUniqueIds { get; set; }
 
         ///<summary>
         ///List of related field visit identifiers
         ///</summary>
         [ApiMember(DataType="array", Description="List of related field visit identifiers", Name="RelatedFieldVisitIdentifiers")]
-        public List<Guid> RelatedFieldVisitIdentifiers { get; set; } = [];
+        public List<Guid> RelatedFieldVisitIdentifiers { get; set; }
 
         ///<summary>
         ///List of hydraulic test results
         ///</summary>
         [ApiMember(DataType="array", Description="List of hydraulic test results", Name="Results")]
-        public List<HydraulicTestResult> Results { get; set; } = [];
+        public List<HydraulicTestResult> Results { get; set; }
 
         ///<summary>
         ///Additional comments or notes
@@ -4595,16 +4595,16 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
     public interface IFieldVisitData
     {
         string Identifier { get; set; }
-        List<Attachment> Attachments { get; set; } = [];
-        List<DischargeActivity> DischargeActivities { get; set; } = [];
+        List<Attachment> Attachments { get; set; }
+        List<DischargeActivity> DischargeActivities { get; set; }
         GageHeightAtZeroFlowActivity GageHeightAtZeroFlowActivity { get; set; }
         ControlConditionActivity ControlConditionActivity { get; set; }
         InspectionActivity InspectionActivity { get; set; }
-        List<CrossSectionSurveyActivity> CrossSectionSurveyActivity { get; set; } = [];
+        List<CrossSectionSurveyActivity> CrossSectionSurveyActivity { get; set; }
         LevelSurveyActivity LevelSurveyActivity { get; set; }
         FieldVisitApproval Approval { get; set; }
         DatumConversionResult DatumConversionResult { get; set; }
-        List<HydraulicTestActivity> HydraulicTestActivities { get; set; } = [];
+        List<HydraulicTestActivity> HydraulicTestActivities { get; set; }
         WellIntegrityActivity WellIntegrityActivity { get; set; }
     }
 
@@ -4665,7 +4665,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Readings
         ///</summary>
         [ApiMember(DataType="array", Description="Readings")]
-        public List<Reading> Readings { get; set; } = [];
+        public List<Reading> Readings { get; set; }
 
         ///<summary>
         ///Number of readings which could not be converted to the target datum
@@ -4677,13 +4677,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Calibration checks
         ///</summary>
         [ApiMember(DataType="array", Description="Calibration checks")]
-        public List<CalibrationCheck> CalibrationChecks { get; set; } = [];
+        public List<CalibrationCheck> CalibrationChecks { get; set; }
 
         ///<summary>
         ///Inspections
         ///</summary>
         [ApiMember(DataType="array", Description="Inspections")]
-        public List<Inspection> Inspections { get; set; } = [];
+        public List<Inspection> Inspections { get; set; }
 
         ///<summary>
         ///Is valid
@@ -4722,7 +4722,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Level survey measurements
         ///</summary>
         [ApiMember(DataType="array", Description="Level survey measurements")]
-        public List<LevelSurveyMeasurement> LevelMeasurements { get; set; } = [];
+        public List<LevelSurveyMeasurement> LevelMeasurements { get; set; }
     }
 
     public class LevelSurveyMeasurement
@@ -4962,7 +4962,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Verticals
         ///</summary>
         [ApiMember(DataType="array", Description="Verticals")]
-        public List<Vertical> Verticals { get; set; } = [];
+        public List<Vertical> Verticals { get; set; }
     }
 
     public class QuantityWithDisplay
@@ -5101,7 +5101,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Reading Qualifiers
         ///</summary>
         [ApiMember(DataType="array", Description="Reading Qualifiers")]
-        public List<string> ReadingQualifiers { get; set; } = [];
+        public List<string> ReadingQualifiers { get; set; }
 
         ///<summary>
         ///Groundwater measurements
@@ -5374,7 +5374,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Calibration
         ///</summary>
         [ApiMember(DataType="array", Description="Calibration")]
-        public List<Calibration> Calibrations { get; set; } = [];
+        public List<Calibration> Calibrations { get; set; }
     }
 
     public class VolumetricDischargeActivity
@@ -5389,7 +5389,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Volumetric discharge readings
         ///</summary>
         [ApiMember(DataType="array", Description="Volumetric discharge readings")]
-        public List<VolumetricDischargeReading> VolumetricDischargeReadings { get; set; } = [];
+        public List<VolumetricDischargeReading> VolumetricDischargeReadings { get; set; }
 
         ///<summary>
         ///Measurement container volume
@@ -5539,25 +5539,25 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///List of aquifer connections associated with the well
         ///</summary>
         [ApiMember(DataType="array", Description="List of aquifer connections associated with the well", Name="WellAquiferConnections")]
-        public List<WellAquiferConnection> WellAquiferConnections { get; set; } = [];
+        public List<WellAquiferConnection> WellAquiferConnections { get; set; }
 
         ///<summary>
         ///List of inspections performed on the well
         ///</summary>
         [ApiMember(DataType="array", Description="List of inspections performed on the well", Name="WellInspections")]
-        public List<WellInspection> WellInspections { get; set; } = [];
+        public List<WellInspection> WellInspections { get; set; }
 
         ///<summary>
         ///List of redevelopment activities for the well
         ///</summary>
         [ApiMember(DataType="array", Description="List of redevelopment activities for the well", Name="WellRedevelopments")]
-        public List<WellRedevelopment> WellRedevelopments { get; set; } = [];
+        public List<WellRedevelopment> WellRedevelopments { get; set; }
 
         ///<summary>
         ///List of repair activities performed on the well
         ///</summary>
         [ApiMember(DataType="array", Description="List of repair activities performed on the well", Name="WellRepairs")]
-        public List<WellRepair> WellRepairs { get; set; } = [];
+        public List<WellRepair> WellRepairs { get; set; }
     }
 
     public class WellRedevelopment
@@ -5632,7 +5632,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Equations
         ///</summary>
         [ApiMember(DataType="array", Description="Equations")]
-        public List<ActiveMeterCalibrationEquation> Equations { get; set; } = [];
+        public List<ActiveMeterCalibrationEquation> Equations { get; set; }
     }
 
     public class ActiveMeterCalibrationEquation
@@ -5671,7 +5671,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Meter calibrations
         ///</summary>
         [ApiMember(DataType="array", Description="Meter calibrations")]
-        public List<ActiveMeterCalibration> MeterCalibrations { get; set; } = [];
+        public List<ActiveMeterCalibration> MeterCalibrations { get; set; }
     }
 
     public enum ActivityType
@@ -6232,19 +6232,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///If set, only return specified activity types, selected from: Reading, Inspection, CalibrationCheck, DischargeSummary, DischargePointVelocity, DischargeVolumetric, DischargeEngineeredStructure, DischargeAdcp, DischargeOtherMethod, GageHeightAtZeroFlow, ControlCondition, CrossSectionSurvey, LevelSurvey, Attachment, HydraulicTest or WellIntegrity
         ///</summary>
         [ApiMember(AllowMultiple=true, DataType="array", Description="If set, only return specified activity types, selected from: Reading, Inspection, CalibrationCheck, DischargeSummary, DischargePointVelocity, DischargeVolumetric, DischargeEngineeredStructure, DischargeAdcp, DischargeOtherMethod, GageHeightAtZeroFlow, ControlCondition, CrossSectionSurvey, LevelSurvey, Attachment, HydraulicTest or WellIntegrity")]
-        public List<ActivityType> Activities { get; set; } = [];
+        public List<ActivityType> Activities { get; set; }
 
         ///<summary>
         ///If set, only return readings and calibrations of the specified parameters
         ///</summary>
         [ApiMember(DataType="array", Description="If set, only return readings and calibrations of the specified parameters")]
-        public List<string> Parameters { get; set; } = [];
+        public List<string> Parameters { get; set; }
 
         ///<summary>
         ///If set, only return inspections of the specified types, selected from: BubbleGage, CrestStageGage, WireWeightGage, MaximumMinimumGage, WaterQuality, FieldMeter, Other
         ///</summary>
         [ApiMember(AllowMultiple=true, DataType="array", Description="If set, only return inspections of the specified types, selected from: BubbleGage, CrestStageGage, WireWeightGage, MaximumMinimumGage, WaterQuality, FieldMeter, Other")]
-        public List<InspectionType> InspectionTypes { get; set; } = [];
+        public List<InspectionType> InspectionTypes { get; set; }
 
         ///<summary>
         ///True if node details (raw JSON of each specific activity) should be included
@@ -6292,7 +6292,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to items matching the given extended attribute values
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to items matching the given extended attribute values")]
-        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; } = [];
+        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; }
     }
 
     [Route("/GetFieldVisitData", "GET")]
@@ -6392,7 +6392,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to items matching the given extended attribute values
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to items matching the given extended attribute values")]
-        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; } = [];
+        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; }
     }
 
     [Route("/GetAuthToken", "GET")]
@@ -6438,7 +6438,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///If set, only return readings of the specified parameters
         ///</summary>
         [ApiMember(DataType="array", Description="If set, only return readings of the specified parameters")]
-        public List<string> Parameters { get; set; } = [];
+        public List<string> Parameters { get; set; }
 
         ///<summary>
         ///Filter results to items matching the Publish value
@@ -6525,25 +6525,25 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///DEPRECATED: renamed to TagKeys
         ///</summary>
         [ApiMember(DataType="array", Description="DEPRECATED: renamed to TagKeys")]
-        public List<string> TagNames { get; set; } = [];
+        public List<string> TagNames { get; set; }
 
         ///<summary>
         ///Filter results to locations matching all tags by key (supports *partialname* pattern)
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to locations matching all tags by key (supports *partialname* pattern)")]
-        public List<string> TagKeys { get; set; } = [];
+        public List<string> TagKeys { get; set; }
 
         ///<summary>
         ///Filter results to locations matching all tags by value (supports *partialname* pattern)
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to locations matching all tags by value (supports *partialname* pattern)")]
-        public List<string> TagValues { get; set; } = [];
+        public List<string> TagValues { get; set; }
 
         ///<summary>
         ///Filter results to items matching the given extended attribute values
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to items matching the given extended attribute values")]
-        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; } = [];
+        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; }
 
         ///<summary>
         ///Filter results to items matching the Publish value
@@ -6804,7 +6804,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to given source time series unique IDs
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to given source time series unique IDs")]
-        public List<Guid> TimeSeriesUniqueIds { get; set; } = [];
+        public List<Guid> TimeSeriesUniqueIds { get; set; }
 
         ///<summary>
         ///Filter results to the given user unique ID
@@ -6822,7 +6822,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to given report unique IDs
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to given report unique IDs")]
-        public List<Guid> ReportUniqueIds { get; set; } = [];
+        public List<Guid> ReportUniqueIds { get; set; }
 
         ///<summary>
         ///Filter results to items created at or after the CreatedFrom time
@@ -6834,13 +6834,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to items matching all tags by key (supports *partialname* pattern)
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to items matching all tags by key (supports *partialname* pattern)")]
-        public List<string> TagKeys { get; set; } = [];
+        public List<string> TagKeys { get; set; }
 
         ///<summary>
         ///Filter results to items matching all tags by value (supports *partialname* pattern)
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to items matching all tags by value (supports *partialname* pattern)")]
-        public List<string> TagValues { get; set; } = [];
+        public List<string> TagValues { get; set; }
 
         ///<summary>
         ///Limit the number of results items, after all filtering and ordering
@@ -6921,19 +6921,19 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to sensors and gauges for these locations. Limited to roughly 60 items for a GET request; use POST to avoid this limit.
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to sensors and gauges for these locations. Limited to roughly 60 items for a GET request; use POST to avoid this limit.")]
-        public List<Guid> LocationUniqueIds { get; set; } = [];
+        public List<Guid> LocationUniqueIds { get; set; }
 
         ///<summary>
         ///Filter results to sensors and gauges matching all tags by key (supports *partialname* pattern)
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to sensors and gauges matching all tags by key (supports *partialname* pattern)")]
-        public List<string> TagKeys { get; set; } = [];
+        public List<string> TagKeys { get; set; }
 
         ///<summary>
         ///Filter results to sensors and gauges matching all tags by value (supports *partialname* pattern)
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to sensors and gauges matching all tags by value (supports *partialname* pattern)")]
-        public List<string> TagValues { get; set; } = [];
+        public List<string> TagValues { get; set; }
     }
 
     [Route("/GetTagList", "GET")]
@@ -6944,7 +6944,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///If set, return only tags with specified applicability, selected from: AppliesToLocations, AppliesToLocationNotes, AppliesToSensorsGauges, AppliesToAttachments, AppliesToReports
         ///</summary>
         [ApiMember(AllowMultiple=true, DataType="array", Description="If set, return only tags with specified applicability, selected from: AppliesToLocations, AppliesToLocationNotes, AppliesToSensorsGauges, AppliesToAttachments, AppliesToReports")]
-        public List<TagApplicability> Applicability { get; set; } = [];
+        public List<TagApplicability> Applicability { get; set; }
     }
 
     [Route("/GetTimeSeriesData", "GET")]
@@ -6961,7 +6961,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///The unit identifiers for points. Defaults to the time-series unit
         ///</summary>
         [ApiMember(DataType="array", Description="The unit identifiers for points. Defaults to the time-series unit")]
-        public List<string> TimeSeriesOutputUnitIds { get; set; } = [];
+        public List<string> TimeSeriesOutputUnitIds { get; set; }
 
         ///<summary>
         ///Filter results to items at or after the QueryFrom time
@@ -7131,7 +7131,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///A collection of time series unique IDs to query. Limited to roughly 60 items for a GET request; use POST to avoid this limit.
         ///</summary>
         [ApiMember(DataType="array", Description="A collection of time series unique IDs to query. Limited to roughly 60 items for a GET request; use POST to avoid this limit.")]
-        public List<Guid> TimeSeriesUniqueIds { get; set; } = [];
+        public List<Guid> TimeSeriesUniqueIds { get; set; }
     }
 
     [Route("/GetTimeSeriesDescriptionList", "GET")]
@@ -7172,7 +7172,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to items matching the given extended attribute values
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to items matching the given extended attribute values")]
-        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; } = [];
+        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; }
     }
 
     [Route("/GetTimeSeriesUniqueIdList", "GET")]
@@ -7225,7 +7225,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Filter results to items matching the given extended attribute values
         ///</summary>
         [ApiMember(DataType="array", Description="Filter results to items matching the given extended attribute values")]
-        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; } = [];
+        public List<ExtendedAttributeFilter> ExtendedFilters { get; set; }
     }
 
     [Route("/GetTrendLineAnalysis", "POST")]
@@ -7298,7 +7298,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Current meter details
         ///</summary>
         [ApiMember(DataType="array", Description="Current meter details")]
-        public List<ActiveMeterDetails> ActiveMeterDetails { get; set; } = [];
+        public List<ActiveMeterDetails> ActiveMeterDetails { get; set; }
     }
 
     public class ApprovalListServiceResponse
@@ -7308,7 +7308,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Approvals
         ///</summary>
         [ApiMember(DataType="array", Description="Approvals")]
-        public List<ApprovalMetadata> Approvals { get; set; } = [];
+        public List<ApprovalMetadata> Approvals { get; set; }
     }
 
     public class CorrectionListServiceResponse
@@ -7318,7 +7318,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Corrections
         ///</summary>
         [ApiMember(DataType="array", Description="Corrections")]
-        public List<Correction> Corrections { get; set; } = [];
+        public List<Correction> Corrections { get; set; }
     }
 
     public class EffectiveRatingCurveServiceResponse
@@ -7338,13 +7338,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Expanded stage table
         ///</summary>
         [ApiMember(DataType="array", Description="Expanded stage table")]
-        public List<StagePoint> ExpandedStageTable { get; set; } = [];
+        public List<StagePoint> ExpandedStageTable { get; set; }
 
         ///<summary>
         ///Corrections
         ///</summary>
         [ApiMember(DataType="array", Description="Corrections")]
-        public List<Correction> Corrections { get; set; } = [];
+        public List<Correction> Corrections { get; set; }
     }
 
     public class FieldVisitDataByLocationServiceResponse
@@ -7354,7 +7354,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Field visit descriptions and data
         ///</summary>
         [ApiMember(DataType="array", Description="Field visit descriptions and data")]
-        public List<FieldVisit> FieldVisitData { get; set; } = [];
+        public List<FieldVisit> FieldVisitData { get; set; }
     }
 
     public class FieldVisitDataServiceResponse
@@ -7370,13 +7370,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Attachments
         ///</summary>
         [ApiMember(DataType="array", Description="Attachments")]
-        public List<Attachment> Attachments { get; set; } = [];
+        public List<Attachment> Attachments { get; set; }
 
         ///<summary>
         ///Discharge activities
         ///</summary>
         [ApiMember(DataType="array", Description="Discharge activities")]
-        public List<DischargeActivity> DischargeActivities { get; set; } = [];
+        public List<DischargeActivity> DischargeActivities { get; set; }
 
         ///<summary>
         ///Gage height at zero flow activity
@@ -7400,7 +7400,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Cross-section survey activity
         ///</summary>
         [ApiMember(DataType="array", Description="Cross-section survey activity")]
-        public List<CrossSectionSurveyActivity> CrossSectionSurveyActivity { get; set; } = [];
+        public List<CrossSectionSurveyActivity> CrossSectionSurveyActivity { get; set; }
 
         ///<summary>
         ///Level survey activity
@@ -7424,7 +7424,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Hydraulic Test Activities
         ///</summary>
         [ApiMember(DataType="array", Description="Hydraulic Test Activities")]
-        public List<HydraulicTestActivity> HydraulicTestActivities { get; set; } = [];
+        public List<HydraulicTestActivity> HydraulicTestActivities { get; set; }
 
         ///<summary>
         ///Well integrity activity
@@ -7446,13 +7446,13 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Field visit descriptions
         ///</summary>
         [ApiMember(DataType="array", Description="Field visit descriptions")]
-        public List<FieldVisitDescription> FieldVisitDescriptions { get; set; } = [];
+        public List<FieldVisitDescription> FieldVisitDescriptions { get; set; }
 
         ///<summary>
         ///Field visits that have been deleted since the requested ChangesSinceToken
         ///</summary>
         [ApiMember(DataType="array", Description="Field visits that have been deleted since the requested ChangesSinceToken")]
-        public List<FieldVisitDescription> DeletedFieldVisitDescriptions { get; set; } = [];
+        public List<FieldVisitDescription> DeletedFieldVisitDescriptions { get; set; }
 
         ///<summary>
         ///Next token
@@ -7468,7 +7468,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Field visit readings
         ///</summary>
         [ApiMember(DataType="array", Description="Field visit readings")]
-        public List<FieldVisitReading> FieldVisitReadings { get; set; } = [];
+        public List<FieldVisitReading> FieldVisitReadings { get; set; }
     }
 
     public class GradeListServiceResponse
@@ -7478,7 +7478,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Grades
         ///</summary>
         [ApiMember(DataType="array", Description="Grades")]
-        public List<GradeMetadata> Grades { get; set; } = [];
+        public List<GradeMetadata> Grades { get; set; }
     }
 
     public class LocationDataServiceResponse
@@ -7560,31 +7560,31 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Tags
         ///</summary>
         [ApiMember(DataType="array", Description="Tags")]
-        public List<TagMetadata> Tags { get; set; } = [];
+        public List<TagMetadata> Tags { get; set; }
 
         ///<summary>
         ///Extended attributes
         ///</summary>
         [ApiMember(DataType="array", Description="Extended attributes")]
-        public List<ExtendedAttribute> ExtendedAttributes { get; set; } = [];
+        public List<ExtendedAttribute> ExtendedAttributes { get; set; }
 
         ///<summary>
         ///Location remarks
         ///</summary>
         [ApiMember(DataType="array", Description="Location remarks")]
-        public List<LocationRemark> LocationRemarks { get; set; } = [];
+        public List<LocationRemark> LocationRemarks { get; set; }
 
         ///<summary>
         ///Location notes
         ///</summary>
         [ApiMember(DataType="array", Description="Location notes")]
-        public List<LocationNote> LocationNotes { get; set; } = [];
+        public List<LocationNote> LocationNotes { get; set; }
 
         ///<summary>
         ///Attachments
         ///</summary>
         [ApiMember(DataType="array", Description="Attachments")]
-        public List<Attachment> Attachments { get; set; } = [];
+        public List<Attachment> Attachments { get; set; }
 
         ///<summary>
         ///Location datum
@@ -7596,7 +7596,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Reference points
         ///</summary>
         [ApiMember(DataType="array", Description="Reference points")]
-        public List<ReferencePoint> ReferencePoints { get; set; } = [];
+        public List<ReferencePoint> ReferencePoints { get; set; }
 
         ///<summary>
         ///Property Bag
@@ -7612,7 +7612,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Location descriptions
         ///</summary>
         [ApiMember(DataType="array", Description="Location descriptions")]
-        public List<LocationDescription> LocationDescriptions { get; set; } = [];
+        public List<LocationDescription> LocationDescriptions { get; set; }
 
         ///<summary>
         ///Next token
@@ -7646,7 +7646,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Location notes
         ///</summary>
         [ApiMember(DataType="array", Description="Location notes")]
-        public List<LocationNote> LocationNotes { get; set; } = [];
+        public List<LocationNote> LocationNotes { get; set; }
     }
 
     public class MetadataChangeTransactionListServiceResponse
@@ -7683,7 +7683,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Monitoring methods
         ///</summary>
         [ApiMember(DataType="array", Description="Monitoring methods")]
-        public List<MonitoringMethod> MonitoringMethods { get; set; } = [];
+        public List<MonitoringMethod> MonitoringMethods { get; set; }
     }
 
     public class ParameterListServiceResponse
@@ -7693,7 +7693,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Parameters
         ///</summary>
         [ApiMember(DataType="array", Description="Parameters")]
-        public List<ParameterMetadata> Parameters { get; set; } = [];
+        public List<ParameterMetadata> Parameters { get; set; }
     }
 
     public class ProcessorListServiceResponse
@@ -7703,7 +7703,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Processors
         ///</summary>
         [ApiMember(DataType="array", Description="Processors")]
-        public List<Processor> Processors { get; set; } = [];
+        public List<Processor> Processors { get; set; }
     }
 
     public class PublishServiceResponse
@@ -7734,7 +7734,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Qualifiers
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifiers")]
-        public List<QualifierMetadata> Qualifiers { get; set; } = [];
+        public List<QualifierMetadata> Qualifiers { get; set; }
     }
 
     public class RatingCurveListServiceResponse
@@ -7782,7 +7782,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Effective shift values
         ///</summary>
         [ApiMember(DataType="array", Description="Effective shift values")]
-        public List<Nullable<Double>> EffectiveShiftValues { get; set; } = [];
+        public List<Nullable<Double>> EffectiveShiftValues { get; set; }
     }
 
     public class RatingModelEffectiveShiftsServiceResponse
@@ -7792,7 +7792,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Effective shifts
         ///</summary>
         [ApiMember(DataType="array", Description="Effective shifts")]
-        public List<EffectiveShift> EffectiveShifts { get; set; } = [];
+        public List<EffectiveShift> EffectiveShifts { get; set; }
     }
 
     public class RatingModelInputValuesServiceResponse
@@ -7802,7 +7802,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Input values
         ///</summary>
         [ApiMember(DataType="array", Description="Input values")]
-        public List<Nullable<Double>> InputValues { get; set; } = [];
+        public List<Nullable<Double>> InputValues { get; set; }
     }
 
     public class RatingModelOutputValuesServiceResponse
@@ -7812,7 +7812,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Output values
         ///</summary>
         [ApiMember(DataType="array", Description="Output values")]
-        public List<Nullable<Double>> OutputValues { get; set; } = [];
+        public List<Nullable<Double>> OutputValues { get; set; }
     }
 
     public class ReportListServiceResponse
@@ -7822,7 +7822,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Reports
         ///</summary>
         [ApiMember(DataType="array", Description="Reports")]
-        public List<Report> Reports { get; set; } = [];
+        public List<Report> Reports { get; set; }
     }
 
     public class RoundServiceResponse
@@ -7832,7 +7832,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Values rounded as requested
         ///</summary>
         [ApiMember(DataType="array", Description="Values rounded as requested")]
-        public List<string> Data { get; set; } = [];
+        public List<string> Data { get; set; }
     }
 
     public class SensorsAndGaugesServiceResponse
@@ -7842,7 +7842,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Monitoring methods
         ///</summary>
         [ApiMember(DataType="array", Description="Monitoring methods")]
-        public List<LocationMonitoringMethod> MonitoringMethods { get; set; } = [];
+        public List<LocationMonitoringMethod> MonitoringMethods { get; set; }
     }
 
     public class TagListServiceResponse
@@ -7852,7 +7852,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Tags
         ///</summary>
         [ApiMember(DataType="array", Description="Tags")]
-        public List<TagDefinition> Tags { get; set; } = [];
+        public List<TagDefinition> Tags { get; set; }
     }
 
     public class TimeAlignedDataServiceResponse
@@ -7862,7 +7862,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Summary info of the retrieved time-series
         ///</summary>
         [ApiMember(DataType="array", Description="Summary info of the retrieved time-series")]
-        public List<TimeAlignedTimeSeriesInfo> TimeSeries { get; set; } = [];
+        public List<TimeAlignedTimeSeriesInfo> TimeSeries { get; set; }
 
         ///<summary>
         ///Time range
@@ -7880,7 +7880,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Points
         ///</summary>
         [ApiMember(DataType="array", Description="Points")]
-        public List<TimeAlignedPoint> Points { get; set; } = [];
+        public List<TimeAlignedPoint> Points { get; set; }
     }
 
     public class TimeSeriesApprovalsTransactionListServiceResponse
@@ -7936,43 +7936,43 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Approvals
         ///</summary>
         [ApiMember(DataType="array", Description="Approvals")]
-        public List<Approval> Approvals { get; set; } = [];
+        public List<Approval> Approvals { get; set; }
 
         ///<summary>
         ///Qualifiers
         ///</summary>
         [ApiMember(DataType="array", Description="Qualifiers")]
-        public List<Qualifier> Qualifiers { get; set; } = [];
+        public List<Qualifier> Qualifiers { get; set; }
 
         ///<summary>
         ///Methods
         ///</summary>
         [ApiMember(DataType="array", Description="Methods")]
-        public List<Method> Methods { get; set; } = [];
+        public List<Method> Methods { get; set; }
 
         ///<summary>
         ///Grades
         ///</summary>
         [ApiMember(DataType="array", Description="Grades")]
-        public List<Grade> Grades { get; set; } = [];
+        public List<Grade> Grades { get; set; }
 
         ///<summary>
         ///Gap tolerances
         ///</summary>
         [ApiMember(DataType="array", Description="Gap tolerances")]
-        public List<GapTolerance> GapTolerances { get; set; } = [];
+        public List<GapTolerance> GapTolerances { get; set; }
 
         ///<summary>
         ///Interpolation types
         ///</summary>
         [ApiMember(DataType="array", Description="Interpolation types")]
-        public List<InterpolationType> InterpolationTypes { get; set; } = [];
+        public List<InterpolationType> InterpolationTypes { get; set; }
 
         ///<summary>
         ///Notes
         ///</summary>
         [ApiMember(DataType="array", Description="Notes")]
-        public List<Note> Notes { get; set; } = [];
+        public List<Note> Notes { get; set; }
 
         ///<summary>
         ///Time range
@@ -7984,7 +7984,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Points
         ///</summary>
         [ApiMember(DataType="array", Description="Points")]
-        public List<TimeSeriesPoint> Points { get; set; } = [];
+        public List<TimeSeriesPoint> Points { get; set; }
     }
 
     public class TimeSeriesDescriptionListByUniqueIdServiceResponse
@@ -7994,7 +7994,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Time series descriptions
         ///</summary>
         [ApiMember(DataType="array", Description="Time series descriptions")]
-        public List<TimeSeriesDescription> TimeSeriesDescriptions { get; set; } = [];
+        public List<TimeSeriesDescription> TimeSeriesDescriptions { get; set; }
     }
 
     public class TimeSeriesDescriptionListServiceResponse
@@ -8004,7 +8004,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Time series descriptions
         ///</summary>
         [ApiMember(DataType="array", Description="Time series descriptions")]
-        public List<TimeSeriesDescription> TimeSeriesDescriptions { get; set; } = [];
+        public List<TimeSeriesDescription> TimeSeriesDescriptions { get; set; }
     }
 
     public class TimeSeriesUniqueIdListServiceResponse
@@ -8026,7 +8026,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Time series unique ids
         ///</summary>
         [ApiMember(DataType="array", Description="Time series unique ids")]
-        public List<TimeSeriesUniqueIds> TimeSeriesUniqueIds { get; set; } = [];
+        public List<TimeSeriesUniqueIds> TimeSeriesUniqueIds { get; set; }
     }
 
     public class TrendLineAnalysisServiceResponse
@@ -8046,7 +8046,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Units
         ///</summary>
         [ApiMember(DataType="array", Description="Units")]
-        public List<UnitMetadata> Units { get; set; } = [];
+        public List<UnitMetadata> Units { get; set; }
     }
 
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
@@ -1,5 +1,5 @@
 /* Options:
-Date: 2026-01-29 12:26:22
+Date: 2026-01-29 13:26:32
 Version: 10.04
 Tip: To override a DTO option, remove "//" prefix before updating
 BaseUrl: https://aqwp-opendata.aquariusdev.net/AQUARIUS/Publish/v2
@@ -6706,7 +6706,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///The input stage values to which the shift is to be applied
         ///</summary>
         [ApiMember(DataType="array", Description="The input stage values to which the shift is to be applied", IsRequired=true)]
-        public List<double> StageValues { get; set; } = [];
+        public List<double> StageValues { get; set; }
     }
 
     [Route("/GetRatingModelEffectiveShifts", "GET")]
@@ -6752,7 +6752,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Output values
         ///</summary>
         [ApiMember(DataType="array", Description="Output values", IsRequired=true)]
-        public List<double> OutputValues { get; set; } = [];
+        public List<double> OutputValues { get; set; }
 
         ///<summary>
         ///Effective time of the calculation. Defaults to the current time if not specified
@@ -6775,7 +6775,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///Input values
         ///</summary>
         [ApiMember(DataType="array", Description="Input values", IsRequired=true)]
-        public List<double> InputValues { get; set; } = [];
+        public List<double> InputValues { get; set; }
 
         ///<summary>
         ///Effective time of the calculation. Defaults to the current time if not specified
@@ -6881,7 +6881,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///A list of data values to be rounded and returned as strings
         ///</summary>
         [ApiMember(DataType="array", Description="A list of data values to be rounded and returned as strings", IsRequired=true)]
-        public List<double> Data { get; set; } = [];
+        public List<double> Data { get; set; }
     }
 
     [Route("/Round/ToSpec", "PUT")]
@@ -6904,7 +6904,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///A list of data values to be rounded and returned as strings
         ///</summary>
         [ApiMember(DataType="array", Description="A list of data values to be rounded and returned as strings", IsRequired=true)]
-        public List<double> Data { get; set; } = [];
+        public List<double> Data { get; set; }
     }
 
     [Route("/GetSensorsAndGauges", "GET,POST")]
@@ -6955,7 +6955,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///The unique IDs of the time-series to retrieve
         ///</summary>
         [ApiMember(DataType="array", Description="The unique IDs of the time-series to retrieve", IsRequired=true)]
-        public List<Guid> TimeSeriesUniqueIds { get; set; } = [];
+        public List<Guid> TimeSeriesUniqueIds { get; set; }
 
         ///<summary>
         ///The unit identifiers for points. Defaults to the time-series unit
@@ -7254,7 +7254,7 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
         ///List of data points to perform analysis on. Requires a minimum of three points, and points sorted by timestamp in ascending order. Must not contain any duplicate times.
         ///</summary>
         [ApiMember(DataType="array", Description="List of data points to perform analysis on. Requires a minimum of three points, and points sorted by timestamp in ascending order. Must not contain any duplicate times.", IsRequired=true)]
-        public List<TimeSeriesPoint> Points { get; set; } = [];
+        public List<TimeSeriesPoint> Points { get; set; }
     }
 
     [Route("/GetUnitList", "GET")]

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceStackConfig.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceStackConfig.cs
@@ -98,6 +98,9 @@ namespace Aquarius.TimeSeries.Client
             JsConfig<Offset>.DeSerializeFn = DeserializeOffset;
             JsConfig<Offset>.IncludeDefaultValue = true;
 
+            JsConfig<Offset?>.RawSerializeFn = SerializeOffset;
+            JsConfig<Offset?>.DeSerializeFn = DeserializeNullableOffset;
+
             JsConfig<ObjectId>.SerializeFn = id => id.ToString();
             JsConfig<ObjectId>.DeSerializeFn = s => new ObjectId(long.Parse(s, CultureInfo.InvariantCulture));
 
@@ -397,8 +400,21 @@ namespace Aquarius.TimeSeries.Client
             return value.ToTimeSpan().SerializeToString();
         }
 
+        private static string SerializeOffset(Offset? value)
+        {
+            return value?.ToTimeSpan().SerializeToString();
+        }
+
         private static Offset DeserializeOffset(string text)
         {
+            return Offset.FromTicks(text.FromJson<TimeSpan>().Ticks);
+        }
+
+        private static Offset? DeserializeNullableOffset(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return null;
+
             return Offset.FromTicks(text.FromJson<TimeSpan>().Ticks);
         }
 

--- a/src/Aquarius.Client/TimeSeries/Client/generate_code_from_live_endpoint.sh
+++ b/src/Aquarius.Client/TimeSeries/Client/generate_code_from_live_endpoint.sh
@@ -37,7 +37,7 @@ ApiVersion=`echo "$ApiVersionJson" | sed -e "s/{\"ApiVersion\":\"//" -e "s/\"}//
 
 echo "Generating $OutputFile ..."
 OutputFile=$OutputPath/$EndPointName.cs
-curl -s -o "$OutputFile" "$ServerName/AQUARIUS/$EndPoint/types/csharp?MakePartial=false&MakeVirtual=false&AddNullableAnnotations=false&InitializeCollections=true&ExportValueTypes=true&GlobalNamespace=$GlobalNamespace&DefaultNamespaces=System,System.Collections.Generic,ServiceStack,ServiceStack.DataAnnotations,ServiceStack.Web,NodaTime" || exit_abort "Can't read endpoint"
+curl -s -o "$OutputFile" "$ServerName/AQUARIUS/$EndPoint/types/csharp?MakePartial=false&MakeVirtual=false&AddNullableAnnotations=false&InitializeCollections=false&ExportValueTypes=true&GlobalNamespace=$GlobalNamespace&DefaultNamespaces=System,System.Collections.Generic,ServiceStack,ServiceStack.DataAnnotations,ServiceStack.Web,NodaTime" || exit_abort "Can't read endpoint"
 
 # 2021.1 added a hidden IFileUploadRequest.IsFileRequired property with [ApiMember(ExcludeInSchema = true)][IgnoreDataMember] attributes.
 # The built-in ServiceStack code generator endpoint doesn't respect these attributes.

--- a/src/Aquarius.Client/TimeSeries/Client/generate_code_from_live_endpoint.sh
+++ b/src/Aquarius.Client/TimeSeries/Client/generate_code_from_live_endpoint.sh
@@ -44,6 +44,8 @@ curl -s -o "$OutputFile" "$ServerName/AQUARIUS/$EndPoint/types/csharp?MakePartia
 # So we need to manually detect and remove the IsFileRequired property so that everything compiles.
 # This blunt-hammer approach works for 2021.1, but may need to be revisited if a property of the same name ever needs to exist in the API
 sed -i.bak -e "s/        bool IsFileRequired { get; set; }/        \\/\\/ HACK from generate_code_from_live_endpoint.sh \\/\\/ bool IsFileRequired { get; set; }/" "$OutputFile"
+# 2026.1 InitializeCollections=false doesn't work for 100% of collections, need to remove some code manually
+sed -i.bak -e 's/ = \[\];//g' "$OutputFile"
 
 # Append the generated version to the code
 echo "namespace $GlobalNamespace" >> "$OutputFile"

--- a/src/Aquarius.Client/TimeSeries/Client/generate_code_from_live_endpoint.sh
+++ b/src/Aquarius.Client/TimeSeries/Client/generate_code_from_live_endpoint.sh
@@ -37,7 +37,7 @@ ApiVersion=`echo "$ApiVersionJson" | sed -e "s/{\"ApiVersion\":\"//" -e "s/\"}//
 
 echo "Generating $OutputFile ..."
 OutputFile=$OutputPath/$EndPointName.cs
-curl -s -o "$OutputFile" "$ServerName/AQUARIUS/$EndPoint/types/csharp?MakePartial=false&MakeVirtual=false&ExportValueTypes=true&GlobalNamespace=$GlobalNamespace&DefaultNamespaces=System,System.Collections.Generic,ServiceStack,ServiceStack.DataAnnotations,ServiceStack.Web,NodaTime" || exit_abort "Can't read endpoint"
+curl -s -o "$OutputFile" "$ServerName/AQUARIUS/$EndPoint/types/csharp?MakePartial=false&MakeVirtual=false&AddNullableAnnotations=false&InitializeCollections=true&ExportValueTypes=true&GlobalNamespace=$GlobalNamespace&DefaultNamespaces=System,System.Collections.Generic,ServiceStack,ServiceStack.DataAnnotations,ServiceStack.Web,NodaTime" || exit_abort "Can't read endpoint"
 
 # 2021.1 added a hidden IFileUploadRequest.IsFileRequired property with [ApiMember(ExcludeInSchema = true)][IgnoreDataMember] attributes.
 # The built-in ServiceStack code generator endpoint doesn't respect these attributes.


### PR DESCRIPTION
this fixes the major changes that came up with #221 auto-generated pr. i've run the generate code script to show how the auto-generated c# code looks

`AddNullableAnnotations` is a new field true by default, we want it false to avoid massively changing the file (adding `?` to most fields). 
`InitializeCollections` defaulted to true, but now defaults to false, so had to be set - the way it initialises collections is different, but shouldn't be a material change.
