### PR TITLE
AT-2035: Fix SetTimeout not applied in ServiceStack async path

### DIFF
--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/SetTimeoutTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/SetTimeoutTests.cs
@@ -112,6 +112,7 @@ namespace Aquarius.Client.UnitTests.TimeSeries.Client
         {
             var serviceClient = new JsonServiceClient("http://localhost");
             var defaultTimeout = 100000; // .NET default HttpWebRequest.Timeout
+            var defaultReadWriteTimeout = 300000; // .NET default HttpWebRequest.ReadWriteTimeout
 
             _client.SetTimeout(serviceClient, null, null);
 
@@ -119,6 +120,7 @@ namespace Aquarius.Client.UnitTests.TimeSeries.Client
             serviceClient.RequestFilter(request);
 
             request.Timeout.Should().Be(defaultTimeout);
+            request.ReadWriteTimeout.Should().Be(defaultReadWriteTimeout);
         }
 
         [Test]

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/SetTimeoutTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/SetTimeoutTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Net;
+using Aquarius.TimeSeries.Client;
+using Aquarius.TimeSeries.Client.Helpers;
+using FluentAssertions;
+using NUnit.Framework;
+using ServiceStack;
+
+namespace Aquarius.Client.UnitTests.TimeSeries.Client
+{
+    [TestFixture]
+    public class SetTimeoutTests
+    {
+        private AquariusClient _client;
+
+        [SetUp]
+        public void BeforeEachTest()
+        {
+            _client = new AquariusClient(AuthenticationType.Credential)
+            {
+                ServerVersion = AquariusServerVersion.Create("0")
+            };
+        }
+
+        [Test]
+        public void SetTimeout_WithRequestTimeout_SetsTimeoutProperty()
+        {
+            var serviceClient = new JsonServiceClient("http://localhost");
+            var timeout = TimeSpan.FromSeconds(300);
+
+            _client.SetTimeout(serviceClient, timeout, null);
+
+            serviceClient.Timeout.Should().Be(timeout);
+        }
+
+        [Test]
+        public void SetTimeout_WithReadWriteTimeout_SetsReadWriteTimeoutProperty()
+        {
+            var serviceClient = new JsonServiceClient("http://localhost");
+            var readWriteTimeout = TimeSpan.FromSeconds(600);
+
+            _client.SetTimeout(serviceClient, null, readWriteTimeout);
+
+            serviceClient.ReadWriteTimeout.Should().Be(readWriteTimeout);
+        }
+
+        [Test]
+        public void SetTimeout_WithRequestTimeout_SetsRequestFilterThatAppliesToHttpWebRequest()
+        {
+            var serviceClient = new JsonServiceClient("http://localhost");
+            var timeout = TimeSpan.FromSeconds(300);
+
+            _client.SetTimeout(serviceClient, timeout, null);
+
+            serviceClient.RequestFilter.Should().NotBeNull();
+
+            var request = WebRequest.CreateHttp("http://localhost");
+            serviceClient.RequestFilter(request);
+
+            request.Timeout.Should().Be((int)timeout.TotalMilliseconds);
+        }
+
+        [Test]
+        public void SetTimeout_WithReadWriteTimeout_SetsRequestFilterThatAppliesReadWriteToHttpWebRequest()
+        {
+            var serviceClient = new JsonServiceClient("http://localhost");
+            var readWriteTimeout = TimeSpan.FromSeconds(600);
+
+            _client.SetTimeout(serviceClient, null, readWriteTimeout);
+
+            serviceClient.RequestFilter.Should().NotBeNull();
+
+            var request = WebRequest.CreateHttp("http://localhost");
+            serviceClient.RequestFilter(request);
+
+            request.ReadWriteTimeout.Should().Be((int)readWriteTimeout.TotalMilliseconds);
+        }
+
+        [Test]
+        public void SetTimeout_WithBothTimeouts_SetsBothOnHttpWebRequest()
+        {
+            var serviceClient = new JsonServiceClient("http://localhost");
+            var timeout = TimeSpan.FromSeconds(300);
+            var readWriteTimeout = TimeSpan.FromSeconds(600);
+
+            _client.SetTimeout(serviceClient, timeout, readWriteTimeout);
+
+            var request = WebRequest.CreateHttp("http://localhost");
+            serviceClient.RequestFilter(request);
+
+            request.Timeout.Should().Be((int)timeout.TotalMilliseconds);
+            request.ReadWriteTimeout.Should().Be((int)readWriteTimeout.TotalMilliseconds);
+        }
+
+        [Test]
+        public void SetTimeout_PreservesExistingRequestFilter()
+        {
+            var serviceClient = new JsonServiceClient("http://localhost");
+            var existingFilterCalled = false;
+            serviceClient.RequestFilter = _ => existingFilterCalled = true;
+
+            _client.SetTimeout(serviceClient, TimeSpan.FromSeconds(300), null);
+
+            var request = WebRequest.CreateHttp("http://localhost");
+            serviceClient.RequestFilter(request);
+
+            existingFilterCalled.Should().BeTrue();
+        }
+
+        [Test]
+        public void SetTimeout_WithNullTimeouts_DoesNotSetTimeoutOnHttpWebRequest()
+        {
+            var serviceClient = new JsonServiceClient("http://localhost");
+            var defaultTimeout = 100000; // .NET default HttpWebRequest.Timeout
+
+            _client.SetTimeout(serviceClient, null, null);
+
+            var request = WebRequest.CreateHttp("http://localhost");
+            serviceClient.RequestFilter(request);
+
+            request.Timeout.Should().Be(defaultTimeout);
+        }
+
+        [Test]
+        public void SetTimeout_WithNonServiceClientBase_DoesNotThrow()
+        {
+            var mockClient = NSubstitute.Substitute.For<IServiceClient>();
+
+            Assert.DoesNotThrow(() => _client.SetTimeout(mockClient, TimeSpan.FromSeconds(300), null));
+        }
+    }
+}

--- a/src/Aquarius.Client/TimeSeries/Client/AquariusClient.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/AquariusClient.cs
@@ -130,13 +130,31 @@ namespace Aquarius.TimeSeries.Client
 
         public void SetTimeout(IServiceClient client, TimeSpan? requestTimeout, TimeSpan? readWriteTimeout)
         {
-            if (client is JsonServiceClient jsonServiceClient)
+            if (client is ServiceClientBase serviceClient)
             {
                 if (requestTimeout.HasValue)
-                    jsonServiceClient.Timeout = requestTimeout.Value;
+                    serviceClient.Timeout = requestTimeout.Value;
 
                 if (readWriteTimeout.HasValue)
-                    jsonServiceClient.ReadWriteTimeout = readWriteTimeout.Value;
+                    serviceClient.ReadWriteTimeout = readWriteTimeout.Value;
+
+                var timeoutMs = requestTimeout.HasValue
+                    ? (int)requestTimeout.Value.TotalMilliseconds
+                    : (int?)null;
+
+                var readWriteTimeoutMs = readWriteTimeout.HasValue
+                    ? (int)readWriteTimeout.Value.TotalMilliseconds
+                    : (int?)null;
+
+                var existingFilter = serviceClient.RequestFilter;
+                serviceClient.RequestFilter = req =>
+                {
+                    existingFilter?.Invoke(req);
+                    if (timeoutMs.HasValue)
+                        req.Timeout = timeoutMs.Value;
+                    if (readWriteTimeoutMs.HasValue)
+                        req.ReadWriteTimeout = readWriteTimeoutMs.Value;
+                };
             }
         }
 


### PR DESCRIPTION
## Problem

`AquariusClient.SetTimeout` sets `ServiceClientBase.Timeout` and `ReadWriteTimeout` properties, but ServiceStack has a bug where `AsyncServiceClient.SendWebRequestAsync` calls `PclExport.Instance.Config()` without passing timeout parameters. The sync path (`ServiceClientBase.PrepareWebRequest`) correctly passes the configured values, but the async path does not.

This means `HttpWebRequest.Timeout` stays at the .NET default of 100s for all async requests, regardless of what timeout was configured via `SetTimeout`.

## Fix

Add a `RequestFilter` in `SetTimeout` that applies the timeout values directly on the `HttpWebRequest`. `ApplyWebRequestFilters` is called in the async path, so this bypasses the ServiceStack limitation. Existing request filters are preserved by composing with the new filter.

Also widens the type check from `JsonServiceClient` to `ServiceClientBase` so the fix applies to all ServiceStack client types.

## References

- [ServiceStack forum: Timeout of 100 seconds when using SendAll](https://forums.servicestack.net/t/timeout-of-100-seconds-when-using-sendall-in-a-net-core-projet/9664)
- [ServiceStack forum: JsonApiClient vs JsonServiceClient](https://forums.servicestack.net/t/jsonapiclient-vs-jsonserviceclient/10509)
- [GitHub Discussion: Why doesn't JsonServiceClient use HttpClient?](https://github.com/ServiceStack/Discuss/discussions/103)
- [ServiceStack docs: C#/.NET Service Clients](https://docs.servicestack.net/csharp-client)
- [ServiceStack source: AsyncUtils.cs (master)](https://github.com/ServiceStack/ServiceStack/blob/master/src/ServiceStack.Client/AsyncUtils.cs)
- [ServiceStack source: AsyncServiceClient.cs (master)](https://github.com/ServiceStack/ServiceStack/blob/master/src/ServiceStack.Client/AsyncServiceClient.cs)