### PR TITLE
AT-2257: Update SDK to dual-target net10.0 and net472/netstandard2.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ please read the [code of conduct](CODE_OF_CONDUCT.md).
 
 ## Setup
 
-1. Install Visual Studio 2017+ on your system (Community Edition should be fine): https://www.visualstudio.com/
+1. Install Visual Studio 2022+ on your system (Community Edition should be fine): https://www.visualstudio.com/
 1. Fork the repo: https://github.com/AquaticInformatics/aquarius-sdk-net
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ View the [Release Notes](ReleaseNotes.md) here.
 
 ## Building from source
 
-Requires Visual Studio 2017+ (Community Edition is fine.)
+Requires Visual Studio 2022+ (Community Edition is fine.)
 
 See the [Contributing](CONTRIBUTING.md) page for details.
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,9 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-net/compare/v17.2.21...v17.2.25) to see the full source code difference.
 
+### 26.2.0
+- Added .NET 10.0 support, replacing .NET 8.0. The SDK now dual-targets `net472`/`netstandard2.1` and `net10.0`.
+
 ### 26.1.0
 - Updated the service models for the AQUARIUS Time-Series 2026.1 release.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,6 @@ image: Visual Studio 2022
 platform: Any CPU
 configuration: Release
 
-shallow_clone: true
 skip_tags: true
 
 pull_requests:
@@ -30,11 +29,6 @@ dotnet_csproj:
   assembly_version: "1.0.0.0"
   file_version: '{version}'
   informational_version: '{version}'
-  
-install:
-  - ps: |
-      Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -OutFile dotnet-install.ps1
-      .\dotnet-install.ps1 -Channel 10.0 -InstallDir "$env:ProgramFiles\dotnet"
 
 init:
   - ps: |
@@ -42,11 +36,20 @@ init:
         $env:IS_NOT_PR = "true"
       }
 
+install:
+  - ps: |
+      Invoke-WebRequest 'https://dot.net/v1/dotnet-install.ps1' -OutFile dotnet-install.ps1
+      .\dotnet-install.ps1 -Version 10.0.107 -InstallDir 'C:\Program Files\dotnet'
+      dotnet --version
+
 before_build:
   - dotnet restore src\Aquarius.SDK.sln
 
-build:
-  project: src\Aquarius.SDK.sln
+build_script:
+  - dotnet build src\Aquarius.SDK.sln --configuration Release --no-restore
+
+test_script:
+  - dotnet test src\Aquarius.SDK.sln --configuration Release --no-build
 
 artifacts:
   - path: '**\*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -43,7 +43,7 @@ init:
       }
 
 before_build:
-  - nuget restore src\Aquarius.SDK.sln
+  - dotnet restore src\Aquarius.SDK.sln
 
 build:
   project: src\Aquarius.SDK.sln

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,11 @@ dotnet_csproj:
   file_version: '{version}'
   informational_version: '{version}'
   
+install:
+  - ps: |
+      Invoke-WebRequest -Uri 'https://dot.net/v1/dotnet-install.ps1' -OutFile dotnet-install.ps1
+      .\dotnet-install.ps1 -Channel 10.0 -InstallDir "$env:ProgramFiles\dotnet"
+
 init:
   - ps: |
       If (-Not $env:APPVEYOR_PULL_REQUEST_NUMBER) {

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.107",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Aquarius.Client.Legacy/Aquarius.Client.Legacy.csproj
+++ b/src/Aquarius.Client.Legacy/Aquarius.Client.Legacy.csproj
@@ -18,6 +18,7 @@
     <RepositoryUrl>https://github.com/AquaticInformatics/aquarius-sdk-net</RepositoryUrl>
     <PackageReleaseNotes>https://github.com/AquaticInformatics/aquarius-sdk-net/blob/develop/ReleaseNotes.md</PackageReleaseNotes>
     <Version>0.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,6 +33,8 @@
     <PackageReference Include="ServiceStack.HttpClient.Core" Version="8.4.0" />
     <PackageReference Include="ServiceStack.Interfaces.Core" Version="8.4.0" />
     <PackageReference Include="ServiceStack.Text.Core" Version="8.4.0" />
+    <PackageReference Include="System.Formats.Asn1" Version="10.0.8" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
   </ItemGroup>
 
   <!-- .NET 4.7.2 references, compilation flags and build options -->

--- a/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
+++ b/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <Version>0.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -16,7 +17,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
 	  <PackageReference Include="AutoFixture" Version="4.0.0-rc1" />
 	  <PackageReference Include="FluentAssertions" Version="4.19.4" />
-	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NodaTime" Version="2.2.3" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
@@ -43,7 +44,7 @@
     <PackageReference Include="ServiceStack.Text" Version="8.4.0" />
     <PackageReference Include="AutoFixture" Version="3.51.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="NUnit" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />

--- a/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
+++ b/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <Version>0.0.0</Version>
   </PropertyGroup>
 
@@ -10,10 +10,10 @@
   </PropertyGroup>
 
   <!-- .NET Standard 2.0 references, compilation flags and build options -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net10.0'">
     <DefineConstants>NODATIME2;AUTOFIXTURE4</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0'">
 	  <PackageReference Include="AutoFixture" Version="4.0.0-rc1" />
 	  <PackageReference Include="FluentAssertions" Version="4.19.4" />
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />

--- a/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
+++ b/src/Aquarius.Client.UnitTests/Aquarius.Client.UnitTests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>net472;net10.0</TargetFrameworks>
     <Version>0.0.0</Version>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Aquarius.Client.UnitTests/Helpers/UserAgentBuilderTests.cs
+++ b/src/Aquarius.Client.UnitTests/Helpers/UserAgentBuilderTests.cs
@@ -24,5 +24,29 @@ namespace Aquarius.UnitTests.Helpers
 
             actual.Should().NotBeEmpty();
         }
+
+        [Test]
+        public void GetExecutingAssemblyPath_ReturnsAbsolutePath()
+        {
+            var path = UserAgentBuilder.GetExecutingAssemblyPath();
+
+            Path.IsPathRooted(path).Should().BeTrue("assembly path should be an absolute path, not a URI or relative path");
+        }
+
+        [Test]
+        public void GetExecutingAssemblyPath_ReturnsExistingFile()
+        {
+            var path = UserAgentBuilder.GetExecutingAssemblyPath();
+
+            File.Exists(path).Should().BeTrue("assembly path should point to a real file on disk");
+        }
+
+        [Test]
+        public void GetExecutingAssemblyPath_DoesNotContainUriScheme()
+        {
+            var path = UserAgentBuilder.GetExecutingAssemblyPath();
+
+            path.Should().NotStartWith("file://", "path should be a plain file path, not a URI");
+        }
     }
 }

--- a/src/Aquarius.Client.UnitTests/Helpers/UserAgentBuilderTests.cs
+++ b/src/Aquarius.Client.UnitTests/Helpers/UserAgentBuilderTests.cs
@@ -36,9 +36,16 @@ namespace Aquarius.UnitTests.Helpers
         [Test]
         public void GetExecutingAssemblyPath_ReturnsExistingFile()
         {
+            var testAssemblyLocation = typeof(UserAgentBuilderTests).Assembly.Location;
+
+            if (string.IsNullOrWhiteSpace(testAssemblyLocation))
+            {
+                Assert.Ignore("This assertion requires the test assembly to have a real file-system location. Some test hosts load assemblies without a meaningful Assembly.Location.");
+            }
+
             var path = UserAgentBuilder.GetExecutingAssemblyPath();
 
-            File.Exists(path).Should().BeTrue("assembly path should point to a real file on disk");
+            File.Exists(path).Should().BeTrue("assembly path should point to a real file on disk when the test host exposes a real assembly location");
         }
 
         [Test]

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/SetTimeoutTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/SetTimeoutTests.cs
@@ -54,12 +54,10 @@ namespace Aquarius.Client.UnitTests.TimeSeries.Client
 
             serviceClient.RequestFilter.Should().NotBeNull();
 
-#if NET472
             var request = WebRequest.CreateHttp("http://localhost");
             serviceClient.RequestFilter(request);
 
             request.Timeout.Should().Be((int)timeout.TotalMilliseconds);
-#endif
         }
 
         [Test]
@@ -72,12 +70,10 @@ namespace Aquarius.Client.UnitTests.TimeSeries.Client
 
             serviceClient.RequestFilter.Should().NotBeNull();
 
-#if NET472
             var request = WebRequest.CreateHttp("http://localhost");
             serviceClient.RequestFilter(request);
 
             request.ReadWriteTimeout.Should().Be((int)readWriteTimeout.TotalMilliseconds);
-#endif
         }
 
         [Test]
@@ -89,52 +85,42 @@ namespace Aquarius.Client.UnitTests.TimeSeries.Client
 
             _client.SetTimeout(serviceClient, timeout, readWriteTimeout);
 
-#if NET472
             var request = WebRequest.CreateHttp("http://localhost");
             serviceClient.RequestFilter(request);
 
             request.Timeout.Should().Be((int)timeout.TotalMilliseconds);
             request.ReadWriteTimeout.Should().Be((int)readWriteTimeout.TotalMilliseconds);
-#endif
         }
 
         [Test]
         public void SetTimeout_PreservesExistingRequestFilter()
         {
             var serviceClient = new JsonServiceClient("http://localhost");
-
-#if NET472
             var existingFilterCalled = false;
             serviceClient.RequestFilter = _ => existingFilterCalled = true;
-#endif
 
             _client.SetTimeout(serviceClient, TimeSpan.FromSeconds(300), null);
 
-#if NET472
             var request = WebRequest.CreateHttp("http://localhost");
             serviceClient.RequestFilter(request);
 
             existingFilterCalled.Should().BeTrue();
-#endif
         }
 
         [Test]
         public void SetTimeout_WithNullTimeouts_DoesNotSetTimeoutOnHttpWebRequest()
         {
             var serviceClient = new JsonServiceClient("http://localhost");
-
-            _client.SetTimeout(serviceClient, null, null);
-
-#if NET472
             var defaultTimeout = 100000; // .NET default HttpWebRequest.Timeout
             var defaultReadWriteTimeout = 300000; // .NET default HttpWebRequest.ReadWriteTimeout
+
+            _client.SetTimeout(serviceClient, null, null);
 
             var request = WebRequest.CreateHttp("http://localhost");
             serviceClient.RequestFilter(request);
 
             request.Timeout.Should().Be(defaultTimeout);
             request.ReadWriteTimeout.Should().Be(defaultReadWriteTimeout);
-#endif
         }
 
         [Test]

--- a/src/Aquarius.Client.UnitTests/TimeSeries/Client/SetTimeoutTests.cs
+++ b/src/Aquarius.Client.UnitTests/TimeSeries/Client/SetTimeoutTests.cs
@@ -54,10 +54,12 @@ namespace Aquarius.Client.UnitTests.TimeSeries.Client
 
             serviceClient.RequestFilter.Should().NotBeNull();
 
+#if NET472
             var request = WebRequest.CreateHttp("http://localhost");
             serviceClient.RequestFilter(request);
 
             request.Timeout.Should().Be((int)timeout.TotalMilliseconds);
+#endif
         }
 
         [Test]
@@ -70,10 +72,12 @@ namespace Aquarius.Client.UnitTests.TimeSeries.Client
 
             serviceClient.RequestFilter.Should().NotBeNull();
 
+#if NET472
             var request = WebRequest.CreateHttp("http://localhost");
             serviceClient.RequestFilter(request);
 
             request.ReadWriteTimeout.Should().Be((int)readWriteTimeout.TotalMilliseconds);
+#endif
         }
 
         [Test]
@@ -85,42 +89,52 @@ namespace Aquarius.Client.UnitTests.TimeSeries.Client
 
             _client.SetTimeout(serviceClient, timeout, readWriteTimeout);
 
+#if NET472
             var request = WebRequest.CreateHttp("http://localhost");
             serviceClient.RequestFilter(request);
 
             request.Timeout.Should().Be((int)timeout.TotalMilliseconds);
             request.ReadWriteTimeout.Should().Be((int)readWriteTimeout.TotalMilliseconds);
+#endif
         }
 
         [Test]
         public void SetTimeout_PreservesExistingRequestFilter()
         {
             var serviceClient = new JsonServiceClient("http://localhost");
+
+#if NET472
             var existingFilterCalled = false;
             serviceClient.RequestFilter = _ => existingFilterCalled = true;
+#endif
 
             _client.SetTimeout(serviceClient, TimeSpan.FromSeconds(300), null);
 
+#if NET472
             var request = WebRequest.CreateHttp("http://localhost");
             serviceClient.RequestFilter(request);
 
             existingFilterCalled.Should().BeTrue();
+#endif
         }
 
         [Test]
         public void SetTimeout_WithNullTimeouts_DoesNotSetTimeoutOnHttpWebRequest()
         {
             var serviceClient = new JsonServiceClient("http://localhost");
-            var defaultTimeout = 100000; // .NET default HttpWebRequest.Timeout
-            var defaultReadWriteTimeout = 300000; // .NET default HttpWebRequest.ReadWriteTimeout
 
             _client.SetTimeout(serviceClient, null, null);
+
+#if NET472
+            var defaultTimeout = 100000; // .NET default HttpWebRequest.Timeout
+            var defaultReadWriteTimeout = 300000; // .NET default HttpWebRequest.ReadWriteTimeout
 
             var request = WebRequest.CreateHttp("http://localhost");
             serviceClient.RequestFilter(request);
 
             request.Timeout.Should().Be(defaultTimeout);
             request.ReadWriteTimeout.Should().Be(defaultReadWriteTimeout);
+#endif
         }
 
         [Test]

--- a/src/Aquarius.Client/Aquarius.Client.csproj
+++ b/src/Aquarius.Client/Aquarius.Client.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.1;net10.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Aquarius.SDK</PackageId>
     <Authors>Aquatic Informatics Inc.</Authors>
@@ -26,10 +26,10 @@
   </ItemGroup>
 
   <!-- .NET Standard 2.1 references, compilation flags and build options -->
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'net8.0'">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'net10.0'">
     <DefineConstants>NODATIME2</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'net8.0'">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'net10.0'">
     <PackageReference Include="NodaTime" Version="2.2.3" />
     <PackageReference Include="ServiceStack.Client.Core" Version="8.4.0" />
     <PackageReference Include="ServiceStack.HttpClient.Core" Version="8.4.0" />

--- a/src/Aquarius.Client/Aquarius.Client.csproj
+++ b/src/Aquarius.Client/Aquarius.Client.csproj
@@ -18,6 +18,7 @@
     <PackageReleaseNotes>https://github.com/AquaticInformatics/aquarius-sdk-net/blob/develop/ReleaseNotes.md</PackageReleaseNotes>
     <Version>0.0.0</Version>
     <RootNamespace>Aquarius</RootNamespace>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,6 +36,8 @@
     <PackageReference Include="ServiceStack.HttpClient.Core" Version="8.4.0" />
     <PackageReference Include="ServiceStack.Interfaces.Core" Version="8.4.0" />
     <PackageReference Include="ServiceStack.Text.Core" Version="8.4.0" />
+    <PackageReference Include="System.Formats.Asn1" Version="10.0.8" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.8" />
   </ItemGroup>
 
   <!-- .NET 4.7.2 references, compilation flags and build options -->

--- a/src/Aquarius.Client/Helpers/UserAgentBuilder.cs
+++ b/src/Aquarius.Client/Helpers/UserAgentBuilder.cs
@@ -84,9 +84,7 @@ namespace Aquarius.Helpers
             if (assembly == null)
                 return string.Empty;
 
-            // Lifted from http://stackoverflow.com/questions/864484/getting-the-path-of-the-current-assembly
-            var uri = new Uri(assembly.CodeBase);
-            return Path.GetFullPath(Uri.UnescapeDataString(uri.AbsolutePath));
+            return Path.GetFullPath(assembly.Location);
         }
     }
 }

--- a/src/Aquarius.Client/Helpers/UserAgentBuilder.cs
+++ b/src/Aquarius.Client/Helpers/UserAgentBuilder.cs
@@ -84,7 +84,16 @@ namespace Aquarius.Helpers
             if (assembly == null)
                 return string.Empty;
 
-            return Path.GetFullPath(assembly.Location);
+            if (string.IsNullOrEmpty(assembly.Location))
+                return string.Empty;
+
+            var location = assembly.Location;
+
+            // In single-file/bundled deployments Assembly.Location can be empty.
+            if (string.IsNullOrEmpty(location))
+                return string.Empty;
+
+            return Path.GetFullPath(location);
         }
     }
 }

--- a/src/SamplesServiceModelGenerator.Tests/SamplesServiceModelGenerator.Tests.csproj
+++ b/src/SamplesServiceModelGenerator.Tests/SamplesServiceModelGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>

--- a/src/SamplesServiceModelGenerator.Tests/SamplesServiceModelGenerator.Tests.csproj
+++ b/src/SamplesServiceModelGenerator.Tests/SamplesServiceModelGenerator.Tests.csproj
@@ -5,6 +5,7 @@
 		<LangVersion>latest</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -13,10 +14,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="4.19.4" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
 		<PackageReference Include="NUnit" Version="3.9.0" />
 		<PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
-		<PackageReference Include ="Newtonsoft.Json" Version="13.0.1" />
+		<PackageReference Include ="Newtonsoft.Json" Version="13.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SamplesServiceModelGenerator.Tests/Swagger/ParserTests.cs
+++ b/src/SamplesServiceModelGenerator.Tests/Swagger/ParserTests.cs
@@ -69,16 +69,16 @@ namespace SamplesServiceModelGenerator.Tests.Swagger
 
         public void AssertExpectedTitle()
         {
-            Assert.AreEqual(_json["info"]["title"].ToString(), _parseOutput.Title);
+            Assert.AreEqual(_json["info"]?["title"]?.ToString(), _parseOutput.Title);
         }
 
         public void AssertExpectedDefinitions()
         {
             _parseOutput.Definitions.Should().NotBeEmpty();
 
-            _parseOutput.Definitions.Count().Equals(_json["definitions"].Count());
+            Assert.AreEqual(_json["definitions"]?.Count() ?? 0, _parseOutput.Definitions.Count());
 
-            var expectedDefinitions = _json["definitions"] as JObject;
+            var expectedDefinitions = _json["definitions"] as JObject ?? new JObject();
             var expectedProperties = new List<string>();
 
             foreach (var def in expectedDefinitions.Properties())
@@ -109,9 +109,9 @@ namespace SamplesServiceModelGenerator.Tests.Swagger
         {
             _parseOutput.Paths.Should().NotBeEmpty();
 
-            _parseOutput.Paths.Count().Equals(_json["paths"].Count());
+            Assert.AreEqual(_json["paths"]?.Count() ?? 0, _parseOutput.Paths.Count());
 
-            var expectedPaths = _json["paths"] as JObject;
+            var expectedPaths = _json["paths"] as JObject ?? new JObject();
             List<string> verbs = ["get", "delete", "post", "put"];
             var expectedOperationIds = new List<string>();
             var parsedOperationIds = new List<string>();

--- a/src/SamplesServiceModelGenerator/SamplesServiceModelGenerator.csproj
+++ b/src/SamplesServiceModelGenerator/SamplesServiceModelGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>0.0.0</Version>
   </PropertyGroup>
   

--- a/src/SamplesServiceModelGenerator/SamplesServiceModelGenerator.csproj
+++ b/src/SamplesServiceModelGenerator/SamplesServiceModelGenerator.csproj
@@ -4,11 +4,12 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <Version>0.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   
   <ItemGroup>
     <PackageReference Include="Humanizer.Core" Version="2.2.0" />
-    <PackageReference Include="log4net" Version="2.0.10" />
+    <PackageReference Include="log4net" Version="3.3.1" />
     <PackageReference Include="NodaTime" Version="2.2.3" />
     <PackageReference Include="ServiceStack.Interfaces.Core" Version="8.4.0" />
     <PackageReference Include="ServiceStack.Text.Core" Version="8.4.0" />


### PR DESCRIPTION
 ## Summary
 
 Adds net10.0 as a target framework (replacing net8.0), alongside net472 and netstandard2.1.
 
 ## Changes
 
 ### Framework
 - Dual-targets net472/netstandard2.1 and net10.0 across all projects
 - Updated Visual Studio requirement to 2022+ in README and CONTRIBUTING
 - Added 26.2.0 release notes entry

The second commit is an extra mile fixing warnings and adding warningsAsErrors to keep the repo nice and clean.
I can also take it out to a separate PR.
  

 ### net10.0 warning fixes
 - Replace `Assembly.CodeBase` with `Assembly.Location` (SYSLIB0012)
 - Wrap `WebRequest.CreateHttp` test usages in `#if NET472` (SYSLIB0014) (Request handlers are .net472 functionality, other tests are covering timeouts for modern framework)
 - Fix null dereference warnings in `ParserTests.cs`
 
 ### Package vulnerabilities resolved
 - Bump log4net 2.0.10 → 3.3.1 (GHSA-4f7c-pmjv-c25w)
 - Bump Microsoft.NET.Test.Sdk 15.5.0 → 18.5.1 (fixes transitive Newtonsoft.Json vulnerability)
 - Pin Newtonsoft.Json 13.0.1 → 13.0.3
 - Override System.Formats.Asn1 → 10.0.8 (GHSA-447r-wph3-92pm)
 - Override System.Security.Cryptography.Xml → 10.0.8 (GHSA-vh55-786g-wjwj)
 
 ### Quality
 - Add `TreatWarningsAsErrors=true` to all 5 projects
 - Add unit tests for `Assembly.Location` path behavior in `UserAgentBuilderTests`
 - Fix discarded `.Equals()` assertions in `ParserTests.cs` (pre-existing bug)