### PR TITLE
Auto-update Time-Series .NET SDK

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,9 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
+### 2x.x.x
+- Updated the service models for the AQUARIUS Time-Series 202x.x release.
+
 ### 25.4.2
 - Collections are no longer initialized by default. When creating an API object directly collections won't be initalized but appear to be done so when binding through an API request.
 - Fixes a bug where Provisioning Locations POST/PUT methods failed on the UtcOffset field

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,8 +4,8 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
-### 2x.x.x
-- Updated the service models for the AQUARIUS Time-Series 202x.x release.
+### 26.1.0
+- Updated the service models for the AQUARIUS Time-Series 2026.1 release.
 
 ### 25.4.2
 - Collections are no longer initialized by default. When creating an API object directly collections won't be initalized but appear to be done so when binding through an API request.

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Acquisition.cs
@@ -1,8 +1,8 @@
 /* Options:
-Date: 2026-01-29 13:26:44
+Date: 2026-04-02 22:03:48
 Version: 10.04
 Tip: To override a DTO option, remove "//" prefix before updating
-BaseUrl: https://aqwp-opendata.aquariusdev.net/AQUARIUS/Acquisition/v2
+BaseUrl: https://develop-1.dev.aquariusdev.net/AQUARIUS/Acquisition/v2
 
 GlobalNamespace: Aquarius.TimeSeries.Client.ServiceModels.Acquisition
 MakePartial: False
@@ -678,6 +678,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Acquisition
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("26.1.8.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("26.1.68.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Provisioning.cs
@@ -1,8 +1,8 @@
 /* Options:
-Date: 2026-01-29 13:26:38
+Date: 2026-04-02 22:03:47
 Version: 10.04
 Tip: To override a DTO option, remove "//" prefix before updating
-BaseUrl: https://aqwp-opendata.aquariusdev.net/AQUARIUS/Provisioning/v1
+BaseUrl: https://develop-1.dev.aquariusdev.net/AQUARIUS/Provisioning/v1
 
 GlobalNamespace: Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 MakePartial: False
@@ -6429,6 +6429,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Provisioning
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("26.1.8.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("26.1.68.0");
     }
 }

--- a/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
+++ b/src/Aquarius.Client/TimeSeries/Client/ServiceModels/Publish.cs
@@ -1,8 +1,8 @@
 /* Options:
-Date: 2026-01-29 13:26:32
+Date: 2026-04-02 22:03:45
 Version: 10.04
 Tip: To override a DTO option, remove "//" prefix before updating
-BaseUrl: https://aqwp-opendata.aquariusdev.net/AQUARIUS/Publish/v2
+BaseUrl: https://develop-1.dev.aquariusdev.net/AQUARIUS/Publish/v2
 
 GlobalNamespace: Aquarius.TimeSeries.Client.ServiceModels.Publish
 MakePartial: False
@@ -8055,6 +8055,6 @@ namespace Aquarius.TimeSeries.Client.ServiceModels.Publish
 {
     public static class Current
     {
-        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("26.1.8.0");
+        public static readonly AquariusServerVersion Version = AquariusServerVersion.Create("26.1.68.0");
     }
 }


### PR DESCRIPTION
Automatic PR to update the Time-Series .NET SDK. Manually push a commit to update the ReleaseNotes.md file, and update the version in AppVeyor, before merging.<br><br>Companion Java SDK update at: https://github.com/AquaticInformatics/aquarius-sdk-java/pulls/